### PR TITLE
tests: global state must work when env is not defined (needed for documentation)

### DIFF
--- a/tests/python/tools/test_binaries.py
+++ b/tests/python/tools/test_binaries.py
@@ -13,7 +13,7 @@ import typeguard
 from cuda_helpers.tools.architecture import NVIDIAArch
 from cuda_helpers.tools.binaries import get_arch_from_compile_command, CuObjDump, CuppFilt, ResourceUsage
 
-TMPDIR = pathlib.Path(os.environ['CMAKE_CURRENT_BINARY_DIR'])
+TMPDIR = pathlib.Path(os.environ['CMAKE_CURRENT_BINARY_DIR']) if 'CMAKE_CURRENT_BINARY_DIR' in os.environ else None
 
 def test_get_arch_from_compile_command():
     """

--- a/tests/python/tools/test_device_properties.py
+++ b/tests/python/tools/test_device_properties.py
@@ -112,7 +112,7 @@ class TestCuda(unittest.TestCase):
 
     def test_cuda_device_attribute_uptodate(self):
         """
-        Check that :py:enum:`CudaDeviceAttribute` is up-to-date with the content of `cuda.h`.
+        Check that :py:class:`cuda_helpers.tools.device_properties.CudaDeviceAttribute` is up-to-date with the content of `cuda.h`.
         """
         cuda_header = self.INCLUDE_DIR / 'cuda.h'
 

--- a/tests/python/tools/test_nsys.py
+++ b/tests/python/tools/test_nsys.py
@@ -13,8 +13,8 @@ class TestSession:
     """
     Test :py:class:`cuda_helpers.tools.nsys.Session`.
     """
-    TMPDIR = pathlib.Path(os.environ['CMAKE_CURRENT_BINARY_DIR'])
-    EXECUTABLE = pathlib.Path(os.environ['CMAKE_BINARY_DIR']) / 'tests' / 'cpp' / 'cuda' / 'tests_cuda_saxpy'
+    TMPDIR = pathlib.Path(os.environ['CMAKE_CURRENT_BINARY_DIR']) if 'CMAKE_CURRENT_BINARY_DIR' in os.environ else None
+    EXECUTABLE = pathlib.Path(os.environ['CMAKE_BINARY_DIR']) / 'tests' / 'cpp' / 'cuda' / 'tests_cuda_saxpy' if 'CMAKE_BINARY_DIR' in os.environ else None
 
     @staticmethod
     @typeguard.typechecked
@@ -44,7 +44,7 @@ class TestSession:
 
     def test_cuda_api_trace(self):
         """
-        Collect all `Cuda` API calls of :cpp:file:`tests/cpp/cuda/test_saxpy.cpp`.
+        Collect all `Cuda` API calls of :file:`tests/cpp/cuda/test_saxpy.cpp`.
         """
         ns = self.run()
 

--- a/tests/python/tools/test_sass.py
+++ b/tests/python/tools/test_sass.py
@@ -8,7 +8,7 @@ from cuda_helpers.tools import sass, binaries
 
 from test_binaries import Parameters, PARAMETERS, get_compilation_output
 
-TMPDIR = pathlib.Path(os.environ['CMAKE_CURRENT_BINARY_DIR'])
+TMPDIR = pathlib.Path(os.environ['CMAKE_CURRENT_BINARY_DIR']) if 'CMAKE_CURRENT_BINARY_DIR' in os.environ else None
 
 FFMA = \
 """\


### PR DESCRIPTION
Extracted from #55.