### PR TITLE
docker: add google benchmark

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,17 @@
 {
     "dockerFile": "dockerfile",
-    "extensions": [
-        "eamodio.gitlens",
-        "GitHub.vscode-pull-request-github",
-        "mhutchie.git-graph",
-        "ms-azuretools.vscode-docker",
-        "ms-python.python",
-        "ms-vscode.cmake-tools",
-    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "eamodio.gitlens",
+                "GitHub.vscode-pull-request-github",
+                "mhutchie.git-graph",
+                "ms-azuretools.vscode-docker",
+                "ms-python.python",
+                "ms-vscode.cmake-tools",
+            ],
+        }
+    },
     "runArgs": [
         "--privileged",
     ],

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,8 +139,10 @@ jobs:
                   cache-to: type=inline
                   build-args: |
                       BASE_IMAGE=${{ matrix.base_image }}
-                      COMPILER=${{ matrix.compilers['CXX'][0] }}
-                      COMPILER_VERSION=${{ matrix.compilers['CXX'][1] }}
+                      CXX_COMPILER_ID=${{ matrix.compilers.CXX.ID }}
+                      CXX_COMPILER_VERSION=${{ matrix.compilers.CXX.version }}
+                      CXX_COMPILER=${{ matrix.compilers.CXX.path }}
+                      GOOGLEBENCHMARK_VERSION=1.9.4
                   labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 
             - uses: docker/build-push-action@v6.18.0
@@ -156,8 +158,8 @@ jobs:
                   build-args: |
                       BASE_IMAGE=${{ matrix.image }}
                       KOKKOS_ARCH=${{ matrix.nvidia_arch }}
-                      KOKKOS_CXX_COMPILER=${{ matrix.compilers['CXX'][0] == 'gcc' && 'g++' || matrix.compilers['CXX'][0] == 'clang' && 'clang++' || 'not-defined'}}
-                      KOKKOS_CUDA_COMPILER=${{ matrix.compilers['CUDA'][0] }}
+                      KOKKOS_CXX_COMPILER=${{ matrix.compilers.CXX.path }}
+                      KOKKOS_CUDA_COMPILER=${{ matrix.compilers.CUDA.path }}
                       KOKKOS_INSTALL_SUFFIX=${{ matrix.cmake_preset }}-${{ matrix.nvidia_arch }}
                       KOKKOS_SHA=4.7.01
                       KOKKOS_TOOLS_INSTALL_SUFFIX=${{ matrix.cmake_preset }}
@@ -250,7 +252,7 @@ jobs:
 
             - uses: actions/download-artifact@v5
               with:
-                  name: tests-gcc-nvcc-BLACKWELL120
+                  name: tests-gnu-nvidia-BLACKWELL120
                   path: artifacts
 
             - run: |

--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -1,16 +1,29 @@
 import argparse
+import copy
+import dataclasses
 import json
 import logging
 import pprint
+import typing
+
+import typeguard
 
 from reprospect.tools.architecture import NVIDIAArch
 
+@dataclasses.dataclass
+class Compiler:
+    ID : str
+    version : typing.Optional[str] = None
+    path : typing.Optional[str] = None
+
+@typeguard.typechecked
 def full_image(*, name : str, tag : str, args : argparse.Namespace) -> str:
     """
     Full image from its `name` and `tag`, with remote.
     """
     return f'{args.registry}/{args.repository}/{name}:{tag}'
 
