### PR TITLE
CICD: allow `gcc` versions other than 13 to be installed

### DIFF
--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/uliegecsm/cuda-helpers/cuda-gcc-nvcc:12.8.1-devel-ubuntu24.04
+FROM ghcr.io/uliegecsm/cuda-helpers/cuda-gcc-13-nvcc:12.8.1-devel-ubuntu24.04
 
 # Installing gpg and gnupg2 allows the container to use GPG keys to sign commits.
 # See also:

--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -56,7 +56,7 @@ def main(*, args : argparse.Namespace) -> None:
 
     matrix.append(complete_job({
         'cuda_version' : '13.0.0',
-        'compiler_family' : [('gcc', '13'), ('nvcc',)],
+        'compiler_family' : [('gcc', '14'), ('nvcc',)],
         'nvidia_compute_capability' : 120,
     }, args = args))
 

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -59,14 +59,19 @@ ARG COMPILER_VERSION
 RUN <<EOF
     set -ex
 
-    echo "Expecting GCC major version to be ${COMPILER_VERSION}."
+    apt-helpers install-packages --update --packages gcc-${COMPILER_VERSION} g++-${COMPILER_VERSION}
+    
+    update-alternatives-helpers --prefix /usr/bin \
+        --display --level=10 \
+        --for-each-of \
+            gcc=gcc-${COMPILER_VERSION} \
+            g++=g++-${COMPILER_VERSION} \
+            $(uname -m)-linux-gnu-gcc=$(uname -m)-linux-gnu-gcc-${COMPILER_VERSION} \
+            $(uname -m)-linux-gnu-g++=$(uname -m)-linux-gnu-g++-${COMPILER_VERSION}
 
-    GCC_VERSION_MAJOR=$(gcc -dumpfullversion -dumpversion | cut -d. -f1)
+    gcc -dumpfullversion -dumpversion
 
-    if [ ! "$GCC_VERSION_MAJOR" = "${COMPILER_VERSION}" ];then
-        echo "GCC major version is ${GCC_VERSION_MAJOR}."
-        exit 1
-    fi
+    apt-helpers clean
 EOF
 
 FROM requirements-compiler-${COMPILER}


### PR DESCRIPTION
Currently, the `dockerfile` exits if a `gcc` version other than 13 is asked to be installed. This PR adds the installation commands to install other versions.