### PR TITLE
ncu: add printer for profiling results

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,10 +38,12 @@ extlinks = {
 intersphinx_mapping = {
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'python': ('https://docs.python.org/3', None),
+    'rich'  : ("https://rich.readthedocs.io/en/stable/", None),
 }
 
 autodoc_default_options = {
     'members' : True,
+    'special-members' : True,
     'show-inheritance' : True,
     'undoc-members' : True,
 }

--- a/python/reprospect/tools/ncu.py
+++ b/python/reprospect/tools/ncu.py
@@ -18,6 +18,8 @@ import types
 import typing
 
 import blake3
+import rich.console
+import rich.tree
 import typeguard
 
 from reprospect.tools import cacher
@@ -581,6 +583,35 @@ class ProfilingResults(collections.UserDict):
             aggregate[key] = sum(map(lambda x: x[key], samples.values()))
 
         return aggregate
+
+    @typeguard.typechecked
+    def to_tree(self) -> rich.tree.Tree:
+        """
+        Convert to a :py:class:`rich.tree.Tree`.
+        """
+        @typeguard.typechecked
+        def add_branch(*, tree : rich.tree.Tree, data : dict) -> None:
+            for key, value in data.items():
+                if isinstance(value, dict):
+                    branch = tree.add(key)
+                    add_branch(tree = branch, data = value)
+                else:
+                    tree.add(f'{key}: {value}')
+
+        tree = rich.tree.Tree('Profiling results')
+        add_branch(tree = tree, data = self.data)
+
+        return tree
+
+    def __str__(self) -> str:
+        """
+        Rich representation with :py:meth:`to_tree`.
+        """
+        console = rich.console.Console()
+        with console.capture() as capture:
+            console.print(self.to_tree(), no_wrap = True)
+
+        return capture.get()
 
 @typeguard.typechecked
 def load_ncu_report() -> typing.Optional[types.ModuleType]:

--- a/tests/python/tools/test_ncu.py
+++ b/tests/python/tools/test_ncu.py
@@ -259,6 +259,36 @@ class TestSession:
                 session.run(executable = self.GRAPH, opts = ['--something-ncu-does-not-know'], retries = 5)
             mock_sleep.assert_not_called()
 
+class TestProfilingResults:
+    """
+    Tests for :py:class:`reprospect.tools.ncu.ProfilingResults`.
+    """
+    def test_string_representation(self):
+        """
+        Test :py:meth:`reprospect.tools.ncu.ProfilingResults.__str__`.
+        """
+        results = ncu.ProfilingResults()
+        
+        # Add nested data.
+        results.get(["nvtx_range_name", "global_function_name_a_idx_0"])["metric_i"] = 15
+        results.get(["nvtx_range_name", "global_function_name_a_idx_0"])["metric_ii"] = 7
+        results.get(["nvtx_range_name", "global_function_name_b_idx_1"])["metric_i"] = 15
+        results.get(["nvtx_range_name", "global_function_name_b_idx_1"])["metric_ii"] = 9
+
+        formatted_as_tree = str(results)
+        
+        expt_results_formatted_as_tree = """\
+Profiling results
+└── nvtx_range_name
+    ├── global_function_name_a_idx_0
+    │   ├── metric_i: 15
+    │   └── metric_ii: 7
+    └── global_function_name_b_idx_1
+        ├── metric_i: 15
+        └── metric_ii: 9
+        """
+        assert formatted_as_tree.rstrip() == expt_results_formatted_as_tree.rstrip()
+
 class TestCacher:
     """
     Tests for :py:class:`reprospect.tools.ncu.Cacher`.


### PR DESCRIPTION
For our alignment example, the result looks something like:

```
 run
 ├── reprospect::examples::kokkos::MulAddFunctor<Kokkos::View<Kokkos::complex<double>*, Kokkos::CudaSpace> >
 │   └── void Kokkos::Impl::cuda_parallel_launch_local_memory<Kokkos::Impl::ParallelFor<reprospect::examples::kokkos::MulAddFunctor<Kokkos::View<Kokkos::complex<double> *, Kokkos::CudaSpace>>, Kokkos::RangePolicy<>, Kokkos::Cuda>>(T1)
 │       └── smsp__inst_executed.sum: 220.0
 └── reprospect::examples::kokkos::MulAddFunctor<Kokkos::View<reprospect::examples::kokkos::Complex<double>*, Kokkos::CudaSpace> >
     └── void Kokkos::Impl::cuda_parallel_launch_local_memory<Kokkos::Impl::ParallelFor<reprospect::examples::kokkos::MulAddFunctor<Kokkos::View<reprospect::examples::kokkos::Complex<double> *, Kokkos::CudaSpace>>, Kokkos::RangePolicy<>, Kokkos::Cuda>>(T1)
         └── smsp__inst_executed.sum: 236.0
```

Not too bad :)

We had to change the `autodoc` configuration to get doc for special members:
- https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-option-automodule-special-members