### PR TITLE
CICD: add `rich` package

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,6 @@
 blake3
 pandas
+rich
 semantic_version
 system-helpers @ git+https://github.com/uliegecsm/system-helpers@0.0.3
 typeguard


### PR DESCRIPTION
This PR adds the `Python` package `rich`.

Extracted from:
- #96 