### PR TITLE
Build configuration: rely on `CMake` default search paths to find `kokkosTools`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,7 +165,7 @@ jobs:
                       KOKKOS_INSTALL_SUFFIX=${{ matrix.cmake_preset }}-${{ matrix.nvidia_arch }}
                       KOKKOS_SHA=4.7.01
                       KOKKOS_TOOLS_INSTALL_SUFFIX=${{ matrix.cmake_preset }}
-                      KOKKOS_TOOLS_SHA=3c7c734a4509cca06184bcdcc6e7034f6b88b030
+                      KOKKOS_TOOLS_SHA=35c6aebf1499687f41d24d7f5dc0dbff57567070
                   labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 
     tests:

--- a/examples/kokkos/CMakeLists.txt
+++ b/examples/kokkos/CMakeLists.txt
@@ -29,4 +29,10 @@ endfunction()
 
 find_package(Kokkos REQUIRED COMPONENTS kokkoscore)
 
+find_package(
+    KokkosTools
+    REQUIRED
+    COMPONENTS kp_nvtx_connector
+)
+
 add_subdirectory(view)

--- a/examples/kokkos/view/CMakeLists.txt
+++ b/examples/kokkos/view/CMakeLists.txt
@@ -1,11 +1,2 @@
-# Fix for https://github.com/kokkos/kokkos-tools/issues/306.
-set(KokkosTools_DIR $ENV{KokkosTools_ROOT}/lib/cmake)
-
-find_package(
-    KokkosTools
-    REQUIRED
-    COMPONENTS kp_nvtx_connector
-)
-
 add_one_example(allocation)
 test_environment(examples_kokkos_view_allocation KOKKOS_TOOLS_NVTX_CONNECTOR_LIB set $<TARGET_FILE:KokkosTools::kp_nvtx_connector>)


### PR DESCRIPTION
This PR:
- lets `cmake` rely on the default search paths to find `kokkosTools`
- also moves the `find_package` to the parent directory

Follow-up for:
- https://github.com/kokkos/kokkos-tools/pull/307

Partially extracted from:
- #80 