### PR TITLE
renaming to `reprospect`

### DIFF
--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/uliegecsm/cuda-helpers/cuda-gcc-13-nvcc:12.8.1-devel-ubuntu24.04
+FROM ghcr.io/uliegecsm/reprospect/cuda-gcc-13-nvcc:12.8.1-devel-ubuntu24.04
 
 # Installing gpg and gnupg2 allows the container to use GPG keys to sign commits.
 # See also:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,4 +56,4 @@ bibtex_bibfiles = ['references.bib']
 import unittest
 unittest.TestCase.__module__ = 'unittest'
 
-linkcode_url = 'https://github.com/uliegecsm/cuda-helpers'
+linkcode_url = 'https://github.com/uliegecsm/reprospect'

--- a/python/setup.py
+++ b/python/setup.py
@@ -11,7 +11,7 @@ setup(
     name             = 'reprospect',
     version          = reprospect.__version__,
     license          = 'MIT',
-    url              = 'https://github.com/uliegecsm/cuda-helpers',
+    url              = 'https://github.com/uliegecsm/reprospect',
     install_requires = [
         *requirements,
     ],


### PR DESCRIPTION
Followup of #46  after changing the name on GitHub