### PR TITLE
NVTX: Avoid dashes in markup

### DIFF
--- a/python/reprospect/tools/nsys.py
+++ b/python/reprospect/tools/nsys.py
@@ -67,6 +67,7 @@ class Session:
         executable : pathlib.Path,
         opts : typing.Optional[list[str]] = None,
         nvtx_capture : typing.Optional[str] = None,
+        capture_range_end : str = 'stop',
         args : typing.Optional[list[str | pathlib.Path]] = None,
     ) -> 'Session.Command':
         """
@@ -78,7 +79,7 @@ class Session:
         # This reduces the amount of data collected (and makes things faster).
         opts += [
             '--capture-range=nvtx',
-            '--capture-range-end=none',
+            f'--capture-range-end={capture_range_end}',
             f'--nvtx-capture={nvtx_capture}',
             '--trace=nvtx,cuda',
         ] if nvtx_capture else ['--trace=cuda']

--- a/tests/cpp/cuda/test_graph.cpp
+++ b/tests/cpp/cuda/test_graph.cpp
@@ -40,7 +40,7 @@ cudaGraphNode_t add_node(const cudaGraph_t graph, index_t* const counters, const
     return node;
 }
 
-struct MyAppDomain{ static constexpr char const* name {"application-domain"}; };
+struct MyAppDomain{ static constexpr char const* name {"application_domain"}; };
 
 int main()
 {
@@ -48,7 +48,7 @@ int main()
     ::nvtx3::mark_in<MyAppDomain>("Starting my application.");
 
     //! This one is superfluous but serves the tests.
-    const auto& outer = ::nvtx3::start_range_in<MyAppDomain>("outer-useless-range");
+    const auto& outer = ::nvtx3::start_range_in<MyAppDomain>("outer_useless_range");
 
     //! Create stream.
     cudaStream_t stream = nullptr;

--- a/tests/cpp/cuda/test_saxpy.cpp
+++ b/tests/cpp/cuda/test_saxpy.cpp
@@ -20,7 +20,7 @@ void saxpy_kernel(const index_t size, const float factor, const float* __restric
         vec_y[index] += factor * vec_x[index];
 }
 
-struct MyAppDomain{ static constexpr char const* name {"application-domain"}; };
+struct MyAppDomain{ static constexpr char const* name {"application_domain"}; };
 
 int main()
 {
@@ -28,14 +28,14 @@ int main()
     ::nvtx3::mark_in<MyAppDomain>("Starting my application.");
 
     //! This one is superfluous but serves the tests.
-    const auto& outer = ::nvtx3::start_range_in<MyAppDomain>("outer-useless-range");
+    const auto& outer = ::nvtx3::start_range_in<MyAppDomain>("outer_useless_range");
 
     constexpr index_t size = 1024;
 
     //! Create streams.
     cudaStream_t stream_A = nullptr, stream_B = nullptr;
     {
-        ::nvtx3::scoped_range_in<MyAppDomain> range{"create-streams"};
+        ::nvtx3::scoped_range_in<MyAppDomain> range{"create_streams"};
         REPROSPECT_CHECK_CUDART_CALL(cudaStreamCreate(&stream_A));
         REPROSPECT_CHECK_CUDART_CALL(cudaStreamCreate(&stream_B));
     }
@@ -57,11 +57,11 @@ int main()
     constexpr index_t grid_size  = (size + block_size - 1) / block_size;
 
     {
-        ::nvtx3::scoped_range_in<MyAppDomain> range{"launch-saxpy-kernel-first-time"};
+        ::nvtx3::scoped_range_in<MyAppDomain> range{"launch_saxpy_kernel_first_time"};
         saxpy_kernel<<<dim3{grid_size, 1, 1}, dim3{block_size, 1, 1} , 0, stream_B>>>(size, 2.f, vec_x, vec_y);
     }
     {
-        ::nvtx3::scoped_range_in<MyAppDomain> range{"launch-saxpy-kernel-second-time"};
+        ::nvtx3::scoped_range_in<MyAppDomain> range{"launch_saxpy_kernel_second_time"};
         saxpy_kernel<<<dim3{grid_size, 1, 1}, dim3{block_size, 1, 1} , 0, stream_B>>>(size, 2.f, vec_x, vec_y);
     }
 

--- a/tests/python/test/test_graph.py
+++ b/tests/python/test/test_graph.py
@@ -61,7 +61,7 @@ class TestNCU(TestGraph):
         ncu.Metric(name = 'launch__registers_per_thread_allocated')
     ]
 
-    NVTX_INCLUDES = ['application-domain@outer-useless-range']
+    NVTX_INCLUDES = ['application_domain@outer_useless_range']
 
     @pytest.fixture(scope = 'class')
     @typeguard.typechecked

--- a/tests/python/test/test_saxpy.py
+++ b/tests/python/test/test_saxpy.py
@@ -48,8 +48,8 @@ class TestNCU(TestSaxpy):
     ]
 
     NVTX_INCLUDES = [
-        'application-domain@launch-saxpy-kernel-first-time/',
-        'application-domain@launch-saxpy-kernel-second-time/',
+        'application_domain@launch_saxpy_kernel_first_time/',
+        'application_domain@launch_saxpy_kernel_second_time/',
     ]
 
     @pytest.fixture(scope = 'class')

--- a/tests/python/tools/test_ncu.py
+++ b/tests/python/tools/test_ncu.py
@@ -56,8 +56,8 @@ class TestSession:
             executable = self.SAXPY,
             metrics = METRICS,
             nvtx_includes = map(
-                lambda x: f'application-domain@{x}/',
-                ['launch-saxpy-kernel-first-time', 'launch-saxpy-kernel-second-time'],
+                lambda x: f'application_domain@{x}/',
+                ['launch_saxpy_kernel_first_time', 'launch_saxpy_kernel_second_time'],
             ),
             retries = 5,
         )
@@ -79,14 +79,14 @@ class TestSession:
 
         # Extract results with NVTX filtering. Request only the 2 first metrics.
         with pytest.raises(RuntimeError, match = 'no action found'):
-            results_filtered = report.extract_metrics_in_range(0, metrics = METRICS[:2], includes = ['outer-useless-range'])
+            results_filtered = report.extract_metrics_in_range(0, metrics = METRICS[:2], includes = ['outer_useless_range'])
 
-        results_filtered = report.extract_metrics_in_range(0, metrics = METRICS[:2], includes = ['application-domain@outer-useless-range'])
+        results_filtered = report.extract_metrics_in_range(0, metrics = METRICS[:2], includes = ['application_domain@outer_useless_range'])
 
         logging.info(results_filtered)
 
-        results_filtered_first  = results_filtered['launch-saxpy-kernel-first-time']
-        results_filtered_second = results_filtered['launch-saxpy-kernel-second-time']
+        results_filtered_first  = results_filtered['launch_saxpy_kernel_first_time']
+        results_filtered_second = results_filtered['launch_saxpy_kernel_second_time']
 
         assert len(results_filtered_first)  == 1
         assert len(results_filtered_second) == 1

--- a/tests/python/tools/test_nsys.py
+++ b/tests/python/tools/test_nsys.py
@@ -4,7 +4,6 @@ import pathlib
 import tempfile
 import typing
 
-import pandas
 import semantic_version
 import typeguard
 
@@ -18,7 +17,8 @@ class TestSession:
     """
     EXECUTABLE = pathlib.Path(os.environ['CMAKE_BINARY_DIR']) / 'tests' / 'cpp' / 'cuda' / 'tests_cpp_cuda_saxpy' if 'CMAKE_BINARY_DIR' in os.environ else None
 
-    def run(self) -> Session:
+    @typeguard.typechecked
+    def run(self, nvtx_capture : typing.Optional[str] = None) -> Session:
         assert self.EXECUTABLE.is_file()
 
         ns = Session(
@@ -28,6 +28,7 @@ class TestSession:
 
         ns.run(
             executable = self.EXECUTABLE,
+            nvtx_capture = nvtx_capture,
             cwd = TMPDIR,
         )
 
@@ -39,7 +40,7 @@ class TestSession:
         """
         Collect all `Cuda` API calls of :file:`tests/cpp/cuda/test_saxpy.cpp`.
         """
-        ns = self.run()
+        ns = self.run(nvtx_capture = "outer_useless_range@application_domain")
 
         cuda_api_trace = ns.extract_statistical_report(report = 'cuda_api_trace')
 


### PR DESCRIPTION
This PR:
- We found that `nsys` seems to have problems with `-` in names of ranges and domains.
- Change default value for `capture-range-end` to `stop`.