### PR TITLE
examples(kokkos): view allocation benchmarking needs a proper tracing first

### DIFF
--- a/.github/config/typos.toml
+++ b/.github/config/typos.toml
@@ -5,3 +5,7 @@ extend-ignore-identifiers-re = [
 
 [default.extend-identifiers]
 NervanaSystems = "NervanaSystems"
+
+[type.svg]
+extend-glob = ["*.svg"]
+check-file = false

--- a/docs/source/examples/kokkos/view/allocation.rst
+++ b/docs/source/examples/kokkos/view/allocation.rst
@@ -1,4 +1,30 @@
 `Kokkos::View` allocation
 =========================
 
+The use of API tracing to elucidate benchmarking results
+--------------------------------------------------------
+
+A benchmark comparing :code:`Kokkos` with native CUDA can be found in :py:mod:`examples.kokkos.view.example_allocation_benchmarking`.
+
+To better understand the results, a comprehensive CUDA API tracing test is required.
+Indeed, as tested in :py:class:`examples.kokkos.view.example_allocation_tracing.TestNSYS`,
+the code path followed by :code:`Kokkos` depends on the memory space in which the allocation happens
+as well as its size.
+The tracing also brings to light that :code:`Kokkos` always copies the :code:`Kokkos::View` shared allocation
+header, which greatly impacts the performance compared to allocating manually with CUDA (see also https://github.com/kokkos/kokkos/pull/8440).
+
+Benchmarking
+------------
+
+.. figure:: example_allocation_benchmarking.svg
+
+    Comparison of repeated buffer allocation/deallocation using :code:`Kokkos` or native CUDA, with stream-ordered allocation or not.
+    CUDA 13.0.0, :code:`Kokkos` 4.7.01, NVIDIA GeForce RTX 5070 Ti, :lastcommit:`docs/source/examples/kokkos/view/example_allocation_benchmarking.svg`.
+    Note that the results may vary with machine setup.
+
+.. automodule:: examples.kokkos.view.example_allocation_benchmarking
+
+Tracing
+-------
+
 .. automodule:: examples.kokkos.view.example_allocation_tracing

--- a/docs/source/examples/kokkos/view/example_allocation_benchmarking.svg
+++ b/docs/source/examples/kokkos/view/example_allocation_benchmarking.svg
@@ -1,0 +1,2902 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="2880.39976pt" height="1448.39952pt" viewBox="0 0 2880.39976 1448.39952" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-11-27T16:12:44.609669</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.7, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M -0 1448.39952
+L 2880.39976 1448.39952
+L 2880.39976 0
+L -0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 259.008533 1387.61577
+L 2873.19976 1387.61577
+L 2873.19976 7.2
+L 259.008533 7.2
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 333.288611 1387.61577
+L 333.288611 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="mbf4579de62" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mbf4579de62" x="333.288611" y="1387.61577" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- $\mathdefault{10^{-1}}$ -->
+      <g transform="translate(307.438611 1411.332332) scale(0.22 -0.22)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-2212" d="M 678 2272
+L 4684 2272
+L 4684 1741
+L 678 1741
+L 678 2272
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-2212" transform="translate(128.203125 38.965625) scale(0.7)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(186.855469 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 748.798433 1387.61577
+L 748.798433 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mbf4579de62" x="748.798433" y="1387.61577" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g transform="translate(729.438433 1411.332332) scale(0.22 -0.22)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 1164.308255 1387.61577
+L 1164.308255 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mbf4579de62" x="1164.308255" y="1387.61577" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(1144.948255 1411.332332) scale(0.22 -0.22)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 1579.818078 1387.61577
+L 1579.818078 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mbf4579de62" x="1579.818078" y="1387.61577" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(1560.458078 1411.332332) scale(0.22 -0.22)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 1995.3279 1387.61577
+L 1995.3279 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mbf4579de62" x="1995.3279" y="1387.61577" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(1975.9679 1411.332332) scale(0.22 -0.22)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516
+Q 3050 2419 3304 2112
+Q 3559 1806 3559 1356
+Q 3559 666 3084 287
+Q 2609 -91 1734 -91
+Q 1441 -91 1130 -33
+Q 819 25 488 141
+L 488 750
+Q 750 597 1062 519
+Q 1375 441 1716 441
+Q 2309 441 2620 675
+Q 2931 909 2931 1356
+Q 2931 1769 2642 2001
+Q 2353 2234 1838 2234
+L 1294 2234
+L 1294 2753
+L 1863 2753
+Q 2328 2753 2575 2939
+Q 2822 3125 2822 3475
+Q 2822 3834 2567 4026
+Q 2313 4219 1838 4219
+Q 1578 4219 1281 4162
+Q 984 4106 628 3988
+L 628 4550
+Q 988 4650 1302 4700
+Q 1616 4750 1894 4750
+Q 2613 4750 3031 4423
+Q 3450 4097 3450 3541
+Q 3450 3153 3228 2886
+Q 3006 2619 2597 2516
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 2410.837722 1387.61577
+L 2410.837722 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#mbf4579de62" x="2410.837722" y="1387.61577" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- $\mathdefault{10^{4}}$ -->
+      <g transform="translate(2391.477722 1411.332332) scale(0.22 -0.22)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116
+L 825 1625
+L 2419 1625
+L 2419 4116
+z
+M 2253 4666
+L 3047 4666
+L 3047 1625
+L 3713 1625
+L 3713 1100
+L 3047 1100
+L 3047 0
+L 2419 0
+L 2419 1100
+L 313 1100
+L 313 1709
+L 2253 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 2826.347544 1387.61577
+L 2826.347544 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#mbf4579de62" x="2826.347544" y="1387.61577" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- $\mathdefault{10^{5}}$ -->
+      <g transform="translate(2806.987544 1411.332332) scale(0.22 -0.22)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 268.925325 1387.61577
+L 268.925325 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <defs>
+       <path id="mdae5b2aa94" d="M 0 0
+L 0 2
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="268.925325" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_17">
+      <path d="M 293.021549 1387.61577
+L 293.021549 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="293.021549" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_19">
+      <path d="M 314.275924 1387.61577
+L 314.275924 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="314.275924" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_21">
+      <path d="M 458.369531 1387.61577
+L 458.369531 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="458.369531" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_23">
+      <path d="M 531.537179 1387.61577
+L 531.537179 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="531.537179" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_13">
+     <g id="line2d_25">
+      <path d="M 583.450451 1387.61577
+L 583.450451 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="583.450451" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_27">
+      <path d="M 623.717513 1387.61577
+L 623.717513 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="623.717513" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_29">
+      <path d="M 656.618099 1387.61577
+L 656.618099 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="656.618099" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_31">
+      <path d="M 684.435147 1387.61577
+L 684.435147 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="684.435147" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_33">
+      <path d="M 708.531371 1387.61577
+L 708.531371 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="708.531371" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_35">
+      <path d="M 729.785746 1387.61577
+L 729.785746 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="729.785746" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_19">
+     <g id="line2d_37">
+      <path d="M 873.879353 1387.61577
+L 873.879353 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="873.879353" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_39">
+      <path d="M 947.047001 1387.61577
+L 947.047001 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="947.047001" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_41">
+      <path d="M 998.960273 1387.61577
+L 998.960273 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="998.960273" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_43">
+      <path d="M 1039.227335 1387.61577
+L 1039.227335 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1039.227335" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_45">
+      <path d="M 1072.127921 1387.61577
+L 1072.127921 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1072.127921" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_47">
+      <path d="M 1099.94497 1387.61577
+L 1099.94497 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1099.94497" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_49">
+      <path d="M 1124.041193 1387.61577
+L 1124.041193 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1124.041193" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_26">
+     <g id="line2d_51">
+      <path d="M 1145.295569 1387.61577
+L 1145.295569 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1145.295569" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_27">
+     <g id="line2d_53">
+      <path d="M 1289.389175 1387.61577
+L 1289.389175 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1289.389175" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_28">
+     <g id="line2d_55">
+      <path d="M 1362.556823 1387.61577
+L 1362.556823 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1362.556823" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_29">
+     <g id="line2d_57">
+      <path d="M 1414.470095 1387.61577
+L 1414.470095 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1414.470095" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_30">
+     <g id="line2d_59">
+      <path d="M 1454.737158 1387.61577
+L 1454.737158 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1454.737158" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_31">
+     <g id="line2d_61">
+      <path d="M 1487.637743 1387.61577
+L 1487.637743 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1487.637743" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_32">
+     <g id="line2d_63">
+      <path d="M 1515.454792 1387.61577
+L 1515.454792 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1515.454792" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_33">
+     <g id="line2d_65">
+      <path d="M 1539.551015 1387.61577
+L 1539.551015 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1539.551015" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_34">
+     <g id="line2d_67">
+      <path d="M 1560.805391 1387.61577
+L 1560.805391 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1560.805391" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_35">
+     <g id="line2d_69">
+      <path d="M 1704.898998 1387.61577
+L 1704.898998 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1704.898998" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_36">
+     <g id="line2d_71">
+      <path d="M 1778.066645 1387.61577
+L 1778.066645 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1778.066645" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_37">
+     <g id="line2d_73">
+      <path d="M 1829.979918 1387.61577
+L 1829.979918 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1829.979918" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_38">
+     <g id="line2d_75">
+      <path d="M 1870.24698 1387.61577
+L 1870.24698 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_76">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1870.24698" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_39">
+     <g id="line2d_77">
+      <path d="M 1903.147565 1387.61577
+L 1903.147565 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_78">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1903.147565" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_40">
+     <g id="line2d_79">
+      <path d="M 1930.964614 1387.61577
+L 1930.964614 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1930.964614" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_41">
+     <g id="line2d_81">
+      <path d="M 1955.060838 1387.61577
+L 1955.060838 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1955.060838" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_42">
+     <g id="line2d_83">
+      <path d="M 1976.315213 1387.61577
+L 1976.315213 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="1976.315213" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_43">
+     <g id="line2d_85">
+      <path d="M 2120.40882 1387.61577
+L 2120.40882 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_86">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2120.40882" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_44">
+     <g id="line2d_87">
+      <path d="M 2193.576468 1387.61577
+L 2193.576468 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_88">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2193.576468" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_45">
+     <g id="line2d_89">
+      <path d="M 2245.48974 1387.61577
+L 2245.48974 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_90">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2245.48974" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_46">
+     <g id="line2d_91">
+      <path d="M 2285.756802 1387.61577
+L 2285.756802 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_92">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2285.756802" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_47">
+     <g id="line2d_93">
+      <path d="M 2318.657388 1387.61577
+L 2318.657388 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_94">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2318.657388" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_48">
+     <g id="line2d_95">
+      <path d="M 2346.474436 1387.61577
+L 2346.474436 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_96">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2346.474436" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_49">
+     <g id="line2d_97">
+      <path d="M 2370.57066 1387.61577
+L 2370.57066 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_98">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2370.57066" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_50">
+     <g id="line2d_99">
+      <path d="M 2391.825035 1387.61577
+L 2391.825035 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_100">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2391.825035" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_51">
+     <g id="line2d_101">
+      <path d="M 2535.918642 1387.61577
+L 2535.918642 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_102">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2535.918642" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_52">
+     <g id="line2d_103">
+      <path d="M 2609.08629 1387.61577
+L 2609.08629 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_104">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2609.08629" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_53">
+     <g id="line2d_105">
+      <path d="M 2660.999562 1387.61577
+L 2660.999562 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_106">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2660.999562" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_54">
+     <g id="line2d_107">
+      <path d="M 2701.266624 1387.61577
+L 2701.266624 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_108">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2701.266624" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_55">
+     <g id="line2d_109">
+      <path d="M 2734.16721 1387.61577
+L 2734.16721 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_110">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2734.16721" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_56">
+     <g id="line2d_111">
+      <path d="M 2761.984258 1387.61577
+L 2761.984258 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_112">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2761.984258" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_57">
+     <g id="line2d_113">
+      <path d="M 2786.080482 1387.61577
+L 2786.080482 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_114">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2786.080482" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_58">
+     <g id="line2d_115">
+      <path d="M 2807.334858 1387.61577
+L 2807.334858 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_116">
+      <g>
+       <use xlink:href="#mdae5b2aa94" x="2807.334858" y="1387.61577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <!-- buffer size [kB] -->
+     <g transform="translate(1482.294459 1436.624208) scale(0.22 -0.22)">
+      <defs>
+       <path id="DejaVuSans-62" d="M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+M 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+L 1159 0
+L 581 0
+L 581 4863
+L 1159 4863
+L 1159 2969
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-75" d="M 544 1381
+L 544 3500
+L 1119 3500
+L 1119 1403
+Q 1119 906 1312 657
+Q 1506 409 1894 409
+Q 2359 409 2629 706
+Q 2900 1003 2900 1516
+L 2900 3500
+L 3475 3500
+L 3475 0
+L 2900 0
+L 2900 538
+Q 2691 219 2414 64
+Q 2138 -91 1772 -91
+Q 1169 -91 856 284
+Q 544 659 544 1381
+z
+M 1991 3584
+L 1991 3584
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-66" d="M 2375 4863
+L 2375 4384
+L 1825 4384
+Q 1516 4384 1395 4259
+Q 1275 4134 1275 3809
+L 1275 3500
+L 2222 3500
+L 2222 3053
+L 1275 3053
+L 1275 0
+L 697 0
+L 697 3053
+L 147 3053
+L 147 3500
+L 697 3500
+L 697 3744
+Q 697 4328 969 4595
+Q 1241 4863 1831 4863
+L 2375 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894
+L 3597 1613
+L 953 1613
+Q 991 1019 1311 708
+Q 1631 397 2203 397
+Q 2534 397 2845 478
+Q 3156 559 3463 722
+L 3463 178
+Q 3153 47 2828 -22
+Q 2503 -91 2169 -91
+Q 1331 -91 842 396
+Q 353 884 353 1716
+Q 353 2575 817 3079
+Q 1281 3584 2069 3584
+Q 2775 3584 3186 3129
+Q 3597 2675 3597 1894
+z
+M 3022 2063
+Q 3016 2534 2758 2815
+Q 2500 3097 2075 3097
+Q 1594 3097 1305 2825
+Q 1016 2553 972 2059
+L 3022 2063
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963
+Q 2534 3019 2420 3045
+Q 2306 3072 2169 3072
+Q 1681 3072 1420 2755
+Q 1159 2438 1159 1844
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1341 3275 1631 3429
+Q 1922 3584 2338 3584
+Q 2397 3584 2469 3576
+Q 2541 3569 2628 3553
+L 2631 2963
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397
+L 2834 2853
+Q 2591 2978 2328 3040
+Q 2066 3103 1784 3103
+Q 1356 3103 1142 2972
+Q 928 2841 928 2578
+Q 928 2378 1081 2264
+Q 1234 2150 1697 2047
+L 1894 2003
+Q 2506 1872 2764 1633
+Q 3022 1394 3022 966
+Q 3022 478 2636 193
+Q 2250 -91 1575 -91
+Q 1294 -91 989 -36
+Q 684 19 347 128
+L 347 722
+Q 666 556 975 473
+Q 1284 391 1588 391
+Q 1994 391 2212 530
+Q 2431 669 2431 922
+Q 2431 1156 2273 1281
+Q 2116 1406 1581 1522
+L 1381 1569
+Q 847 1681 609 1914
+Q 372 2147 372 2553
+Q 372 3047 722 3315
+Q 1072 3584 1716 3584
+Q 2034 3584 2315 3537
+Q 2597 3491 2834 3397
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500
+L 1178 3500
+L 1178 0
+L 603 0
+L 603 3500
+z
+M 603 4863
+L 1178 4863
+L 1178 4134
+L 603 4134
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-7a" d="M 353 3500
+L 3084 3500
+L 3084 2975
+L 922 459
+L 3084 459
+L 3084 0
+L 275 0
+L 275 525
+L 2438 3041
+L 353 3041
+L 353 3500
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5b" d="M 550 4863
+L 1875 4863
+L 1875 4416
+L 1125 4416
+L 1125 -397
+L 1875 -397
+L 1875 -844
+L 550 -844
+L 550 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863
+L 1159 4863
+L 1159 1991
+L 2875 3500
+L 3609 3500
+L 1753 1863
+L 3688 0
+L 2938 0
+L 1159 1709
+L 1159 0
+L 581 0
+L 581 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-42" d="M 1259 2228
+L 1259 519
+L 2272 519
+Q 2781 519 3026 730
+Q 3272 941 3272 1375
+Q 3272 1813 3026 2020
+Q 2781 2228 2272 2228
+L 1259 2228
+z
+M 1259 4147
+L 1259 2741
+L 2194 2741
+Q 2656 2741 2882 2914
+Q 3109 3088 3109 3444
+Q 3109 3797 2882 3972
+Q 2656 4147 2194 4147
+L 1259 4147
+z
+M 628 4666
+L 2241 4666
+Q 2963 4666 3353 4366
+Q 3744 4066 3744 3513
+Q 3744 3084 3544 2831
+Q 3344 2578 2956 2516
+Q 3422 2416 3680 2098
+Q 3938 1781 3938 1306
+Q 3938 681 3513 340
+Q 3088 0 2303 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5d" d="M 1947 4863
+L 1947 -844
+L 622 -844
+L 622 -397
+L 1369 -397
+L 1369 4416
+L 622 4416
+L 622 4863
+L 1947 4863
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-62"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(126.855469 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(162.060547 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(197.265625 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(258.789062 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(299.902344 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(331.689453 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(383.789062 0)"/>
+      <use xlink:href="#DejaVuSans-7a" transform="translate(411.572266 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(464.0625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(525.585938 0)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(557.373047 0)"/>
+      <use xlink:href="#DejaVuSans-6b" transform="translate(596.386719 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(654.296875 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(722.900391 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_117">
+      <path d="M 259.008533 1304.019696
+L 2873.19976 1304.019696
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_118">
+      <defs>
+       <path id="mdd28988c14" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mdd28988c14" x="259.008533" y="1304.019696" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(213.288533 1312.377977) scale(0.22 -0.22)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_119">
+      <path d="M 259.008533 882.865242
+L 2873.19976 882.865242
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_120">
+      <g>
+       <use xlink:href="#mdd28988c14" x="259.008533" y="882.865242" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{4}}$ -->
+      <g transform="translate(213.288533 891.223524) scale(0.22 -0.22)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-34" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_121">
+      <path d="M 259.008533 461.710789
+L 2873.19976 461.710789
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_122">
+      <g>
+       <use xlink:href="#mdd28988c14" x="259.008533" y="461.710789" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{5}}$ -->
+      <g transform="translate(213.288533 470.06907) scale(0.22 -0.22)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_123">
+      <path d="M 259.008533 40.556336
+L 2873.19976 40.556336
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_124">
+      <g>
+       <use xlink:href="#mdd28988c14" x="259.008533" y="40.556336" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- $\mathdefault{10^{6}}$ -->
+      <g transform="translate(213.288533 48.914617) scale(0.22 -0.22)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-36" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_125">
+      <path d="M 259.008533 1369.257346
+L 2873.19976 1369.257346
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_126">
+      <defs>
+       <path id="m5ac4545a5c" d="M 0 0
+L -2 0
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="1369.257346" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_127">
+      <path d="M 259.008533 1344.833779
+L 2873.19976 1344.833779
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_128">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="1344.833779" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_129">
+      <path d="M 259.008533 1323.290667
+L 2873.19976 1323.290667
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_130">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="1323.290667" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_131">
+      <path d="M 259.008533 1177.239572
+L 2873.19976 1177.239572
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_132">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="1177.239572" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_133">
+      <path d="M 259.008533 1103.077954
+L 2873.19976 1103.077954
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_134">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="1103.077954" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_135">
+      <path d="M 259.008533 1050.459449
+L 2873.19976 1050.459449
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_136">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="1050.459449" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_137">
+      <path d="M 259.008533 1009.645366
+L 2873.19976 1009.645366
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_138">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="1009.645366" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_139">
+      <path d="M 259.008533 976.297831
+L 2873.19976 976.297831
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_140">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="976.297831" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_141">
+      <path d="M 259.008533 948.102893
+L 2873.19976 948.102893
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_142">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="948.102893" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_143">
+      <path d="M 259.008533 923.679326
+L 2873.19976 923.679326
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_144">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="923.679326" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_145">
+      <path d="M 259.008533 902.136213
+L 2873.19976 902.136213
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_146">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="902.136213" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_147">
+      <path d="M 259.008533 756.085119
+L 2873.19976 756.085119
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_148">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="756.085119" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_149">
+      <path d="M 259.008533 681.923501
+L 2873.19976 681.923501
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_150">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="681.923501" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_151">
+      <path d="M 259.008533 629.304996
+L 2873.19976 629.304996
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_152">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="629.304996" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_153">
+      <path d="M 259.008533 588.490912
+L 2873.19976 588.490912
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_154">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="588.490912" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_155">
+      <path d="M 259.008533 555.143378
+L 2873.19976 555.143378
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_156">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="555.143378" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_157">
+      <path d="M 259.008533 526.948439
+L 2873.19976 526.948439
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_158">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="526.948439" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_159">
+      <path d="M 259.008533 502.524873
+L 2873.19976 502.524873
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_160">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="502.524873" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_161">
+      <path d="M 259.008533 480.98176
+L 2873.19976 480.98176
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_162">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="480.98176" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_163">
+      <path d="M 259.008533 334.930666
+L 2873.19976 334.930666
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_164">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="334.930666" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_165">
+      <path d="M 259.008533 260.769048
+L 2873.19976 260.769048
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_166">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="260.769048" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_167">
+      <path d="M 259.008533 208.150543
+L 2873.19976 208.150543
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_168">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="208.150543" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_169">
+      <path d="M 259.008533 167.336459
+L 2873.19976 167.336459
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_170">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="167.336459" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_171">
+      <path d="M 259.008533 133.988925
+L 2873.19976 133.988925
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_172">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="133.988925" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_173">
+      <path d="M 259.008533 105.793986
+L 2873.19976 105.793986
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_174">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="105.793986" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_175">
+      <path d="M 259.008533 81.370419
+L 2873.19976 81.370419
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_176">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="81.370419" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_177">
+      <path d="M 259.008533 59.827307
+L 2873.19976 59.827307
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #b0b0b0; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_178">
+      <g>
+       <use xlink:href="#m5ac4545a5c" x="259.008533" y="59.827307" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_13">
+     <!-- time [ns] -->
+     <g transform="translate(204.71322 747.040229) rotate(-90) scale(0.22 -0.22)">
+      <defs>
+       <path id="DejaVuSans-74" d="M 1172 4494
+L 1172 3500
+L 2356 3500
+L 2356 3053
+L 1172 3053
+L 1172 1153
+Q 1172 725 1289 603
+Q 1406 481 1766 481
+L 2356 481
+L 2356 0
+L 1766 0
+Q 1100 0 847 248
+Q 594 497 594 1153
+L 594 3053
+L 172 3053
+L 172 3500
+L 594 3500
+L 594 4494
+L 1172 4494
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828
+Q 3544 3216 3844 3400
+Q 4144 3584 4550 3584
+Q 5097 3584 5394 3201
+Q 5691 2819 5691 2113
+L 5691 0
+L 5113 0
+L 5113 2094
+Q 5113 2597 4934 2840
+Q 4756 3084 4391 3084
+Q 3944 3084 3684 2787
+Q 3425 2491 3425 1978
+L 3425 0
+L 2847 0
+L 2847 2094
+Q 2847 2600 2669 2842
+Q 2491 3084 2119 3084
+Q 1678 3084 1418 2786
+Q 1159 2488 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1356 3278 1631 3431
+Q 1906 3584 2284 3584
+Q 2666 3584 2933 3390
+Q 3200 3197 3328 2828
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-74"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(39.208984 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(66.992188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(164.404297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(225.927734 0)"/>
+      <use xlink:href="#DejaVuSans-5b" transform="translate(257.714844 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(296.728516 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(360.107422 0)"/>
+      <use xlink:href="#DejaVuSans-5d" transform="translate(412.207031 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_179">
+    <path d="M 1414.470095 1387.61577
+L 1414.470095 7.2
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke-dasharray: 11.1,4.8; stroke-dashoffset: 0; stroke: #000000; stroke-width: 3"/>
+   </g>
+   <g id="line2d_180">
+    <path d="M 377.835406 1290.207945
+L 493.511805 1289.218936
+L 691.760373 1303.354581
+L 890.008941 1291.951006
+L 1088.257508 1294.911549
+L 1286.506076 1304.457759
+L 1409.901405 1302.109332
+L 1418.925967 1288.851774
+L 1484.754644 1290.332625
+L 1683.003212 1286.034793
+L 1881.251779 1291.711982
+L 2079.500347 1294.871093
+L 2277.748915 1291.137421
+L 2475.997482 1290.681688
+L 2674.24605 479.42671
+L 2754.372886 346.158157
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #000000; stroke-width: 4; stroke-linecap: square"/>
+    <defs>
+     <path id="m32cb50298b" d="M -5 5
+L 5 5
+L 5 -5
+L -5 -5
+z
+" style="stroke: #000000; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#m32cb50298b" x="377.835406" y="1290.207945" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="493.511805" y="1289.218936" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="691.760373" y="1303.354581" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="890.008941" y="1291.951006" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="1088.257508" y="1294.911549" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="1286.506076" y="1304.457759" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="1409.901405" y="1302.109332" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="1418.925967" y="1288.851774" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="1484.754644" y="1290.332625" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="1683.003212" y="1286.034793" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="1881.251779" y="1291.711982" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="2079.500347" y="1294.871093" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="2277.748915" y="1291.137421" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="2475.997482" y="1290.681688" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="2674.24605" y="479.42671" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="2754.372886" y="346.158157" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_181">
+    <path d="M 377.835406 1034.787402
+L 493.511805 1052.852452
+L 691.760373 1053.533115
+L 890.008941 1037.815142
+L 1088.257508 1038.924675
+L 1286.506076 1035.846879
+L 1409.901405 1039.926
+L 1418.925967 1038.789674
+L 1484.754644 1040.490715
+L 1683.003212 1036.433521
+L 1881.251779 1038.566004
+L 2079.500347 1037.62338
+L 2277.748915 1050.660575
+L 2475.997482 474.044555
+L 2504.211046 338.033656
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #ff0000; stroke-width: 4; stroke-linecap: square"/>
+    <defs>
+     <path id="m92747b9ae6" d="M -5 5
+L 5 5
+L 5 -5
+L -5 -5
+z
+" style="stroke: #ff0000; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#m92747b9ae6" x="377.835406" y="1034.787402" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="493.511805" y="1052.852452" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="691.760373" y="1053.533115" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="890.008941" y="1037.815142" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="1088.257508" y="1038.924675" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="1286.506076" y="1035.846879" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="1409.901405" y="1039.926" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="1418.925967" y="1038.789674" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="1484.754644" y="1040.490715" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="1683.003212" y="1036.433521" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="1881.251779" y="1038.566004" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="2079.500347" y="1037.62338" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="2277.748915" y="1050.660575" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="2475.997482" y="474.044555" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="2504.211046" y="338.033656" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_182">
+    <path d="M 377.835406 910.941485
+L 493.511805 913.768043
+L 691.760373 913.078924
+L 890.008941 913.364603
+L 1088.257508 912.455064
+L 1286.506076 914.842628
+L 1409.901405 915.01534
+L 1418.925967 913.833019
+L 1484.754644 924.297139
+L 1683.003212 925.244275
+L 1881.251779 910.09979
+L 2079.500347 907.558741
+L 2277.748915 470.089293
+L 2475.997482 260.526837
+L 2504.211046 206.066915
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #008000; stroke-width: 4; stroke-linecap: square"/>
+    <defs>
+     <path id="me3266300a0" d="M -5 5
+L 5 5
+L 5 -5
+L -5 -5
+z
+" style="stroke: #008000; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#me3266300a0" x="377.835406" y="910.941485" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="493.511805" y="913.768043" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="691.760373" y="913.078924" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="890.008941" y="913.364603" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="1088.257508" y="912.455064" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="1286.506076" y="914.842628" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="1409.901405" y="915.01534" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="1418.925967" y="913.833019" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="1484.754644" y="924.297139" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="1683.003212" y="925.244275" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="1881.251779" y="910.09979" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="2079.500347" y="907.558741" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="2277.748915" y="470.089293" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="2475.997482" y="260.526837" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="2504.211046" y="206.066915" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_183">
+    <path d="M 377.835406 839.588563
+L 493.511805 835.615033
+L 691.760373 839.614654
+L 890.008941 839.958103
+L 1088.257508 840.13374
+L 1286.506076 836.682911
+L 1409.901405 839.158122
+L 1418.925967 839.962371
+L 1484.754644 845.6335
+L 1683.003212 850.620066
+L 1881.251779 838.036537
+L 2079.500347 849.528168
+L 2277.748915 463.48825
+L 2475.997482 160.819927
+L 2504.211046 127.964686
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #0000ff; stroke-width: 4; stroke-linecap: square"/>
+    <defs>
+     <path id="m79d96dbfd8" d="M -5 5
+L 5 5
+L 5 -5
+L -5 -5
+z
+" style="stroke: #0000ff; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#m79d96dbfd8" x="377.835406" y="839.588563" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="493.511805" y="835.615033" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="691.760373" y="839.614654" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="890.008941" y="839.958103" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="1088.257508" y="840.13374" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="1286.506076" y="836.682911" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="1409.901405" y="839.158122" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="1418.925967" y="839.962371" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="1484.754644" y="845.6335" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="1683.003212" y="850.620066" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="1881.251779" y="838.036537" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="2079.500347" y="849.528168" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="2277.748915" y="463.48825" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="2475.997482" y="160.819927" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="2504.211046" y="127.964686" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_184">
+    <path d="M 377.835406 1324.869599
+L 493.511805 1322.749042
+L 691.760373 1321.268376
+L 890.008941 1317.003666
+L 1088.257508 1321.352214
+L 1286.506076 1324.42769
+L 1409.901405 1319.399508
+L 1418.925967 1312.426574
+L 1484.754644 1313.568073
+L 1683.003212 1321.412224
+L 1881.251779 1309.701018
+L 2079.500347 629.34497
+L 2277.748915 623.205484
+L 2475.997482 575.935005
+L 2674.24605 441.686719
+L 2754.372886 378.464966
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke-dasharray: 4,6.6; stroke-dashoffset: 0; stroke: #000000; stroke-width: 4"/>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#m32cb50298b" x="377.835406" y="1324.869599" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="493.511805" y="1322.749042" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="691.760373" y="1321.268376" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="890.008941" y="1317.003666" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="1088.257508" y="1321.352214" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="1286.506076" y="1324.42769" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="1409.901405" y="1319.399508" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="1418.925967" y="1312.426574" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="1484.754644" y="1313.568073" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="1683.003212" y="1321.412224" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="1881.251779" y="1309.701018" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="2079.500347" y="629.34497" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="2277.748915" y="623.205484" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="2475.997482" y="575.935005" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="2674.24605" y="441.686719" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+     <use xlink:href="#m32cb50298b" x="2754.372886" y="378.464966" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_185">
+    <path d="M 377.835406 1023.522668
+L 493.511805 1032.05832
+L 691.760373 1025.020993
+L 890.008941 1024.998439
+L 1088.257508 1027.232384
+L 1286.506076 1021.721898
+L 1409.901405 1021.069877
+L 1418.925967 1019.190683
+L 1484.754644 1021.199937
+L 1683.003212 612.016529
+L 1881.251779 611.651098
+L 2079.500347 374.027601
+L 2277.748915 337.308806
+L 2475.997482 287.926577
+L 2504.211046 278.350336
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke-dasharray: 4,6.6; stroke-dashoffset: 0; stroke: #ff0000; stroke-width: 4"/>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#m92747b9ae6" x="377.835406" y="1023.522668" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="493.511805" y="1032.05832" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="691.760373" y="1025.020993" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="890.008941" y="1024.998439" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="1088.257508" y="1027.232384" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="1286.506076" y="1021.721898" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="1409.901405" y="1021.069877" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="1418.925967" y="1019.190683" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="1484.754644" y="1021.199937" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="1683.003212" y="612.016529" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="1881.251779" y="611.651098" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="2079.500347" y="374.027601" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="2277.748915" y="337.308806" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="2475.997482" y="287.926577" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+     <use xlink:href="#m92747b9ae6" x="2504.211046" y="278.350336" style="fill: #808080; stroke: #ff0000; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_186">
+    <path d="M 377.835406 895.729404
+L 493.511805 891.277177
+L 691.760373 889.432549
+L 890.008941 884.112391
+L 1088.257508 890.739683
+L 1286.506076 885.606067
+L 1409.901405 887.250231
+L 1418.925967 879.781217
+L 1484.754644 891.288441
+L 1683.003212 591.313743
+L 1881.251779 416.536206
+L 2079.500347 239.249709
+L 2277.748915 210.988137
+L 2475.997482 152.855069
+L 2504.211046 146.223022
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke-dasharray: 4,6.6; stroke-dashoffset: 0; stroke: #008000; stroke-width: 4"/>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#me3266300a0" x="377.835406" y="895.729404" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="493.511805" y="891.277177" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="691.760373" y="889.432549" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="890.008941" y="884.112391" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="1088.257508" y="890.739683" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="1286.506076" y="885.606067" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="1409.901405" y="887.250231" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="1418.925967" y="879.781217" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="1484.754644" y="891.288441" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="1683.003212" y="591.313743" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="1881.251779" y="416.536206" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="2079.500347" y="239.249709" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="2277.748915" y="210.988137" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="2475.997482" y="152.855069" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+     <use xlink:href="#me3266300a0" x="2504.211046" y="146.223022" style="fill: #808080; stroke: #008000; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_187">
+    <path d="M 377.835406 805.32165
+L 493.511805 809.037489
+L 691.760373 811.85849
+L 890.008941 809.183515
+L 1088.257508 811.464406
+L 1286.506076 808.966787
+L 1409.901405 806.238127
+L 1418.925967 811.211752
+L 1484.754644 570.173687
+L 1683.003212 574.288186
+L 1881.251779 361.037866
+L 2079.500347 169.923547
+L 2277.748915 131.403511
+L 2475.997482 75.599215
+L 2504.211046 69.946171
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke-dasharray: 4,6.6; stroke-dashoffset: 0; stroke: #0000ff; stroke-width: 4"/>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#m79d96dbfd8" x="377.835406" y="805.32165" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="493.511805" y="809.037489" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="691.760373" y="811.85849" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="890.008941" y="809.183515" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="1088.257508" y="811.464406" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="1286.506076" y="808.966787" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="1409.901405" y="806.238127" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="1418.925967" y="811.211752" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="1484.754644" y="570.173687" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="1683.003212" y="574.288186" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="1881.251779" y="361.037866" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="2079.500347" y="169.923547" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="2277.748915" y="131.403511" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="2475.997482" y="75.599215" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+     <use xlink:href="#m79d96dbfd8" x="2504.211046" y="69.946171" style="fill: #808080; stroke: #0000ff; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_188">
+    <path d="M 377.835406 1018.015381
+L 493.511805 1019.050355
+L 691.760373 1020.963043
+L 890.008941 1021.234392
+L 1088.257508 1020.502773
+L 1286.506076 1020.770755
+L 1409.901405 1021.211131
+L 1418.925967 1000.061039
+L 1484.754644 1002.839697
+L 1683.003212 1002.852283
+L 1881.251779 1002.361012
+L 2079.500347 1002.761563
+L 2277.748915 1002.674028
+L 2475.997482 1002.36611
+L 2674.24605 472.001587
+L 2754.372886 341.752164
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #000000; stroke-width: 4; stroke-linecap: square"/>
+    <defs>
+     <path id="mf8bc0f2e1c" d="M 0 5
+C 1.326016 5 2.597899 4.473168 3.535534 3.535534
+C 4.473168 2.597899 5 1.326016 5 0
+C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534
+C 2.597899 -4.473168 1.326016 -5 0 -5
+C -1.326016 -5 -2.597899 -4.473168 -3.535534 -3.535534
+C -4.473168 -2.597899 -5 -1.326016 -5 0
+C -5 1.326016 -4.473168 2.597899 -3.535534 3.535534
+C -2.597899 4.473168 -1.326016 5 0 5
+z
+" style="stroke: #000000"/>
+    </defs>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#mf8bc0f2e1c" x="377.835406" y="1018.015381" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="493.511805" y="1019.050355" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="691.760373" y="1020.963043" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="890.008941" y="1021.234392" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="1088.257508" y="1020.502773" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="1286.506076" y="1020.770755" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="1409.901405" y="1021.211131" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="1418.925967" y="1000.061039" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="1484.754644" y="1002.839697" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="1683.003212" y="1002.852283" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="1881.251779" y="1002.361012" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="2079.500347" y="1002.761563" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="2277.748915" y="1002.674028" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="2475.997482" y="1002.36611" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="2674.24605" y="472.001587" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="2754.372886" y="341.752164" style="fill: #808080; stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_189">
+    <path d="M 377.835406 848.780276
+L 493.511805 848.817725
+L 691.760373 847.276263
+L 890.008941 845.17334
+L 1088.257508 846.772549
+L 1286.506076 846.288023
+L 1409.901405 846.976822
+L 1418.925967 762.340529
+L 1484.754644 764.846637
+L 1683.003212 763.371323
+L 1881.251779 761.951471
+L 2079.500347 762.518391
+L 2277.748915 764.241362
+L 2475.997482 459.489024
+L 2504.211046 328.837954
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #ff0000; stroke-width: 4; stroke-linecap: square"/>
+    <defs>
+     <path id="mb9fa4f0e9c" d="M 0 5
+C 1.326016 5 2.597899 4.473168 3.535534 3.535534
+C 4.473168 2.597899 5 1.326016 5 0
+C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534
+C 2.597899 -4.473168 1.326016 -5 0 -5
+C -1.326016 -5 -2.597899 -4.473168 -3.535534 -3.535534
+C -4.473168 -2.597899 -5 -1.326016 -5 0
+C -5 1.326016 -4.473168 2.597899 -3.535534 3.535534
+C -2.597899 4.473168 -1.326016 5 0 5
+z
+" style="stroke: #ff0000"/>
+    </defs>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#mb9fa4f0e9c" x="377.835406" y="848.780276" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="493.511805" y="848.817725" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="691.760373" y="847.276263" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="890.008941" y="845.17334" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="1088.257508" y="846.772549" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="1286.506076" y="846.288023" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="1409.901405" y="846.976822" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="1418.925967" y="762.340529" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="1484.754644" y="764.846637" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="1683.003212" y="763.371323" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="1881.251779" y="761.951471" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="2079.500347" y="762.518391" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="2277.748915" y="764.241362" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="2475.997482" y="459.489024" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="2504.211046" y="328.837954" style="fill: #808080; stroke: #ff0000"/>
+    </g>
+   </g>
+   <g id="line2d_190">
+    <path d="M 377.835406 726.710809
+L 493.511805 723.339565
+L 691.760373 726.338659
+L 890.008941 724.48359
+L 1088.257508 721.577733
+L 1286.506076 723.062934
+L 1409.901405 725.200583
+L 1418.925967 639.605223
+L 1484.754644 640.064008
+L 1683.003212 637.447544
+L 1881.251779 638.339882
+L 2079.500347 638.884052
+L 2277.748915 452.096846
+L 2475.997482 248.962024
+L 2504.211046 197.348984
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #008000; stroke-width: 4; stroke-linecap: square"/>
+    <defs>
+     <path id="mbbb97d3b34" d="M 0 5
+C 1.326016 5 2.597899 4.473168 3.535534 3.535534
+C 4.473168 2.597899 5 1.326016 5 0
+C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534
+C 2.597899 -4.473168 1.326016 -5 0 -5
+C -1.326016 -5 -2.597899 -4.473168 -3.535534 -3.535534
+C -4.473168 -2.597899 -5 -1.326016 -5 0
+C -5 1.326016 -4.473168 2.597899 -3.535534 3.535534
+C -2.597899 4.473168 -1.326016 5 0 5
+z
+" style="stroke: #008000"/>
+    </defs>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#mbbb97d3b34" x="377.835406" y="726.710809" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="493.511805" y="723.339565" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="691.760373" y="726.338659" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="890.008941" y="724.48359" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="1088.257508" y="721.577733" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="1286.506076" y="723.062934" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="1409.901405" y="725.200583" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="1418.925967" y="639.605223" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="1484.754644" y="640.064008" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="1683.003212" y="637.447544" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="1881.251779" y="638.339882" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="2079.500347" y="638.884052" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="2277.748915" y="452.096846" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="2475.997482" y="248.962024" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="2504.211046" y="197.348984" style="fill: #808080; stroke: #008000"/>
+    </g>
+   </g>
+   <g id="line2d_191">
+    <path d="M 377.835406 652.54552
+L 493.511805 651.555057
+L 691.760373 652.462081
+L 890.008941 652.091428
+L 1088.257508 652.457384
+L 1286.506076 653.995386
+L 1409.901405 651.602491
+L 1418.925967 569.041783
+L 1484.754644 566.148007
+L 1683.003212 565.752416
+L 1881.251779 564.756928
+L 2079.500347 567.258718
+L 2277.748915 421.733795
+L 2475.997482 153.505596
+L 2504.211046 121.150638
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke: #0000ff; stroke-width: 4; stroke-linecap: square"/>
+    <defs>
+     <path id="m369be96bd4" d="M 0 5
+C 1.326016 5 2.597899 4.473168 3.535534 3.535534
+C 4.473168 2.597899 5 1.326016 5 0
+C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534
+C 2.597899 -4.473168 1.326016 -5 0 -5
+C -1.326016 -5 -2.597899 -4.473168 -3.535534 -3.535534
+C -4.473168 -2.597899 -5 -1.326016 -5 0
+C -5 1.326016 -4.473168 2.597899 -3.535534 3.535534
+C -2.597899 4.473168 -1.326016 5 0 5
+z
+" style="stroke: #0000ff"/>
+    </defs>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#m369be96bd4" x="377.835406" y="652.54552" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="493.511805" y="651.555057" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="691.760373" y="652.462081" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="890.008941" y="652.091428" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="1088.257508" y="652.457384" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="1286.506076" y="653.995386" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="1409.901405" y="651.602491" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="1418.925967" y="569.041783" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="1484.754644" y="566.148007" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="1683.003212" y="565.752416" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="1881.251779" y="564.756928" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="2079.500347" y="567.258718" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="2277.748915" y="421.733795" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="2475.997482" y="153.505596" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="2504.211046" y="121.150638" style="fill: #808080; stroke: #0000ff"/>
+    </g>
+   </g>
+   <g id="line2d_192">
+    <path d="M 377.835406 1005.56066
+L 493.511805 1004.628998
+L 691.760373 1005.818241
+L 890.008941 1005.895353
+L 1088.257508 1006.069654
+L 1286.506076 1007.222232
+L 1409.901405 1004.463554
+L 1418.925967 969.800624
+L 1484.754644 969.795604
+L 1683.003212 970.019141
+L 1881.251779 969.315849
+L 2079.500347 969.794964
+L 2277.748915 969.942845
+L 2475.997482 971.448852
+L 2674.24605 471.091421
+L 2754.372886 341.007028
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke-dasharray: 4,6.6; stroke-dashoffset: 0; stroke: #000000; stroke-width: 4"/>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#mf8bc0f2e1c" x="377.835406" y="1005.56066" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="493.511805" y="1004.628998" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="691.760373" y="1005.818241" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="890.008941" y="1005.895353" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="1088.257508" y="1006.069654" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="1286.506076" y="1007.222232" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="1409.901405" y="1004.463554" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="1418.925967" y="969.800624" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="1484.754644" y="969.795604" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="1683.003212" y="970.019141" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="1881.251779" y="969.315849" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="2079.500347" y="969.794964" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="2277.748915" y="969.942845" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="2475.997482" y="971.448852" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="2674.24605" y="471.091421" style="fill: #808080; stroke: #000000"/>
+     <use xlink:href="#mf8bc0f2e1c" x="2754.372886" y="341.007028" style="fill: #808080; stroke: #000000"/>
+    </g>
+   </g>
+   <g id="line2d_193">
+    <path d="M 377.835406 743.8427
+L 493.511805 744.964955
+L 691.760373 742.865274
+L 890.008941 742.334873
+L 1088.257508 743.69713
+L 1286.506076 743.114307
+L 1409.901405 743.783017
+L 1418.925967 727.969937
+L 1484.754644 727.928881
+L 1683.003212 728.005057
+L 1881.251779 727.917253
+L 2079.500347 728.633989
+L 2277.748915 727.230932
+L 2475.997482 456.945382
+L 2504.211046 325.520239
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke-dasharray: 4,6.6; stroke-dashoffset: 0; stroke: #ff0000; stroke-width: 4"/>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#mb9fa4f0e9c" x="377.835406" y="743.8427" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="493.511805" y="744.964955" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="691.760373" y="742.865274" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="890.008941" y="742.334873" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="1088.257508" y="743.69713" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="1286.506076" y="743.114307" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="1409.901405" y="743.783017" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="1418.925967" y="727.969937" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="1484.754644" y="727.928881" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="1683.003212" y="728.005057" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="1881.251779" y="727.917253" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="2079.500347" y="728.633989" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="2277.748915" y="727.230932" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="2475.997482" y="456.945382" style="fill: #808080; stroke: #ff0000"/>
+     <use xlink:href="#mb9fa4f0e9c" x="2504.211046" y="325.520239" style="fill: #808080; stroke: #ff0000"/>
+    </g>
+   </g>
+   <g id="line2d_194">
+    <path d="M 377.835406 613.706959
+L 493.511805 612.553571
+L 691.760373 613.06948
+L 890.008941 613.4809
+L 1088.257508 611.876433
+L 1286.506076 613.143137
+L 1409.901405 612.533302
+L 1418.925967 603.41523
+L 1484.754644 601.711916
+L 1683.003212 603.683226
+L 1881.251779 603.164935
+L 2079.500347 601.56966
+L 2277.748915 449.66763
+L 2475.997482 243.998606
+L 2504.211046 192.466025
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke-dasharray: 4,6.6; stroke-dashoffset: 0; stroke: #008000; stroke-width: 4"/>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#mbbb97d3b34" x="377.835406" y="613.706959" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="493.511805" y="612.553571" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="691.760373" y="613.06948" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="890.008941" y="613.4809" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="1088.257508" y="611.876433" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="1286.506076" y="613.143137" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="1409.901405" y="612.533302" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="1418.925967" y="603.41523" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="1484.754644" y="601.711916" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="1683.003212" y="603.683226" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="1881.251779" y="603.164935" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="2079.500347" y="601.56966" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="2277.748915" y="449.66763" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="2475.997482" y="243.998606" style="fill: #808080; stroke: #008000"/>
+     <use xlink:href="#mbbb97d3b34" x="2504.211046" y="192.466025" style="fill: #808080; stroke: #008000"/>
+    </g>
+   </g>
+   <g id="line2d_195">
+    <path d="M 377.835406 537.477987
+L 493.511805 537.208588
+L 691.760373 537.323097
+L 890.008941 532.573093
+L 1088.257508 538.125819
+L 1286.506076 537.528144
+L 1409.901405 537.242622
+L 1418.925967 528.780194
+L 1484.754644 529.568537
+L 1683.003212 529.78001
+L 1881.251779 528.306206
+L 2079.500347 530.115414
+L 2277.748915 413.382527
+L 2475.997482 148.084523
+L 2504.211046 116.018955
+" clip-path="url(#p3b68092bf0)" style="fill: none; stroke-dasharray: 4,6.6; stroke-dashoffset: 0; stroke: #0000ff; stroke-width: 4"/>
+    <g clip-path="url(#p3b68092bf0)">
+     <use xlink:href="#m369be96bd4" x="377.835406" y="537.477987" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="493.511805" y="537.208588" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="691.760373" y="537.323097" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="890.008941" y="532.573093" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="1088.257508" y="538.125819" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="1286.506076" y="537.528144" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="1409.901405" y="537.242622" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="1418.925967" y="528.780194" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="1484.754644" y="529.568537" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="1683.003212" y="529.78001" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="1881.251779" y="528.306206" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="2079.500347" y="530.115414" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="2277.748915" y="413.382527" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="2475.997482" y="148.084523" style="fill: #808080; stroke: #0000ff"/>
+     <use xlink:href="#m369be96bd4" x="2504.211046" y="116.018955" style="fill: #808080; stroke: #0000ff"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 259.008533 1387.61577
+L 259.008533 7.2
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 2873.19976 1387.61577
+L 2873.19976 7.2
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 259.008533 1387.61577
+L 2873.19976 1387.61577
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 259.008533 7.2
+L 2873.19976 7.2
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="legend_1">
+   <g id="text_14">
+    <!-- Framework -->
+    <g transform="translate(19.8 520.373197) scale(0.22 -0.22)">
+     <defs>
+      <path id="DejaVuSans-46" d="M 628 4666
+L 3309 4666
+L 3309 4134
+L 1259 4134
+L 1259 2759
+L 3109 2759
+L 3109 2228
+L 1259 2228
+L 1259 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759
+Q 1497 1759 1228 1600
+Q 959 1441 959 1056
+Q 959 750 1161 570
+Q 1363 391 1709 391
+Q 2188 391 2477 730
+Q 2766 1069 2766 1631
+L 2766 1759
+L 2194 1759
+z
+M 3341 1997
+L 3341 0
+L 2766 0
+L 2766 531
+Q 2569 213 2275 61
+Q 1981 -91 1556 -91
+Q 1019 -91 701 211
+Q 384 513 384 1019
+Q 384 1609 779 1909
+Q 1175 2209 1959 2209
+L 2766 2209
+L 2766 2266
+Q 2766 2663 2505 2880
+Q 2244 3097 1772 3097
+Q 1472 3097 1187 3025
+Q 903 2953 641 2809
+L 641 3341
+Q 956 3463 1253 3523
+Q 1550 3584 1831 3584
+Q 2591 3584 2966 3190
+Q 3341 2797 3341 1997
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-77" d="M 269 3500
+L 844 3500
+L 1563 769
+L 2278 3500
+L 2956 3500
+L 3675 769
+L 4391 3500
+L 4966 3500
+L 4050 0
+L 3372 0
+L 2619 2869
+L 1863 0
+L 1184 0
+L 269 3500
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097
+Q 1497 3097 1228 2736
+Q 959 2375 959 1747
+Q 959 1119 1226 758
+Q 1494 397 1959 397
+Q 2419 397 2687 759
+Q 2956 1122 2956 1747
+Q 2956 2369 2687 2733
+Q 2419 3097 1959 3097
+z
+M 1959 3584
+Q 2709 3584 3137 3096
+Q 3566 2609 3566 1747
+Q 3566 888 3137 398
+Q 2709 -91 1959 -91
+Q 1206 -91 779 398
+Q 353 888 353 1747
+Q 353 2609 779 3096
+Q 1206 3584 1959 3584
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-46"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(50.269531 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(91.382812 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(152.662109 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(250.074219 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(311.597656 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(393.384766 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(454.566406 0)"/>
+     <use xlink:href="#DejaVuSans-6b" transform="translate(495.679688 0)"/>
+    </g>
+   </g>
+   <g id="line2d_196">
+    <g>
+     <use xlink:href="#m32cb50298b" x="41.8" y="544.965072" style="fill: #808080; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- CUDA -->
+    <g transform="translate(81.4 552.665072) scale(0.22 -0.22)">
+     <defs>
+      <path id="DejaVuSans-43" d="M 4122 4306
+L 4122 3641
+Q 3803 3938 3442 4084
+Q 3081 4231 2675 4231
+Q 1875 4231 1450 3742
+Q 1025 3253 1025 2328
+Q 1025 1406 1450 917
+Q 1875 428 2675 428
+Q 3081 428 3442 575
+Q 3803 722 4122 1019
+L 4122 359
+Q 3791 134 3420 21
+Q 3050 -91 2638 -91
+Q 1578 -91 968 557
+Q 359 1206 359 2328
+Q 359 3453 968 4101
+Q 1578 4750 2638 4750
+Q 3056 4750 3426 4639
+Q 3797 4528 4122 4306
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-55" d="M 556 4666
+L 1191 4666
+L 1191 1831
+Q 1191 1081 1462 751
+Q 1734 422 2344 422
+Q 2950 422 3222 751
+Q 3494 1081 3494 1831
+L 3494 4666
+L 4128 4666
+L 4128 1753
+Q 4128 841 3676 375
+Q 3225 -91 2344 -91
+Q 1459 -91 1007 375
+Q 556 841 556 1753
+L 556 4666
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-44" d="M 1259 4147
+L 1259 519
+L 2022 519
+Q 2988 519 3436 956
+Q 3884 1394 3884 2338
+Q 3884 3275 3436 3711
+Q 2988 4147 2022 4147
+L 1259 4147
+z
+M 628 4666
+L 1925 4666
+Q 3281 4666 3915 4102
+Q 4550 3538 4550 2338
+Q 4550 1131 3912 565
+Q 3275 0 1925 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-41" d="M 2188 4044
+L 1331 1722
+L 3047 1722
+L 2188 4044
+z
+M 1831 4666
+L 2547 4666
+L 4325 0
+L 3669 0
+L 3244 1197
+L 1141 1197
+L 716 0
+L 50 0
+L 1831 4666
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-43"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(69.824219 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(143.017578 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(218.269531 0)"/>
+    </g>
+   </g>
+   <g id="line2d_197">
+    <g>
+     <use xlink:href="#mf8bc0f2e1c" x="41.8" y="577.256947" style="fill: #808080; stroke: #000000"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- Kokkos -->
+    <g transform="translate(81.4 584.956947) scale(0.22 -0.22)">
+     <defs>
+      <path id="DejaVuSans-4b" d="M 628 4666
+L 1259 4666
+L 1259 2694
+L 3353 4666
+L 4166 4666
+L 1850 2491
+L 4331 0
+L 3500 0
+L 1259 2247
+L 1259 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4b"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(60.576172 0)"/>
+     <use xlink:href="#DejaVuSans-6b" transform="translate(121.757812 0)"/>
+     <use xlink:href="#DejaVuSans-6b" transform="translate(179.667969 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(233.953125 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(295.134766 0)"/>
+    </g>
+   </g>
+   <g id="line2d_198">
+    <path d="M 19.8 641.840697
+L 41.8 641.840697
+L 63.8 641.840697
+" style="fill: none; stroke: #000000; stroke-width: 4; stroke-linecap: square"/>
+   </g>
+   <g id="text_17">
+    <!-- async -->
+    <g transform="translate(81.4 649.540697) scale(0.22 -0.22)">
+     <defs>
+      <path id="DejaVuSans-79" d="M 2059 -325
+Q 1816 -950 1584 -1140
+Q 1353 -1331 966 -1331
+L 506 -1331
+L 506 -850
+L 844 -850
+Q 1081 -850 1212 -737
+Q 1344 -625 1503 -206
+L 1606 56
+L 191 3500
+L 800 3500
+L 1894 763
+L 2988 3500
+L 3597 3500
+L 2059 -325
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-63" d="M 3122 3366
+L 3122 2828
+Q 2878 2963 2633 3030
+Q 2388 3097 2138 3097
+Q 1578 3097 1268 2742
+Q 959 2388 959 1747
+Q 959 1106 1268 751
+Q 1578 397 2138 397
+Q 2388 397 2633 464
+Q 2878 531 3122 666
+L 3122 134
+Q 2881 22 2623 -34
+Q 2366 -91 2075 -91
+Q 1284 -91 818 406
+Q 353 903 353 1747
+Q 353 2603 823 3093
+Q 1294 3584 2113 3584
+Q 2378 3584 2631 3529
+Q 2884 3475 3122 3366
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-61"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(61.279297 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(113.378906 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(172.558594 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(235.9375 0)"/>
+    </g>
+   </g>
+   <g id="line2d_199">
+    <path d="M 19.8 674.132572
+L 41.8 674.132572
+L 63.8 674.132572
+" style="fill: none; stroke-dasharray: 4,6.6; stroke-dashoffset: 0; stroke: #000000; stroke-width: 4"/>
+   </g>
+   <g id="text_18">
+    <!-- sync -->
+    <g transform="translate(81.4 681.832572) scale(0.22 -0.22)">
+     <use xlink:href="#DejaVuSans-73"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(52.099609 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(111.279297 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(174.658203 0)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- Count -->
+    <g transform="translate(19.8 746.416322) scale(0.22 -0.22)">
+     <use xlink:href="#DejaVuSans-43"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(69.824219 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(131.005859 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(194.384766 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(257.763672 0)"/>
+    </g>
+   </g>
+   <g id="line2d_200">
+    <path d="M 19.8 771.008197
+L 41.8 771.008197
+L 63.8 771.008197
+" style="fill: none; stroke: #000000; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="text_20">
+    <!-- 1 -->
+    <g transform="translate(81.4 778.708197) scale(0.22 -0.22)">
+     <use xlink:href="#DejaVuSans-31"/>
+    </g>
+   </g>
+   <g id="line2d_201">
+    <path d="M 19.8 803.300072
+L 41.8 803.300072
+L 63.8 803.300072
+" style="fill: none; stroke: #ff0000; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="text_21">
+    <!-- 4 -->
+    <g transform="translate(81.4 811.000072) scale(0.22 -0.22)">
+     <use xlink:href="#DejaVuSans-34"/>
+    </g>
+   </g>
+   <g id="line2d_202">
+    <path d="M 19.8 835.591947
+L 41.8 835.591947
+L 63.8 835.591947
+" style="fill: none; stroke: #008000; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="text_22">
+    <!-- 8 -->
+    <g transform="translate(81.4 843.291947) scale(0.22 -0.22)">
+     <defs>
+      <path id="DejaVuSans-38" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-38"/>
+    </g>
+   </g>
+   <g id="line2d_203">
+    <path d="M 19.8 867.883822
+L 41.8 867.883822
+L 63.8 867.883822
+" style="fill: none; stroke: #0000ff; stroke-width: 2; stroke-linecap: square"/>
+   </g>
+   <g id="text_23">
+    <!-- 12 -->
+    <g transform="translate(81.4 875.583822) scale(0.22 -0.22)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="line2d_204">
+    <path d="M 19.8 932.467572
+L 41.8 932.467572
+L 63.8 932.467572
+" style="fill: none; stroke-dasharray: 11.1,4.8; stroke-dashoffset: 0; stroke: #000000; stroke-width: 3"/>
+   </g>
+   <g id="text_24">
+    <!-- threshold -->
+    <g transform="translate(81.4 940.167573) scale(0.22 -0.22)">
+     <defs>
+      <path id="DejaVuSans-68" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 4863
+L 1159 4863
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6c" d="M 603 4863
+L 1178 4863
+L 1178 0
+L 603 0
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-64" d="M 2906 2969
+L 2906 4863
+L 3481 4863
+L 3481 0
+L 2906 0
+L 2906 525
+Q 2725 213 2448 61
+Q 2172 -91 1784 -91
+Q 1150 -91 751 415
+Q 353 922 353 1747
+Q 353 2572 751 3078
+Q 1150 3584 1784 3584
+Q 2172 3584 2448 3432
+Q 2725 3281 2906 2969
+z
+M 947 1747
+Q 947 1113 1208 752
+Q 1469 391 1925 391
+Q 2381 391 2643 752
+Q 2906 1113 2906 1747
+Q 2906 2381 2643 2742
+Q 2381 3103 1925 3103
+Q 1469 3103 1208 2742
+Q 947 2381 947 1747
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-74"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(39.208984 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(102.587891 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(141.451172 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(202.974609 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(255.074219 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(318.453125 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(379.634766 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(407.417969 0)"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p3b68092bf0">
+   <rect x="259.008533" y="7.2" width="2614.191227" height="1380.41577"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/examples/kokkos/graph/CMakeLists.txt
+++ b/examples/kokkos/graph/CMakeLists.txt
@@ -1,5 +1,2 @@
 add_one_example(dispatch)
-test_environment(examples_kokkos_graph_dispatch KOKKOS_TOOLS_NVTX_CONNECTOR_LIB set $<TARGET_FILE:KokkosTools::kp_nvtx_connector>)
-
 add_one_example(then)
-test_environment(examples_kokkos_graph_then KOKKOS_TOOLS_NVTX_CONNECTOR_LIB set $<TARGET_FILE:KokkosTools::kp_nvtx_connector>)

--- a/examples/kokkos/view/CMakeLists.txt
+++ b/examples/kokkos/view/CMakeLists.txt
@@ -1,1 +1,9 @@
 add_one_example(allocation_tracing)
+
+find_package(benchmark REQUIRED COMPONENTS benchmark)
+
+add_one_example(allocation_benchmarking)
+target_link_libraries(examples_kokkos_view_allocation_benchmarking PRIVATE benchmark::benchmark)
+target_sources(examples_kokkos_view_allocation_benchmarking PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/example_allocation_benchmarking.main.cpp)
+
+set_source_files_properties(example_allocation_benchmarking.main.cpp PROPERTIES LANGUAGE CUDA)

--- a/examples/kokkos/view/example_allocation_benchmarking.cpp
+++ b/examples/kokkos/view/example_allocation_benchmarking.cpp
@@ -1,0 +1,244 @@
+#include "Kokkos_Core.hpp"
+
+#include "benchmark/benchmark.h"
+
+#if !defined(KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC)
+    #error "KOKKOS_ENABLE_IMPL_CUDA_MALLOC_ASYNC is not defined."
+#endif
+
+/**
+ * @file
+ *
+ *  Companion of @ref examples/kokkos/view/example_allocation_benchmarking.py.
+ */
+
+//! These partial overrides are only needed by 'nvcc' (as of @c Cuda 12.8.0).
+#if defined(__NVCC__)
+    //! Use this macro when only one @c __what__ method is overridden.
+    #define FIXME_PARTIAL_OVERRIDE_WARNING_NVCC(__what__) \
+        void __what__(::benchmark::State& state) override { this->__what__(static_cast<const ::benchmark::State&>(state)); }
+#else
+    #define FIXME_PARTIAL_OVERRIDE_WARNING_NVCC(...)
+#endif
+
+namespace reprospect::examples::kokkos::view
+{
+//! Type contained in allocated buffers.
+using scalar_t = char;
+
+struct MemoryPoolState
+{
+    uint64_t reserved_mem_current = 0;
+    uint64_t reserved_mem_high = 0;
+    uint64_t used_mem_current = 0;
+    uint64_t used_mem_high = 0;
+    uint64_t release_threshold = 0;
+};
+
+struct MemoryPool
+{
+    cudaMemPool_t ptr = nullptr;
+
+    //! Get default memory pool of the device to which @p exec is associated.
+    static MemoryPool get(const Kokkos::Cuda& exec)
+    {
+        cudaMemPool_t ptr = nullptr;
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaDeviceGetDefaultMemPool(&ptr, exec.cuda_device()));
+        return MemoryPool{.ptr = ptr};
+    }
+
+    void trim(const size_t keep = 0) const {
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemPoolTrimTo(ptr, keep));
+    }
+
+    //! See https://docs.nvidia.com/cuda/cuda-c-programming-guide/#resource-usage-statistics.
+    void reset_watermarks() const
+    {
+        uint64_t value = 0;
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemPoolSetAttribute(ptr, cudaMemPoolAttrReservedMemHigh, &value));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemPoolSetAttribute(ptr, cudaMemPoolAttrUsedMemHigh,     &value));
+    }
+
+    /**
+     * Query attributes.
+     *
+     * References:
+     *  - https://docs.nvidia.com/cuda/cuda-c-programming-guide/#physical-page-caching-behavior
+     */
+    MemoryPoolState state() const
+    {
+        MemoryPoolState state {};
+
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemPoolGetAttribute(ptr, cudaMemPoolAttrReservedMemCurrent, &state.reserved_mem_current));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemPoolGetAttribute(ptr, cudaMemPoolAttrReservedMemHigh,    &state.reserved_mem_high));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemPoolGetAttribute(ptr, cudaMemPoolAttrUsedMemCurrent,     &state.used_mem_current));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemPoolGetAttribute(ptr, cudaMemPoolAttrUsedMemHigh,        &state.used_mem_high));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMemPoolGetAttribute(ptr, cudaMemPoolAttrReleaseThreshold,   &state.release_threshold));
+
+        return state;
+    }
+};
+
+class Common : public ::benchmark::Fixture
+{
+public:
+    static constexpr unsigned short int range_count = 0;
+    static constexpr unsigned short int range_size  = 1;
+
+public:
+    FIXME_PARTIAL_OVERRIDE_WARNING_NVCC(SetUp)
+    FIXME_PARTIAL_OVERRIDE_WARNING_NVCC(TearDown)
+
+    void SetUp(const ::benchmark::State&) override
+    {
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreate(&stream));
+        exec = Kokkos::Cuda(stream);
+
+        //! Ensure that the memory pool is set at the same state for all tests.
+        const auto memory_pool = MemoryPool::get(*exec);
+        memory_pool.trim(0);
+        memory_pool.reset_watermarks();
+    }
+
+    void TearDown(const ::benchmark::State&) override
+    {
+        exec.reset();
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(stream));
+    }
+
+private:
+    cudaStream_t stream = nullptr;
+
+protected:
+    std::optional<Kokkos::Cuda> exec = std::nullopt;
+};
+
+//! Allocate using @c CUDA API.
+template <bool Async>
+class WithCUDA : public Common
+{
+public:
+    using buffer_t = scalar_t*;
+
+public:
+    //! Allocate with @c cudaMallocAsync and synchronize the @c CUDA stream underlying @p exec.
+    void allocate(buffer_t* const ptr, const int64_t size) const requires Async
+    {
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMallocAsync(
+            (void**)ptr,
+            size * sizeof(scalar_t),
+            exec->cuda_stream()
+        ));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamSynchronize(exec->cuda_stream()));
+    }
+
+    //! Allocate with @c cudaMalloc.
+    void allocate(buffer_t* const ptr, const size_t size) const requires (!Async) {
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaMalloc((void**)ptr, size * sizeof(scalar_t)));
+    }
+
+    //! Deallocate with @c cudaFreeAsync and synchronize stream using @c Cuda.
+    void deallocate(buffer_t const ptr) const requires Async
+    {
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFreeAsync((void*)ptr, exec->cuda_stream()));
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamSynchronize(exec->cuda_stream()));
+    }
+
+    //! Deallocate with @c cudaFree.
+    void deallocate(buffer_t const ptr) const requires (!Async) {
+        KOKKOS_IMPL_CUDA_SAFE_CALL(cudaFree((void*)ptr));
+    }
+
+    auto run(const ::benchmark::State& state) const
+    {
+        std::vector<buffer_t> buffers(state.range(range_count), nullptr);
+
+        for(auto& buffer : buffers)
+            allocate(&buffer, state.range(range_size));
+
+        for(const auto buffer : buffers)
+            deallocate(buffer);
+    }
+};
+
+//! Allocate using @c Kokkos.
+template <bool Async>
+class WithKokkos : public Common
+{
+public:
+    using view_t = Kokkos::View<scalar_t*, Kokkos::Cuda>;
+
+public:
+    /**
+     * @brief Pass an execution space instance to the @c Kokkos::View allocation.
+     *
+     * Ultimately, it ends up doing a @c cudaMallocAsync followed by a stream synchronization when the buffer size
+     * is above the threshold.
+     *
+     * See https://github.com/kokkos/kokkos/blob/146241cf3a68454527994a46ac473861c2b5d4f1/core/src/Cuda/Kokkos_CudaSpace.cpp#L209-L220.
+     */
+    auto allocate(const size_t size) const requires Async {
+        return view_t{Kokkos::view_alloc(Kokkos::WithoutInitializing, *exec), size};
+    }
+
+    /**
+     * @brief Do not pass an execution space instance to the @c Kokkos::View allocation.
+     *
+     * Ultimately, it ends up doing a @c cudaMallocAsync followed by a device synchronization when the buffer size
+     * is above the threshold.
+     *
+     * See https://github.com/kokkos/kokkos/blob/146241cf3a68454527994a46ac473861c2b5d4f1/core/src/Cuda/Kokkos_CudaSpace.cpp#L209-L220.
+     */
+    auto allocate(const size_t size) const requires (!Async) {
+        return view_t{Kokkos::view_alloc(Kokkos::WithoutInitializing), size};
+    }
+
+    auto run(const ::benchmark::State& state) const
+    {
+        std::vector<view_t> views(state.range(range_count));
+
+        for(auto& view : views)
+            view = allocate(state.range(range_size));
+
+        views.clear();
+    }
+};
+
+void parameters(::benchmark::internal::Benchmark* benchmark)
+{
+    static constexpr size_t threshold = 40000;
+
+    benchmark
+        ->ArgNames({"count", "size"})
+        ->Args({ 1, threshold - 1000})->Args({ 1, threshold + 1000})
+        ->Args({ 4, threshold - 1000})->Args({ 4, threshold + 1000})
+        ->Args({ 8, threshold - 1000})->Args({ 8, threshold + 1000})
+        ->Args({12, threshold - 1000})->Args({12, threshold + 1000})
+        ->ArgsProduct({
+            {4, 8, 12},
+            ::benchmark::CreateRange(128, 128<<17, 4)
+        })
+        ->ArgsProduct({
+            {1},
+            ::benchmark::CreateRange(128, 128<<19, 4)
+        });
+}
+
+#define REPROSPECT_EXAMPLES_KOKKOS_VIEW_ALLOCATION(_class_, _name_, _async_)            \
+    BENCHMARK_TEMPLATE_DEFINE_F(_class_, _name_, _async_)(benchmark::State& state) {    \
+        for(auto _ : state) this->run(state);                                           \
+        const auto mps = MemoryPool::get(*exec).state();                                \
+        state.counters["cudaMemPoolAttrReservedMemCurrent"] = mps.reserved_mem_current; \
+        state.counters["cudaMemPoolAttrReservedMemHigh"   ] = mps.reserved_mem_high;    \
+        state.counters["cudaMemPoolAttrUsedMemCurrent"    ] = mps.used_mem_current;     \
+        state.counters["cudaMemPoolAttrUsedMemHigh"       ] = mps.used_mem_high;        \
+        state.counters["cudaMemPoolAttrReleaseThreshold"  ] = mps.release_threshold;    \
+    }                                                                                   \
+    BENCHMARK_REGISTER_F(_class_, _name_)->Apply(parameters);
+
+REPROSPECT_EXAMPLES_KOKKOS_VIEW_ALLOCATION(WithCUDA,   cuda_async,   true)
+REPROSPECT_EXAMPLES_KOKKOS_VIEW_ALLOCATION(WithCUDA,   cuda,         false)
+REPROSPECT_EXAMPLES_KOKKOS_VIEW_ALLOCATION(WithKokkos, kokkos_async, true)
+REPROSPECT_EXAMPLES_KOKKOS_VIEW_ALLOCATION(WithKokkos, kokkos,       false)
+
+} // namespace HELM::benchmarks::kokkos::core