+@typeguard.typechecked
 def complete_job(partial : dict, args : argparse.Namespace) -> dict:
     """
     Add fields to a job.
@@ -19,17 +32,35 @@ def complete_job(partial : dict, args : argparse.Namespace) -> dict:
 
     assert isinstance(partial['nvidia_compute_capability'], int)
     assert isinstance(partial['compilers'], dict)
-    assert all(k in ['CXX', 'CUDA'] and isinstance(v, tuple) for k, v in partial['compilers'].items())
+    assert all(k in ['CXX', 'CUDA'] and isinstance(v, Compiler) for k, v in partial['compilers'].items())
 
-    name = 'cuda-' + '-'.join(partial['compilers']['CXX'])
+    # Complete CXX compiler.
+    match partial['compilers']['CXX'].ID:
+        case 'gnu':
+            partial['compilers']['CXX'].path = 'g++'
+        case 'clang':
+            partial['compilers']['CXX'].path = 'clang++'
+        case _:
+            raise ValueError(f'unsupported CXX compiler ID {partial['compilers']['CXX'].ID}')
 
-    if 'CUDA' in partial['compilers'] and partial['compilers']['CUDA'][0] == 'nvcc':
-        name += '-nvcc'
-        partial['compilers']['CUDA'] = ('nvcc', partial['cuda_version'])
-    else:
-        partial['compilers']['CUDA'] = partial['compilers']['CXX']
+    # Complete CUDA compiler.
+    if 'CUDA' not in partial['compilers']:
+        partial['compilers']['CUDA'] = copy.deepcopy(partial['compilers']['CXX'])
 
-    partial['cmake_preset'] = '-'.join(list(dict.fromkeys(map(lambda x: x[0], partial['compilers'].values()))))
+    match partial['compilers']['CUDA'].ID:
+        case 'nvidia':
+            partial['compilers']['CUDA'].path    = 'nvcc'
+            partial['compilers']['CUDA'].version = partial['cuda_version']
+        case 'clang':
+            pass
+        case _:
+            raise ValueError(f'unsupported CUDA compiler ID {partial['compilers']['CUDA'].ID}')
+
+    # CMake preset.
+    partial['cmake_preset'] = '-'.join(list(dict.fromkeys([partial['compilers']['CXX'].ID, partial['compilers']['CUDA'].ID])))
+
+    # Name and tag of the image.
+    name = 'cuda-' + partial['cmake_preset']
 
     tag = f'{partial['cuda_version']}-devel-ubuntu24.04'
 
@@ -49,8 +80,13 @@ def complete_job(partial : dict, args : argparse.Namespace) -> dict:
     if 'tests' not in partial:
         partial['tests'] = True
 
+    # Write compilers as dictionaries.
+    for lang in partial['compilers']:
+        partial['compilers'][lang] = dataclasses.asdict(partial['compilers'][lang])
+
     return partial
 
+@typeguard.typechecked
 def main(*, args : argparse.Namespace) -> None:
     """
     Generate the strategy matrix.
