### PR TITLE
CICD: add `arm` build for image used in `.devcontainer`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,9 @@ jobs:
                   username: ${{ github.actor }}
                   password: ${{ secrets.GITHUB_TOKEN }}
 
+            - uses: docker/setup-qemu-action@v3
+              if  : steps.changed-files.outputs.any_changed == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs['build-images'])
+            
             - uses: docker/setup-buildx-action@v3
               if  : steps.changed-files.outputs.any_changed == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs['build-images'])
 
@@ -120,7 +123,7 @@ jobs:
               if  : steps.changed-files.outputs.any_changed == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs['build-images'])
               with:
                   context: .
-                  platforms: linux/amd64
+                  platforms: ${{ matrix.build_platforms }}
                   push: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs['build-images']) }}
                   file: docker/dockerfile
                   tags: ${{ matrix.image }}

--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -37,6 +37,8 @@ def complete_job(partial : dict, args : argparse.Namespace) -> dict:
 
     partial['nvidia_arch'] = NVIDIAArch.from_compute_capability(cc = partial['nvidia_compute_capability'])
 
+    partial['build_platforms'] = ','.join(['linux/amd64'] + partial['additional_build_platforms'] if 'additional_build_platforms' in partial else [])
+
     # Labels for testing runners.
     runs_on = ['self-hosted', 'linux', 'docker', 'amd64', str(partial['nvidia_arch']).lower(), 'gpu:0']
     partial['runs-on'] = runs_on
@@ -54,6 +56,7 @@ def main(*, args : argparse.Namespace) -> None:
         'cuda_version' : '12.8.1',
         'compiler_family' : [('gcc', '13'), ('nvcc',)],
         'nvidia_compute_capability' : 70,
+        'additional_build_platforms' : ['linux/arm64'],
     }, args = args))
 
     matrix.append(complete_job({

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -4,6 +4,9 @@ ARG COMPILER_VERSION=13
 
 FROM ${BASE_IMAGE} AS base
 
+# Multi-architecture build approach
+ARG TARGETARCH
+
 # Install Python3 (with the trickery for virtual environment).
 ARG PYTHON_VERSION=3.12
 ENV VIRTUAL_ENV=/opt/venv-${PYTHON_VERSION}
@@ -107,7 +110,7 @@ RUN <<EOF
 
     apt-helpers install-packages --update --clean --packages curl
 
-    curl --progress-bar -L https://dl.min.io/aistor/mc/release/linux-amd64/mc \
+    curl --progress-bar -L https://dl.min.io/aistor/mc/release/linux-${TARGETARCH}/mc \
         --create-dirs \
         -o /opt/aistor-binaries/mc
     chmod +x /opt/aistor-binaries/mc


### PR DESCRIPTION
This PR adds a build of an `arm` image for the one used in `.devcontainer`. The short-term goal is to ease coding for the project on mac. Longer term, it's probably important for architectures like Grace-Hopper.