--- a/examples/kokkos/view/example_allocation_benchmarking.main.cpp
+++ b/examples/kokkos/view/example_allocation_benchmarking.main.cpp
@@ -1,0 +1,24 @@
+#include "benchmark/benchmark.h"
+
+#include "Kokkos_Core.hpp"
+
+/**
+ * Steps:
+ *  1. Try to disable @c ASLR.
+ *  2. Initialize @c Kokkos.
+ *  3. Run benchmarks.
+ *  4. Finalize @c Kokkos.
+ */
+int main(int argc, char** argv)
+{
+    ::benchmark::MaybeReenterWithoutASLR(argc, argv);
+
+    Kokkos::ScopeGuard guard {argc, argv};
+    {
+        ::benchmark::Initialize(&argc, argv);
+        ::benchmark::RunSpecifiedBenchmarks();
+        ::benchmark::Shutdown();
+    }
+
+    return EXIT_SUCCESS;
+}

--- a/examples/kokkos/view/example_allocation_benchmarking.py
+++ b/examples/kokkos/view/example_allocation_benchmarking.py
@@ -1,0 +1,318 @@
+"""
+Comparing :code:`Kokkos::View` allocation against native CUDA implementation
+============================================================================
+
+:code:`cudaMallocAsync` calls are immediately followed by a stream or device synchronization, as seen in
+https://github.com/kokkos/kokkos/blob/146241cf3a68454527994a46ac473861c2b5d4f1/core/src/Cuda/Kokkos_CudaSpace.cpp#L209-L220.
+
+Moreover, :code:`Kokkos` opts not to use :code:`cudaMallocAsync` when allocation sizes fall below a threshold defined at
+https://github.com/kokkos/kokkos/blob/c1a715cab26da9407867c6a8c04b2a1d6b2fc7ba/core/src/impl/Kokkos_SharedAlloc.hpp#L23.
+
+Additionally, at least for its CUDA backend, :code:`Kokkos` copies a *shared allocation header* (mainly used for debug), as seen *e.g.* in
+https://github.com/kokkos/kokkos/blob/bba2d1f60741b6a2023b36313016c0a0dd125f42/core/src/impl/Kokkos_SharedAlloc.hpp#L325-L327.
+This copy operation invariably uses :code:`cudaMemcpyAsync`, as demonstrated in :py:class:`examples.kokkos.view.example_allocation_tracing.TestNSYS`.
+Consequently, :code:`Kokkos` will always:
+
+1. allocate buffers that are 128 bytes larger than requested
+2. entail additional API calls
+
+This copy of the shared allocation header has triggered the discussion at
+https://github.com/kokkos/kokkos/issues/8441.
+
+The benchmark results clearly show that allocating with :code:`Kokkos` consistently incurs additional overhead,
+compared to a native CUDA implementation.
+
+References:
+
+* https://docs.nvidia.com/cuda/cuda-c-programming-guide/#stream-ordered-memory-allocator
+"""
+
+import itertools
+import json
+import logging
+import pathlib
+import re
+import subprocess
+import sys
+import typing
+
+import matplotlib.artist
+import matplotlib.legend
+import matplotlib.legend_handler
+import matplotlib.lines
+import matplotlib.pyplot
+import matplotlib.text
+import matplotlib.transforms
+import numpy
+import pandas
+import pytest
+
+from reprospect.test.case import CMakeAwareTestCase
+from reprospect.utils     import detect
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from backports.strenum.strenum import StrEnum
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+class Framework(StrEnum):
+    CUDA = 'CUDA'
+    KOKKOS = 'Kokkos'
+
+class Parameters(typing.TypedDict):
+    use_async : bool
+    framework : Framework
+    count : int
+    size : int
+
+@pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
+class TestAllocation(CMakeAwareTestCase):
+    """
+    Run the companion executable and make a nice visualization.
+    """
+    TIME_UNIT :typing.Final[typing.Literal['ns']] = 'ns'
+    """
+    Time unit of the benchmark.
+    """
+
+    THRESHOLD : typing.Final[int] = 40000
+    """
+    Threshold for using stream ordered allocation, see https://github.com/kokkos/kokkos/blob/146241cf3a68454527994a46ac473861c2b5d4f1/core/src/Cuda/Kokkos_CudaSpace.cpp#L147.
+    """
+
+    PATTERN : typing.Final[re.Pattern[str]] = re.compile(
+        r'^With(CUDA|Kokkos)<(true|false)>/((?:cuda|kokkos)(?:_async)?)/count:([0-9]+)/size:([0-9]+)'
+    )
+
+    @classmethod
+    @override
+    def get_target_name(cls) -> str:
+        return 'examples_kokkos_view_allocation_benchmarking'
+
+    @classmethod
+    def params(cls, *, name : str) -> Parameters:
+        """
+        Parse the name of a case and return parameters.
+        """
+        match = cls.PATTERN.search(name)
+
+        assert match is not None
+        assert len(match.groups()) == 5
+        assert match.group(1) in Framework
+        assert match.group(2) in ['true', 'false']
+
+        framework = Framework(match.group(1))
+        use_async = match.group(2) == 'true'
+
+        expt_name = f'{framework.lower()}' + ('_async' if use_async else '')
+
+        assert match.group(3) == expt_name
+
+        return {
+            'framework' : framework,
+            'use_async' : use_async,
+            'count' : int(match.group(4)),
+            'size' : int(match.group(5)),
+        }
+
+    @pytest.fixture(scope = 'class')
+    def raw(self) -> dict[str, dict]:
+        """
+        Run the benchmark and return the raw `JSON`-based results.
+
+        .. warning::
+
+            Be sure to remove `--benchmark_min_time` for better converged results.
+        """
+        file : pathlib.Path = self.cwd / 'results.json'
+
+        cmd : tuple[str | pathlib.Path, ...] = (
+            self.executable,
+            '--benchmark_min_time=2x',
+            '--benchmark_enable_random_interleaving=true',
+            f'--benchmark_out={file}',
+            '--benchmark_out_format=json',
+        )
+
+        logging.info(f'Running benchmark with {cmd}.')
+
+        subprocess.check_call(cmd, cwd = self.cwd)
+
+        with file.open(mode = 'r') as fp:
+            return json.load(fp = fp)
+
+    @pytest.fixture(scope = 'class')
+    def results(self, raw : dict) -> pandas.DataFrame:
+        """
+        Processed results.
+        """
+        def process(bench_case) -> dict[str, Framework | bool | int | float]:
+            logging.debug(f'Processing benchmark case {bench_case["name"]}.')
+            assert self.TIME_UNIT == bench_case['time_unit']
+            return {
+                **self.params(name=bench_case['name']),
+                'real_time': bench_case['real_time'],
+            }
+
+        return pandas.DataFrame(
+            process(bench_case)
+            for bench_case in raw['benchmarks']
+        )
+
+    def test_memory_pool_attributes(self, raw) -> None:
+        """
+        Retrieve the memory pool attributes and check consistency and behavior.
+        """
+        COLUMNS : typing.Final[tuple[str, ...]] = (
+            'ReservedMemCurrent',
+            'ReservedMemHigh',
+            'UsedMemCurrent',
+            'UsedMemHigh',
+            'ReleaseThreshold',
+        )
+        attributes = pandas.DataFrame(
+            data = (
+                tuple(int(bench_case['cudaMemPoolAttr' + attr]) for attr in COLUMNS)
+                for bench_case in raw['benchmarks']
+            ),
+            columns = COLUMNS,
+        )
+
+        # After the test, the current reserved/used memory is the same for everyone.
+        assert attributes['ReservedMemCurrent'].nunique(dropna = False) == 1
+        assert attributes[    'UsedMemCurrent'].nunique(dropna = False) == 1
+
+        logging.info(f"Default memory pool reserved size is always {attributes.loc[0, 'ReservedMemCurrent']}.")
+        logging.info(f"Default memory pool used     size is always {attributes.loc[0,     'UsedMemCurrent']}.")
+
+        # The release threshold is 0 for everyone.
+        assert attributes['ReleaseThreshold'].eq(0).all()
+
+        logging.info('The release threshold is always 0.')
+
+        logging.info(f"Reserved high: {sorted(set(attributes['ReservedMemHigh']))}")
+        logging.info(f"Used     high: {sorted(set(attributes[    'UsedMemHigh']))}")
+
+        # The memory pool grows by taking steps of multiples of 32MiB.
+        STEP_SIZE = 1024**2 * 32
+        steps = numpy.diff(numpy.sort(attributes['ReservedMemHigh'].unique()))
+        assert (steps % STEP_SIZE == 0).all()
+
+    def test_visualize(self, results : pandas.DataFrame) -> None:
+        """
+        Create a visualization of the results.
+        """
+        # Retrieve unique, sorted counts.
+        counts = sorted(set(results['count'].values))
+        assert len(counts) == 4
+
+        logging.info(f'Counts are {counts}.')
+
+        # Factor for size (results are initially in bytes).
+        SIZE_FACTOR : typing.Final[int] = 1000
+        SIZE_UNIT   : typing.Final[str] = 'kB'
+
+        # Legend.
+        FONTSIZE = 22
+
+        LINESTYLES : typing.Final[dict[bool, matplotlib.lines.Line2D]] = {
+            True  : matplotlib.lines.Line2D((0,), (0,), color = 'black', linestyle = 'solid',  lw = 4, label = 'async'),
+            False : matplotlib.lines.Line2D((0,), (0,), color = 'black', linestyle = 'dotted', lw = 4, label = 'sync'),
+        }
+
+        MARKERS : typing.Final[dict[Framework, matplotlib.lines.Line2D]] = {
+            Framework.CUDA   : matplotlib.lines.Line2D((0,), (0,), color = 'black', marker = 's', linestyle = '', markersize = 10, markerfacecolor = 'grey', label = 'CUDA'),
+            Framework.KOKKOS : matplotlib.lines.Line2D((0,), (0,), color = 'black', marker = 'o', linestyle = '', markersize = 10, markerfacecolor = 'grey', label = 'Kokkos'),
+        }
+
+        COLORS : typing.Final[dict[int, matplotlib.lines.Line2D]] = {
+            1  : matplotlib.lines.Line2D((0,), (0,), color = 'black', lw = 2, linestyle = 'solid', label = '1'),
+            4  : matplotlib.lines.Line2D((0,), (0,), color = 'red',   lw = 2, linestyle = 'solid', label = '4'),
+            8  : matplotlib.lines.Line2D((0,), (0,), color = 'green', lw = 2, linestyle = 'solid', label = '8'),
+            12 : matplotlib.lines.Line2D((0,), (0,), color = 'blue',  lw = 2, linestyle = 'solid', label = '12'),
+        }
+
+        # Make a nice plot.
+        fig = matplotlib.pyplot.figure(figsize = (40, 20), layout = 'constrained')
+        ax  = fig.subplots(nrows = 1, ncols = 1)
+
+        threshold = ax.axvline(self.THRESHOLD / SIZE_FACTOR, color = 'black', linestyle = 'dashed', label = 'threshold', lw = 3)
+
+        for framework, use_async in itertools.product(tuple(Framework), (True, False)):
+            for count in counts:
+                filtered = results[
+                    (results['count'] == count) &
+                    (results['framework'] == framework) &
+                    (results['use_async'] == use_async)
+                ].sort_values('size')
+                ax.plot(
+                    filtered['size'] / SIZE_FACTOR, filtered['real_time'],
+                    marker = MARKERS[framework].get_marker(),
+                    markersize = MARKERS[framework].get_markersize(),
+                    markerfacecolor = MARKERS[framework].get_markerfacecolor(),
+                    linestyle = LINESTYLES[use_async].get_linestyle(),
+                    linewidth = LINESTYLES[use_async].get_linewidth(),
+                    color = COLORS[count].get_color(),
+                )
+
+        ax.set_ylabel(f'time [{self.TIME_UNIT}]',   fontsize = FONTSIZE)
+        ax.set_xlabel(f'buffer size [{SIZE_UNIT}]', fontsize = FONTSIZE)
+        ax.set_yscale('log')
+        ax.set_xscale('log')
+        ax.tick_params(axis = 'both', which = 'major', labelsize = FONTSIZE)
+        ax.tick_params(axis = 'both', which = 'minor', labelsize = FONTSIZE)
+
+        _ = fig.legend(handles = (
+                Subtitle(text = 'Framework'),
+                *MARKERS.values(),
+                Subtitle(text = ''),
+                *LINESTYLES.values(),
+                Subtitle(text = ''),
+                Subtitle(text = 'Count'),
+                *COLORS.values(),
+                Subtitle(text = ''),
+                threshold,
+            ),
+            loc = 'outside center left',
+            frameon = False,
+            handler_map = {Subtitle: HandleSubtitle()},
+            fontsize = FONTSIZE,
+        )
+
+        ax.grid(which = 'both')
+
+        fname = self.cwd / 'results.svg'
+        logging.info(f'Saving results in {fname}.')
+        fig.savefig(fname = fname, bbox_inches = 'tight', transparent = False)
+
+class HandleSubtitle(matplotlib.legend_handler.HandlerBase):
+    @override
+    def create_artists(self,
+        legend : matplotlib.legend.Legend,
+        orig_handle : matplotlib.artist.Artist,
+        xdescent : float, ydescent : float,
+        width : float, height : float,
+        fontsize : float, trans: matplotlib.transforms.Transform,
+    ) -> list[matplotlib.artist.Artist]:
+        if not isinstance(orig_handle, Subtitle):
+            raise RuntimeError('Wrong usage.')
+
+        text = matplotlib.text.Text(
+            x = xdescent, y = ydescent,
+            text = orig_handle.text,
+            fontsize = fontsize, transform = trans,
+        )
+
+        return [text]
+
+class Subtitle:
+    def __init__(self, text : str):
+        self.text : typing.Final[str] = text
+
+    def get_label(self) -> str:
+        return ''


### PR DESCRIPTION
Results on my laptop (`AMPERE86`).

We can clearly observe the "bumps" for all `Kokkos` curves at the 40kB threshold. It must be due to the additional `cudaStreamSynchronize` performed right after the `cudaMallocAsync`.

<img width="3841" height="1931" alt="image" src="https://github.com/user-attachments/assets/0909f9f6-b736-496b-b169-1b1818ec9c58" />

