### PR TITLE
cmake: use automated relative path for naming targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 find_package(Python 3.12 REQUIRED Interpreter)
 
 include(cmake/functions/environment.cmake)
+include(cmake/functions/path_helper.cmake)
 include(cmake/modules/Warnings.cmake)
 
 if(ReProspect_ENABLE_TESTS)

--- a/cmake/functions/path_helper.cmake
+++ b/cmake/functions/path_helper.cmake
@@ -1,0 +1,15 @@
+# Get a representation of the relative path from a directory to the parent path of a file.
+#
+# In this representation, the ``/`` are replaced with ``_``.
+function(get_parent_relpath_repr)
+
+    cmake_parse_arguments(gprr "" "DIRECTORY;FILENAME" "" ${ARGN})
+
+    cmake_path(GET gprr_FILENAME PARENT_PATH FILE_PARENT_PATH)
+    cmake_path(RELATIVE_PATH FILE_PARENT_PATH BASE_DIRECTORY "${gprr_DIRECTORY}" OUTPUT_VARIABLE PARENT_RELPATH)
+
+    string(REPLACE "\/" "_" PARENT_RELPATH_REPR "${PARENT_RELPATH}")
+
+    set(gprr_PARENT_RELPATH_REPR "${PARENT_RELPATH_REPR}" PARENT_SCOPE)
+
+endfunction(get_parent_relpath_repr)

--- a/examples/kokkos/CMakeLists.txt
+++ b/examples/kokkos/CMakeLists.txt
@@ -1,14 +1,20 @@
 function(add_one_example FILE)
 
-    add_executable(examples_kokkos_${FILE})
+    set(FILENAME ${CMAKE_CURRENT_SOURCE_DIR}/example_${FILE}.cpp)
 
-    target_sources(examples_kokkos_${FILE} PRIVATE example_${FILE}.cpp)
+    get_parent_relpath_repr(DIRECTORY ${CMAKE_SOURCE_DIR} FILENAME ${FILENAME})
 
-    set_source_files_properties(example_${FILE}.cpp PROPERTIES LANGUAGE CUDA)
+    set(EXECUTABLE ${gprr_PARENT_RELPATH_REPR}_${FILE})
 
-    target_link_libraries(examples_kokkos_${FILE} PRIVATE Kokkos::kokkoscore)
+    add_executable(${EXECUTABLE})
 
-    add_test(NAME examples_kokkos_${FILE} COMMAND $<TARGET_FILE:examples_kokkos_${FILE}>)
+    target_sources(${EXECUTABLE} PRIVATE ${FILENAME})
+
+    set_source_files_properties(${FILENAME} PROPERTIES LANGUAGE CUDA)
+
+    target_link_libraries(${EXECUTABLE} PRIVATE Kokkos::kokkoscore)
+
+    add_test(NAME ${EXECUTABLE} COMMAND $<TARGET_FILE:${EXECUTABLE}>)
 
 endfunction()
 

--- a/tests/cpp/cuda/CMakeLists.txt
+++ b/tests/cpp/cuda/CMakeLists.txt
@@ -1,12 +1,20 @@
 function(add_one_test FILE)
 
-    add_executable(tests_cpp_cuda_${FILE} test_${FILE}.cpp)
+    set(FILENAME ${CMAKE_CURRENT_SOURCE_DIR}/test_${FILE}.cpp)
 
-    target_link_libraries(tests_cpp_cuda_${FILE} PRIVATE CUDA::cudart CUDA::nvtx3)
+    get_parent_relpath_repr(DIRECTORY ${CMAKE_SOURCE_DIR} FILENAME ${FILENAME})
 
-    set_source_files_properties(test_${FILE}.cpp PROPERTIES LANGUAGE CUDA)
+    set(EXECUTABLE ${gprr_PARENT_RELPATH_REPR}_${FILE})
 
-    add_test(NAME tests_cpp_cuda_${FILE} COMMAND $<TARGET_FILE:tests_cpp_cuda_${FILE}>)
+    add_executable(${EXECUTABLE})
+
+    target_sources(${EXECUTABLE} PRIVATE ${FILENAME})
+
+    target_link_libraries(${EXECUTABLE} PRIVATE CUDA::cudart CUDA::nvtx3)
+
+    set_source_files_properties(${FILENAME} PROPERTIES LANGUAGE CUDA)
+
+    add_test(NAME ${EXECUTABLE} COMMAND $<TARGET_FILE:${EXECUTABLE}>)
 
 endfunction()
 

--- a/tests/python/test/CMakeLists.txt
+++ b/tests/python/test/CMakeLists.txt
@@ -3,7 +3,7 @@ function(add_one_test FILE)
     add_test(
         NAME    tests_python_test_${FILE}
         COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_SOURCE_DIR}/tests/python/test/test_${FILE}.py
-                    -vvv --log-cli-level=info
+                    -vvv -s --log-cli-level=info
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 


### PR DESCRIPTION
Extracted from #73.