@@ -60,39 +96,39 @@ def main(*, args : argparse.Namespace) -> None:
 
     matrix.append(complete_job({
         'cuda_version' : '12.8.1',
-        'compilers' : {'CXX' : ('gcc', '13'), 'CUDA' : ('nvcc',)},
+        'compilers' : {'CXX' : Compiler(ID = 'gnu', version = '13'), 'CUDA' : Compiler(ID = 'nvidia')},
         'nvidia_compute_capability' : 70,
         'additional_build_platforms' : ['linux/arm64'],
     }, args = args))
 
     matrix.append(complete_job({
         'cuda_version' : '13.0.0',
-        'compilers' : {'CXX' : ('gcc', '14'), 'CUDA' : ('nvcc',)},
+        'compilers' : {'CXX' : Compiler(ID = 'gnu', version = '14'), 'CUDA' : Compiler(ID = 'nvidia')},
         'nvidia_compute_capability' : 120,
     }, args = args))
 
     matrix.append(complete_job({
         'cuda_version' : '13.0.0',
-        'compilers' : {'CXX' : ('gcc', '14'), 'CUDA' : ('nvcc',)},
+        'compilers' : {'CXX' : Compiler(ID = 'gnu', version = '14'), 'CUDA' : Compiler(ID = 'nvidia')},
         'nvidia_compute_capability' : 86,
         'tests' : False,
     }, args = args))
 
     matrix.append(complete_job({
         'cuda_version' : '12.8.1',
-        'compilers' : {'CXX' : ('clang', '19'), 'CUDA' : ('nvcc',)},
+        'compilers' : {'CXX' : Compiler(ID = 'clang', version = '19'), 'CUDA' : Compiler(ID = 'nvidia')},
         'nvidia_compute_capability' : 70,
     }, args = args))
 
     matrix.append(complete_job({
         'cuda_version' : '13.0.0',
-        'compilers' : {'CXX' : ('clang', '19'), 'CUDA' : ('nvcc',)},
+        'compilers' : {'CXX' : Compiler(ID = 'clang', version = '19'), 'CUDA' : Compiler(ID = 'nvidia')},
         'nvidia_compute_capability' : 120,
     }, args = args))
 
     matrix.append(complete_job({
         'cuda_version' : '12.8.1',
-        'compilers' : {'CXX' : ('clang', '21'),},
+        'compilers' : {'CXX' : Compiler(ID = 'clang', version = '21')},
         'nvidia_compute_capability' : 120,
     }, args = args))
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,7 +22,7 @@
             }
         },
         {
-            "name" : "cxx-gcc",
+            "name" : "cxx-gnu",
             "hidden": true,
             "inherits" : "cxx-ccache",
             "cacheVariables": {
@@ -45,7 +45,7 @@
             }
         },
         {
-            "name" : "cuda-nvcc",
+            "name" : "cuda-nvidia",
             "hidden" : true,
             "inherits" : "cuda-ccache",
             "cacheVariables": {
@@ -61,15 +61,15 @@
             }
         },
         {
-            "name" : "gcc-nvcc",
-            "inherits" : ["default", "cxx-gcc", "cuda-nvcc"],
+            "name" : "gnu-nvidia",
+            "inherits" : ["default", "cxx-gnu", "cuda-nvidia"],
             "cacheVariables" : {
                 "CMAKE_CUDA_HOST_COMPILER" : "g++"
             }
         },
         {
-            "name" : "clang-nvcc",
-            "inherits" : ["default", "cxx-clang", "cuda-nvcc"],
+            "name" : "clang-nvidia",
+            "inherits" : ["default", "cxx-clang", "cuda-nvidia"],
             "cacheVariables" : {
                 "CMAKE_CUDA_HOST_COMPILER" : "clang"
             }
@@ -87,13 +87,13 @@
             "inheritConfigureEnvironment" : true
         },
         {
-            "name" : "gcc-nvcc",
-            "configurePreset" : "gcc-nvcc",
+            "name" : "gnu-nvidia",
+            "configurePreset" : "gnu-nvidia",
             "inherits" : "default"
         },
         {
-            "name" : "clang-nvcc",
-            "configurePreset" : "clang-nvcc",
+            "name" : "clang-nvidia",
+            "configurePreset" : "clang-nvidia",
             "inherits" : "default"
         },
         {
@@ -116,13 +116,13 @@
             }
         },
         {
-            "name" : "gcc-nvcc",
-            "configurePreset" : "gcc-nvcc",
+            "name" : "gnu-nvidia",
+            "configurePreset" : "gnu-nvidia",
             "inherits" : "default"
         },
         {
-            "name" : "clang-nvcc",
-            "configurePreset" : "clang-nvcc",
+            "name" : "clang-nvidia",
+            "configurePreset" : "clang-nvidia",
             "inherits" : "default"
         },
         {

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,6 +1,5 @@
 ARG BASE_IMAGE=ubuntu:24.04
-ARG COMPILER=gcc
-ARG COMPILER_VERSION=13
+ARG CXX_COMPILER_ID=gnu
 
 FROM ${BASE_IMAGE} AS base
 
@@ -26,15 +25,18 @@ RUN <<EOF
 EOF
 
 # System requirements.
+FROM base AS system-requirements
+
 RUN --mount=target=/requirements/requirements.system.txt,type=bind,source=requirements/requirements.system.txt <<EOF
     set -ex
 
     apt-helpers install-packages --update --clean --requirement /requirements/requirements.system.txt
 EOF
 
-FROM base AS requirements-compiler-clang
+# Install Clang compiler.
+FROM system-requirements AS requirements-compiler-clang
 
-ARG COMPILER_VERSION
+ARG CXX_COMPILER_VERSION
 
 RUN <<EOF
     set -ex
@@ -43,43 +45,45 @@ RUN <<EOF
 
     wget https://apt.llvm.org/llvm.sh
     chmod +x llvm.sh
-    ./llvm.sh ${COMPILER_VERSION}
+    ./llvm.sh ${CXX_COMPILER_VERSION}
     rm llvm.sh
 
     update-alternatives-helpers --prefix /usr/bin \
         --display --level=10 \
-        --for-each-of clang=clang-${COMPILER_VERSION} clang++=clang++-${COMPILER_VERSION}
+        --for-each-of clang=clang-${CXX_COMPILER_VERSION} clang++=clang++-${CXX_COMPILER_VERSION}
 
     clang --version
 
     apt-helpers clean
 EOF
 
-FROM base AS requirements-compiler-gcc
+# Install GNU compilers.
+FROM system-requirements AS requirements-compiler-gnu
 
-ARG COMPILER_VERSION
+ARG CXX_COMPILER_VERSION
 
 RUN <<EOF
     set -ex
 
-    apt-helpers install-packages --update --packages gcc-${COMPILER_VERSION} g++-${COMPILER_VERSION}
-    
+    apt-helpers install-packages --update --packages gcc-${CXX_COMPILER_VERSION} g++-${CXX_COMPILER_VERSION}
+
     update-alternatives-helpers --prefix /usr/bin \
         --display --level=10 \
         --for-each-of \
-            gcc=gcc-${COMPILER_VERSION} \
-            g++=g++-${COMPILER_VERSION} \
-            $(uname -m)-linux-gnu-gcc=$(uname -m)-linux-gnu-gcc-${COMPILER_VERSION} \
-            $(uname -m)-linux-gnu-g++=$(uname -m)-linux-gnu-g++-${COMPILER_VERSION}
+            gcc=gcc-${CXX_COMPILER_VERSION} \
+            g++=g++-${CXX_COMPILER_VERSION} \
+            $(uname -m)-linux-gnu-gcc=$(uname -m)-linux-gnu-gcc-${CXX_COMPILER_VERSION} \
+            $(uname -m)-linux-gnu-g++=$(uname -m)-linux-gnu-g++-${CXX_COMPILER_VERSION}
 
     gcc -dumpfullversion -dumpversion
+    g++ -dumpfullversion -dumpversion
 
     apt-helpers clean
 EOF
 
-FROM requirements-compiler-${COMPILER}
-
 # Python requirements.
+FROM requirements-compiler-${CXX_COMPILER_ID} AS python-requirements
+
 RUN --mount=target=/python/requirements.txt,type=bind,source=python/requirements.txt \
     --mount=target=/requirements/requirements.python.txt,type=bind,source=requirements/requirements.python.txt <<EOF
     set -ex
@@ -90,13 +94,17 @@ RUN --mount=target=/python/requirements.txt,type=bind,source=python/requirements
 EOF
 
 # Install Nsight Systems.
+FROM python-requirements AS nsight-systems
+
 RUN --mount=target=/python/reprospect/installers/nsight_systems.py,type=bind,source=python/reprospect/installers/nsight_systems.py <<EOF
     set -ex
 
     python3 /python/reprospect/installers/nsight_systems.py
 EOF
 
-# MinIO.
+# Install MinIO.
+FROM nsight-systems AS minio
+
 RUN <<EOF
     set -ex
 
@@ -109,3 +117,37 @@ RUN <<EOF
 EOF
 
 ENV PATH=/opt/aistor-binaries/:${PATH}
+
+# Install Google Benchmark.
+FROM requirements-compiler-${CXX_COMPILER_ID} AS google-benchmark
+
+ARG CXX_COMPILER
+ARG GOOGLEBENCHMARK_VERSION
+
+ADD https://github.com/google/benchmark/archive/refs/tags/v${GOOGLEBENCHMARK_VERSION}.tar.gz /opt/google-benchmark-sources/v${GOOGLEBENCHMARK_VERSION}.tar.gz
+
+RUN <<EOF
+    set -ex
+
+    cd /opt/google-benchmark-sources
+    tar -zxf v${GOOGLEBENCHMARK_VERSION}.tar.gz
+
+    cd benchmark-${GOOGLEBENCHMARK_VERSION}
+
+    cmake -S . -B build \
+        -DCMAKE_CXX_COMPILER=${CXX_COMPILER} \
+        -DCMAKE_INSTALL_PREFIX=/opt/google-benchmark-${GOOGLEBENCHMARK_VERSION} \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBENCHMARK_ENABLE_TESTING=OFF \
+        -DBENCHMARK_INSTALL_DOCS=OFF
+
+    cmake --build build -j4 --target install
+EOF
+
+FROM minio
+
+ARG GOOGLEBENCHMARK_VERSION
+
+COPY --from=google-benchmark /opt/google-benchmark-${GOOGLEBENCHMARK_VERSION} /opt/google-benchmark-${GOOGLEBENCHMARK_VERSION}
+
+ENV benchmark_ROOT=/opt/google-benchmark-${GOOGLEBENCHMARK_VERSION}


### PR DESCRIPTION
We adopt the `CMake` compier IDs (https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html) but lowercase because `Docker` wants lowercase.