### PR TITLE
cicd: add clang+nvcc and clang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,9 @@ jobs:
         steps:
             - uses: actions/checkout@v5
 
-            - run: cmake -S . --preset=${{ matrix.cmake_preset }}
+            - run: |
+                cmake -S . --preset=${{ matrix.cmake_preset }} \
+                    -DCMAKE_CUDA_ARCHITECTURES=${{ matrix.cuda_arch[1] }}
 
             - run: cmake --build --preset=${{ matrix.cmake_preset }}
 

--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -51,6 +51,24 @@ def main(*, args : argparse.Namespace) -> None:
         'cuda_arch' : ('blackwell', '120'),
     }, args = args))
 
+    matrix.append(complete_job({
+        'cuda_version' : '12.8.1',
+        'compiler_family' : [('clang', '19'), ('nvcc',)],
+        'cuda_arch' : ('volta', '70'),
+    }, args = args))
+
+    matrix.append(complete_job({
+        'cuda_version' : '13.0.0',
+        'compiler_family' : [('clang', '19'), ('nvcc',)],
+        'cuda_arch' : ('blackwell', '120'),
+    }, args = args))
+
+    matrix.append(complete_job({
+        'cuda_version' : '12.8.1',
+        'compiler_family' : [('clang', '21')],
+        'cuda_arch' : ('blackwell', '120'),
+    }, args = args))
+
     # Labels for testing runners.
     for job in matrix:
         runs_on = ['self-hosted', 'linux', 'docker', 'amd64', ''.join(job['cuda_arch']), 'gpu:0']

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -4,17 +4,7 @@
         {
             "name" : "default",
             "hidden" : true,
-            "binaryDir" : "${sourceDir}/build-with-${presetName}"
-        },
-        {
-            "name" : "gcc-nvcc",
-            "inherits" : "default",
-            "cacheVariables" : {
-                "CMAKE_CXX_COMPILER" : "g++",
-                "CMAKE_CUDA_COMPILER" : "nvcc",
-                "CMAKE_CUDA_HOST_COMPILER" : "g++",
-                "CMAKE_CUDA_SEPARABLE_COMPILATION" : "ON"
-            },
+            "binaryDir" : "${sourceDir}/build-with-${presetName}",
             "errors": {
                 "dev": true
             },
@@ -23,6 +13,53 @@
                 "unusedCli" : true,
                 "deprecated": true
             }
+        },
+        {
+            "name" : "cxx-gcc",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER" : "g++"
+            }
+        },
+        {
+            "name" : "cxx-clang",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CXX_COMPILER" : "clang++"
+            }
+        },
+        {
+            "name" : "cuda-nvcc",
+            "hidden" : true,
+            "cacheVariables": {
+                "CMAKE_CUDA_COMPILER" : "nvcc",
+                "CMAKE_CUDA_SEPARABLE_COMPILATION" : "ON"
+            }
+        },
+        {
+            "name" : "cuda-clang",
+            "hidden" : true,
+            "cacheVariables": {
+                "CMAKE_CUDA_COMPILER" : "clang++"
+            }
+        },
+        {
+            "name" : "gcc-nvcc",
+            "inherits" : ["default", "cxx-gcc", "cuda-nvcc"],
+            "cacheVariables" : {
+                "CMAKE_CUDA_HOST_COMPILER" : "g++"
+            }
+        },
+        {
+            "name" : "clang-nvcc",
+            "inherits" : ["default", "cxx-clang", "cuda-nvcc"],
+            "cacheVariables" : {
+                "CMAKE_CUDA_HOST_COMPILER" : "clang"
+            }
+        },
+        {
+            "name": "clang",
+            "inherits" : ["default", "cxx-clang", "cuda-clang"]
         }
     ],
     "buildPresets" : [
@@ -35,6 +72,16 @@
         {
             "name" : "gcc-nvcc",
             "configurePreset" : "gcc-nvcc",
+            "inherits" : "default"
+        },
+        {
+            "name" : "clang-nvcc",
+            "configurePreset" : "clang-nvcc",
+            "inherits" : "default"
+        },
+        {
+            "name" : "clang",
+            "configurePreset" : "clang",
             "inherits" : "default"
         }
     ],
@@ -54,6 +101,16 @@
         {
             "name" : "gcc-nvcc",
             "configurePreset" : "gcc-nvcc",
+            "inherits" : "default"
+        },
+        {
+            "name" : "clang-nvcc",
+            "configurePreset" : "clang-nvcc",
+            "inherits" : "default"
+        },
+        {
+            "name" : "clang",
+            "configurePreset" : "clang",
             "inherits" : "default"
         }
     ]

--- a/cmake/modules/Warnings.cmake
+++ b/cmake/modules/Warnings.cmake
@@ -6,7 +6,11 @@ set(CUDA_HELPERS_COMPILE_WARNINGS -Wall -Wextra -Werror)
 
 foreach(flag IN LISTS CUDA_HELPERS_COMPILE_WARNINGS)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:${flag}>)
-    add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${flag}>)
+    if(CMAKE_CUDA_COMPILER_ID STREQUAL NVIDIA)
+        add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler=${flag}>)
+    endif()
 endforeach()
 
-add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:--Werror=all-warnings>)
+if(CMAKE_CUDA_COMPILER_ID STREQUAL NVIDIA)
+    add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:--Werror=all-warnings>)
+endif()

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -29,14 +29,35 @@ RUN --mount=target=/requirements/requirements.system.txt,type=bind,source=requir
     apt-helpers install-packages --update --clean --requirement /requirements/requirements.system.txt
 EOF
 
-FROM base AS requirements-compiler-gcc
+FROM base AS requirements-compiler-clang
 
 ARG COMPILER_VERSION
 
 RUN <<EOF
     set -ex
 
-    gcc --version
+    apt-helpers install-packages --update --packages lsb-release wget software-properties-common gnupg
+
+    wget https://apt.llvm.org/llvm.sh
+    chmod +x llvm.sh
+    ./llvm.sh ${COMPILER_VERSION}
+    rm llvm.sh
+
+    update-alternatives-helpers --prefix /usr/bin \
+        --display --level=10 \
+        --for-each-of clang=clang-${COMPILER_VERSION} clang++=clang++-${COMPILER_VERSION}
+
+    clang --version
+
+    apt-helpers clean
+EOF
+
+FROM base AS requirements-compiler-gcc
+
+ARG COMPILER_VERSION
+
+RUN <<EOF
+    set -ex
 
     echo "Expecting GCC major version to be ${COMPILER_VERSION}."
 

--- a/tests/cuda/test_saxpy.cpp
+++ b/tests/cuda/test_saxpy.cpp
@@ -45,7 +45,7 @@ int main()
     constexpr index_t block_size = 128;
     constexpr index_t grid_size  = (size + block_size - 1) / block_size;
 
-    saxpy<<<{grid_size, 1, 1}, {block_size, 1, 1} , 0, stream>>>(size, 2.f, vec_x, vec_y);
+    saxpy<<<dim3{grid_size, 1, 1}, dim3{block_size, 1, 1} , 0, stream>>>(size, 2.f, vec_x, vec_y);
 
     std::vector<float> result(size);
     CUDA_HELPERS_CHECK_CUDART_CALL(cudaMemcpyAsync(result.data(), vec_y, size * sizeof(float), cudaMemcpyDeviceToHost, stream));


### PR DESCRIPTION
This PR adds 2 presets:
* `clang` as host compiler and `nvcc` for the device
* `clang` as host **and** device compiler