### PR TITLE
examples: we need kokkos to be installed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
 
             - uses: docker/setup-qemu-action@v3
               if  : steps.changed-files.outputs.any_changed == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs['build-images'])
-            
+
             - uses: docker/setup-buildx-action@v3
               if  : steps.changed-files.outputs.any_changed == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs['build-images'])
 
@@ -136,6 +136,23 @@ jobs:
                       COMPILER_VERSION=${{ matrix.compiler_family[0][1] }}
                   labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 
+            - uses: docker/build-push-action@v6.18.0
+              if  : steps.changed-files.outputs.any_changed == 'true' || (github.event_name == 'workflow_dispatch' && github.event.inputs['build-images'])
+              with:
+                  context: .
+                  platforms: ${{ matrix.build_platforms }}
+                  push: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs['build-images']) }}
+                  file: docker/dockerfile.kokkos
+                  tags: ${{ matrix.kokkos }}
+                  cache-from: type=registry,ref=${{ matrix.kokkos }}
+                  cache-to: type=inline
+                  build-args: |
+                      BASE_IMAGE=${{ matrix.image }}
+                      KOKKOS_ARCH=${{ matrix.nvidia_arch }}
+                      KOKKOS_CMAKE_PRESET=${{ matrix.cmake_preset }}
+                      KOKKOS_SHA=b3ec45c33bc8151b92d63a764f01281911c83cf9
+                  labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
+
     test:
         needs: [setup-job-matrix, build-image]
         strategy:
@@ -152,6 +169,7 @@ jobs:
             - run: |
                 cmake -S . --preset=${{ matrix.cmake_preset }} \
                     -DCMAKE_CUDA_ARCHITECTURES=${{ matrix.nvidia_compute_capability }} \
+                    -DReProspect_ENABLE_TESTS=ON \
                     -DCPACK_COMPONENTS_ALL=cpp
 
             - run: cmake --build --preset=${{ matrix.cmake_preset }}
@@ -159,6 +177,29 @@ jobs:
             - run: ctest --preset=${{ matrix.cmake_preset }}
 
             - run: cmake --build --preset=${{ matrix.cmake_preset }} --target=package
+
+    examples:
+        needs: [setup-job-matrix, build-image]
+        strategy:
+            fail-fast: false
+            matrix:
+                include: ${{ fromJSON(needs.setup-job-matrix.outputs.matrix) }}
+        env: ${{ fromJSON(needs.setup-job-matrix.outputs.environment) }}
+        runs-on: ${{ matrix.runs-on }}
+        container:
+            image: ${{ matrix.kokkos }}
+        steps:
+            - uses: actions/checkout@v5
+
+            - run: |
+                cmake -S . --preset=${{ matrix.cmake_preset }} \
+                    -DCMAKE_CUDA_ARCHITECTURES=${{ matrix.nvidia_compute_capability }} \
+                    -DReProspect_ENABLE_EXAMPLES=ON \
+                    -DCPACK_COMPONENTS_ALL=cpp
+
+            - run: cmake --build --preset=${{ matrix.cmake_preset }}
+
+            - run: ctest --preset=${{ matrix.cmake_preset }}
 
     install-as-package-and-test:
         needs: [setup-job-matrix, build-image]

--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -30,15 +30,16 @@ def complete_job(partial : dict, args : argparse.Namespace) -> dict:
 
     tag = f'{partial['cuda_version']}-devel-ubuntu24.04'
 
+    partial['nvidia_arch'] = str(NVIDIAArch.from_compute_capability(cc = partial['nvidia_compute_capability']))
+
     partial['base_image'] = f'nvidia/cuda:{tag}'
     partial[     'image'] = full_image(name = name, tag = tag, args = args)
-
-    partial['nvidia_arch'] = NVIDIAArch.from_compute_capability(cc = partial['nvidia_compute_capability'])
+    partial[    'kokkos'] = full_image(name = name, tag = f'{tag}-{partial['nvidia_arch']}'.lower(), args = args)
 
     partial['build_platforms'] = ','.join(['linux/amd64'] + partial['additional_build_platforms'] if 'additional_build_platforms' in partial else [])
 
     # Labels for testing runners.
-    runs_on = ['self-hosted', 'linux', 'docker', 'amd64', str(partial['nvidia_arch']).lower(), 'gpu:0']
+    runs_on = ['self-hosted', 'linux', 'docker', 'amd64', partial['nvidia_arch'].lower(), 'gpu:0']
     partial['runs-on'] = runs_on
 
     return partial

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ project(
     LANGUAGES CXX CUDA
 )
 
+option(ReProspect_ENABLE_TESTS "Enable tests." OFF)
+option(ReProspect_ENABLE_EXAMPLES "Enable examples." OFF)
+
 set(CMAKE_CXX_STANDARD 20)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -22,9 +25,14 @@ include(cmake/modules/Warnings.cmake)
 
 add_subdirectory(cpp)
 
