### PR TITLE
Tools: use `llvm-cxxfilt` to demangle when compiling with `clang`

### DIFF
--- a/python/reprospect/test/case.py
+++ b/python/reprospect/test/case.py
@@ -1,7 +1,9 @@
 import abc
 import pathlib
+import typing
 
 from reprospect.tools.architecture import NVIDIAArch
+from reprospect.tools.binaries     import CuppFilt, LlvmCppFilt
 from reprospect.test.environment   import EnvironmentAwareMixin
 from reprospect.test.cmake         import CMakeMixin
 
@@ -13,21 +15,28 @@ class TestCase(EnvironmentAwareMixin, abc.ABC):
     @abc.abstractmethod
     def cwd(self) -> pathlib.Path:
         """
-        Working directory for the analysis.
+        Working directory.
         """
 
     @property
     @abc.abstractmethod
     def arch(self) -> NVIDIAArch:
         """
-        NVIDIA architecture for the analysis.
+        NVIDIA architecture.
         """
 
     @property
     @abc.abstractmethod
     def executable(self) -> pathlib.Path:
         """
-        Executable for the analysis.
+        Executable.
+        """
+
+    @property
+    @abc.abstractmethod
+    def demangler(self) -> typing.Type[CuppFilt | LlvmCppFilt]:
+        """
+        Demangler.
         """
 
 class CMakeAwareTestCase(CMakeMixin, TestCase):

--- a/python/reprospect/tools/ncu.py
+++ b/python/reprospect/tools/ncu.py
@@ -22,6 +22,7 @@ import rich.tree
 import typeguard
 
 from reprospect.tools import cacher
+from reprospect.tools.binaries import CuppFilt, LlvmCppFilt
 from reprospect.utils import ldd
 from reprospect.utils import rich_helpers
 
@@ -741,6 +742,7 @@ class Report:
         metrics : list[Metric | MetricCorrelation],
         includes : typing.Optional[list[str]] = None,
         excludes : typing.Optional[list[str]] = None,
+        demangler : typing.Optional[typing.Type[CuppFilt | LlvmCppFilt]] = None,
     ) -> ProfilingResults:
         """
         Extract the `metrics` of the actions in the range with ID `range_idx`.
@@ -765,7 +767,7 @@ class Report:
             results = self.collect_metrics_from_action(action = action, metrics = metrics)
 
             results['mangled']   = action.name(action.NameBase_MANGLED)
-            results['demangled'] = action.name(action.NameBase_DEMANGLED)
+            results['demangled'] = action.name(action.NameBase_DEMANGLED) if demangler is None else demangler.demangle(results['mangled'])
 
             # Loop over the domains of the action.
             # Note that domains are only available if NVTX was enabled during collection.

--- a/tests/python/test/test_graph.py
+++ b/tests/python/test/test_graph.py
@@ -24,7 +24,7 @@ class TestGraph(reprospect.CMakeAwareTestCase):
 
     DEMANGLED_NODE_A = {
         'NVIDIA' : 'void add_and_increment_kernel<(unsigned int)0, >(unsigned int *)',
-        'Clang' : '_Z24add_and_increment_kernelILj0ETpTnjJEEvPj',
+        'Clang' : 'void add_and_increment_kernel<0u>(unsigned int*)',
     }
 
 class TestSASS(TestGraph):
@@ -39,7 +39,14 @@ class TestSASS(TestGraph):
     @pytest.fixture(scope = 'class')
     @typeguard.typechecked
     def cuobjdump(self) -> CuObjDump:
-        return CuObjDump.extract(file = self.executable, arch = self.arch, sass = True, cwd = self.cwd, cubin = self.cubin.name)[0]
+        return CuObjDump.extract(
+            file = self.executable,
+            arch = self.arch,
+            sass = True,
+            cwd = self.cwd,
+            cubin = self.cubin.name,
+            demangler = self.demangler,
+        )[0]
 
     @typeguard.typechecked
     def test_kernel_count(self, cuobjdump : CuObjDump) -> None:
@@ -85,7 +92,7 @@ class TestNCU(TestGraph):
     @pytest.fixture(scope = 'class')
     @typeguard.typechecked
     def results(self, report : ncu.Report) -> ncu.ProfilingResults:
-        return report.extract_metrics_in_range(0, metrics = self.METRICS)
+        return report.extract_metrics_in_range(0, metrics = self.METRICS, demangler = self.demangler)
 
     @typeguard.typechecked
     def test_result_count(self, report : ncu.Report, results : ncu.ProfilingResults) -> None:


### PR DESCRIPTION
This PR:
- lets our tools use `llvm-cxxfilt` to demangle when compiling with `clang`.

Motivated by `ncu` not managing to demangle `kokkos` signatures in
- #80 