### PR TITLE
cicd(images): enforce image build with requirements change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,8 +103,9 @@ jobs:
               uses: tj-actions/changed-files@v47
               with:
                   files: |
-                      docker/dockerfile
+                      docker/**
                       .github/workflows/**
+                      requirements/**
 
             - uses: docker/login-action@v3
               if  : steps.changed-files.outputs.any_changed == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs['build-images'])


### PR DESCRIPTION
Followup of #56 that did not trigger a rebuild of the images when I touched `requirements/requirements.python.txt`.