-enable_testing()
+if(ReProspect_ENABLE_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
 
-add_subdirectory(tests)
+if(ReProspect_ENABLE_EXAMPLES)
+    add_subdirectory(examples)
+endif()
 
 #---- Install.
 install(FILES LICENSE README.md DESTINATION .)

--- a/docker/dockerfile.kokkos
+++ b/docker/dockerfile.kokkos
@@ -1,0 +1,35 @@
+ARG BASE_IMAGE=ubuntu:24.04
+
+FROM ${BASE_IMAGE} AS base
+
+FROM base AS kokkos-install
+
+ARG KOKKOS_ARCH=?
+ARG KOKKOS_SHA=?
+ARG KOKKOS_CMAKE_PRESET=?
+
+RUN <<EOF
+    set -ex
+
+    git clone --filter=blob:none --no-checkout https://github.com/kokkos/kokkos /opt/kokkos-sources-${KOKKOS_SHA}
+
+    cd /opt/kokkos-sources-${KOKKOS_SHA}
+
+    git fetch --depth=1 origin ${KOKKOS_SHA}
+
+    git checkout ${KOKKOS_SHA}
+EOF
+
+RUN --mount=target=/tmp/kokkos-install.sh,type=bind,source=docker/kokkos.sh <<EOF
+    set -ex
+
+    cd /opt/kokkos-sources-${KOKKOS_SHA}
+
+    bash /tmp/kokkos-install.sh
+EOF
+
+FROM base AS final
+
+COPY --from=kokkos-install /opt/kokkos-${KOKKOS_SHA} /opt/kokkos-${KOKKOS_SHA}
+
+ENV Kokkos_ROOT=/opt/kokkos-${KOKKOS_SHA}/${KOKKOS_CMAKE_PRESET}

--- a/docker/kokkos.sh
+++ b/docker/kokkos.sh
@@ -1,0 +1,41 @@
+set -ex
+
+cmake_args=(
+    "-DKokkos_ENABLE_SERIAL=ON"
+    "-DKokkos_ENABLE_CUDA=ON"
+    "-DKokkos_ARCH_${KOKKOS_ARCH}=ON"
+    "-DCMAKE_INSTALL_PREFIX=/opt/kokkos-${KOKKOS_SHA}/${KOKKOS_CMAKE_PRESET}"
+)
+
+case "${KOKKOS_CMAKE_PRESET}" in
+    gcc-nvcc)
+        cmake_args+=(
+            "-DCMAKE_CXX_COMPILER=g++"
+            "-DCMAKE_CUDA_COMPILER=nvcc"
+            "-DCMAKE_CUDA_HOST_COMPILER=g++"
+            "-DCMAKE_CUDA_SEPARABLE_COMPILATION=ON"
+        )
+        ;;
+    clang-nvcc)
+        cmake_args+=(
+            "-DCMAKE_CXX_COMPILER=clang++"
+            "-DCMAKE_CUDA_COMPILER=nvcc"
+            "-DCMAKE_CUDA_HOST_COMPILER=clang"
+            "-DCMAKE_CUDA_SEPARABLE_COMPILATION=ON"
+        )
+        ;;
+    clang)
+        cmake_args+=(
+            "-DCMAKE_CXX_COMPILER=clang++"
+            "-DCMAKE_CUDA_COMPILER=clang++"
+        )
+        ;;
+    *)
+        echo "Error: Unknown CMake preset '${KOKKOS_CMAKE_PRESET}'."
+        exit -1
+        ;;
+esac
+
+cmake -S . -B build "${cmake_args[@]}"
+
+cmake --build build --target=install -j4

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(kokkos)

--- a/examples/kokkos/CMakeLists.txt
+++ b/examples/kokkos/CMakeLists.txt
@@ -1,0 +1,15 @@
+function(add_one_example FILE)
+
+    add_executable(examples_kokkos_${FILE})
+
+    target_sources(examples_kokkos_${FILE} PRIVATE example_${FILE}.cpp)
+
+    set_source_files_properties(example_${FILE}.cpp PROPERTIES LANGUAGE CUDA)
+
+    target_link_libraries(examples_kokkos_${FILE} PRIVATE Kokkos::kokkoscore)
+
+endfunction()
+
+find_package(Kokkos REQUIRED COMPONENTS kokkoscore)
+
+add_one_example(integration)

--- a/examples/kokkos/example_integration.cpp
+++ b/examples/kokkos/example_integration.cpp
@@ -1,0 +1,23 @@
+#include "Kokkos_Core.hpp"
+
+struct SayHello
+{
+    template <std::integral T>
+    KOKKOS_FUNCTION
+    void operator()(const T index) const {
+        Kokkos::printf("Hello from index %d.\n", index);
+    }
+};
+
+int main()
+{
+    Kokkos::ScopeGuard guard {};
+    {
+        const Kokkos::DefaultExecutionSpace exec {};
+        Kokkos::parallel_for(
+            Kokkos::RangePolicy(exec, 0, 42);
+            SayHello{}
+        );
+        exec.fence();
+    }
+}


### PR DESCRIPTION
I'm not sure yet what will be the best strategy.

I think our use cases will be to use `Kokkos` within executables that we launch through `ncu`/`nsys` and thus we'd need only to compile for the architectures we have ?

An alternative would be to compile Kokkos in all images for all arches we support in the `Python` tests...

[EDIT]

It was decided to add Kokkos within a new image (built on top of the images we alrady have).

The use cases would go in the "examples" directory, and we need to pass `ReProspect_ENABLE_EXAMPLES` to compile them.

We can compile Kokkos for a single GPU architecture, so we decided to only compile it for the architectures of our runners, since we'll probably only run tests that actually need to run the executables.