### PR TITLE
utils(cmake): use CMake file API to pass all cache and toolchains

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,13 @@ include(cmake/functions/environment.cmake)
 include(cmake/functions/path_helper.cmake)
 include(cmake/modules/Warnings.cmake)
 
+# Ask CMake to dump file-based detailed information about the build system.
+# See also https://cmake.org/cmake/help/latest/manual/cmake-file-api.7.html
+cmake_file_api(QUERY API_VERSION 1
+  CACHE 2
+  TOOLCHAINS 1
+)
+
 if(ReProspect_ENABLE_TESTS)
     enable_testing()
     add_subdirectory(tests)

--- a/docs/source/tests.rst
+++ b/docs/source/tests.rst
@@ -6,3 +6,4 @@ Tests
    :caption: Contents:
 
    tests/tools
+   tests/utils

--- a/docs/source/tests/utils.rst
+++ b/docs/source/tests/utils.rst
@@ -1,0 +1,7 @@
+Utils
+-----
+
+`CMake`
+~~~~~~~
+
+.. automodule:: tests.python.utils.test_cmake

--- a/examples/kokkos/CMakeLists.txt
+++ b/examples/kokkos/CMakeLists.txt
@@ -22,8 +22,8 @@ function(add_one_example FILE)
     )
 
     test_environment(${EXECUTABLE} PYTHONPATH path_list_prepend ${CMAKE_SOURCE_DIR}/python)
-    test_environment(${EXECUTABLE} EXECUTABLE path_list_prepend $<TARGET_FILE:${EXECUTABLE}>)
-    test_environment(${EXECUTABLE} COMPILE_COMMANDS set ${CMAKE_BINARY_DIR}/compile_commands.json)
+    test_environment(${EXECUTABLE} CMAKE_BINARY_DIR set ${CMAKE_BINARY_DIR})
+    test_environment(${EXECUTABLE} CMAKE_CURRENT_BINARY_DIR set ${CMAKE_CURRENT_BINARY_DIR})
 
 endfunction()
 

--- a/examples/kokkos/view/example_allocation.py
+++ b/examples/kokkos/view/example_allocation.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pandas
 import pytest
 import typeguard
@@ -10,6 +12,12 @@ class TestAllocation(reprospect.TestCase):
     """
     Explore the behavior of `Kokkos::View` allocation under different scenarios.
     """
+    NAME = 'examples_kokkos_view_allocation'
+
+    @property
+    @typeguard.typechecked
+    def executable(self) -> pathlib.Path:
+        return self.CMAKE_BINARY_DIR / 'examples' / 'kokkos' / 'view' / self.NAME
 
 class TestNSYS(TestAllocation):
     """
@@ -27,13 +35,13 @@ class TestNSYS(TestAllocation):
         with nsys.Cacher(
             session = nsys.Session(
                 output_dir = self.cwd,
-                output_file_prefix = self.EXECUTABLE.name,
+                output_file_prefix = self.executable.name,
             )
         ) as cacher:
             entry = cacher.run(
                 nvtx_capture = 'Allocation',
                 opts = ['--cuda-memory-usage=true'],
-                executable = self.EXECUTABLE,
+                executable = self.executable,
                 args = [
                     f"--kokkos-tools-libs={self.KOKKOS_TOOLS_NVTX_CONNECTOR_LIB}",
                 ],

--- a/python/reprospect/test/case.py
+++ b/python/reprospect/test/case.py
@@ -46,9 +46,12 @@ class EnvironmentAware(metaclass = EnvironmentAwareMeta):
 class TestCase(EnvironmentAware):
     """
     Base class for carrying out analyses of a given executable.
+
+    The child class must define `NAME` (see :py:meth:`cwd`).
     """
     _TYPES = {
-        'EXECUTABLE' : pathlib.Path,
+        'CMAKE_BINARY_DIR' : pathlib.Path,
+        'CMAKE_CURRENT_BINARY_DIR' : pathlib.Path,
     }
 
     @functools.cached_property
@@ -57,7 +60,7 @@ class TestCase(EnvironmentAware):
         """
         The working directory for the analysis.
         """
-        cwd = cls.EXECUTABLE.parent / (cls.EXECUTABLE.name + '-case')
+        cwd = cls.CMAKE_CURRENT_BINARY_DIR / (cls.NAME + '-case')
         cwd.mkdir(parents = False, exist_ok = True)
         return cwd
 
@@ -71,7 +74,7 @@ class TestCase(EnvironmentAware):
 
         See also https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html.
         """
-        with open(cls.COMPILE_COMMANDS, 'r') as fin:
+        with open(cls.CMAKE_BINARY_DIR / 'compile_commands.json', 'r') as fin:
             commands = json.load(fin)
         logging.info(f'Looking for {cls.TARGET_SOURCE} in {commands}')
         archs = get_arch_from_compile_command(cmd = next(filter(

--- a/python/reprospect/utils/cmake.py
+++ b/python/reprospect/utils/cmake.py
@@ -1,0 +1,42 @@
+import json
+import pathlib
+import typing
+
+import cmake_file_api
+import typeguard
+
+class FileAPI:
+    """
+    Thin wrapper for https://github.com/madebr/python-cmake-file-api.
+    """
+    @typeguard.typechecked
+    def __init__(self, build_path : pathlib.Path, inspect : typing.Dict[str, int]) -> None:
+        """
+        Use our wrapper for cache variables and toolchain information.
+        """
+        reader = cmake_file_api.reply.v1.api.CMakeFileApiV1(build_path = build_path)
+
+        for kind, version in inspect.items():
+            match kind:
+                case 'cache':
+                    self.cache = self.inspect_cache(reader = reader, version = version)
+                case 'toolchains':
+                    self.toolchains = {x.language: x.compiler for x in reader.inspect(kind = cmake_file_api.kinds.kind.ObjectKind(kind), kind_version = version).toolchains}
+                case _:
+                    setattr(self, kind, reader.inspect(kind = cmake_file_api.kinds.kind.ObjectKind(kind), kind_version = version))
+
+    @typeguard.typechecked
+    def inspect_cache(self, reader, version : int) -> dict:
+        """
+        By default, https://github.com/madebr/python-cmake-file-api/blob/3caf111d1ba10f5f9ae624336b55d3e7ca33f9e6/cmake_file_api/reply/v1/api.py#L70
+        will return a list of cache entries, which is impractical for name-based access.
+        """
+        path = reader._create_reply_path() / reader.index().reply.stateless[(cmake_file_api.kinds.kind.ObjectKind.CACHE, version)].jsonFile
+
+        with path.open() as file:
+            dikt = json.load(file)
+
+        if dikt['kind'] != cmake_file_api.kinds.kind.ObjectKind.CACHE.value:
+            raise ValueError(f'unexpected kind {dikt['kind']}')
+
+        return {ce.name: ce for ce in map(cmake_file_api.kinds.cache.v2.CacheEntry.from_dict, dikt['entries'])}

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -1,2 +1,27 @@
+function(add_pytest FILE)
+
+    set(FILEPATH ${CMAKE_CURRENT_SOURCE_DIR}/test_${FILE}.py)
+
+    get_parent_relpath_repr(DIRECTORY ${CMAKE_SOURCE_DIR} FILENAME ${FILEPATH})
+
+    set(FILENAME ${gprr_PARENT_RELPATH_REPR}_${FILE})
+
+    add_test(
+        NAME ${FILENAME}
+        COMMAND ${Python_EXECUTABLE} -m pytest ${FILEPATH} -vvv -s --log-cli-level=info
+    )
+
+    test_environment(${FILENAME} PYTHONPATH path_list_prepend ${CMAKE_SOURCE_DIR}/python)
+    test_environment(${FILENAME} PYTHONPATH path_list_prepend ${CMAKE_SOURCE_DIR})
+    test_environment(${FILENAME} CMAKE_BINARY_DIR set ${CMAKE_BINARY_DIR})
+    test_environment(${FILENAME} CMAKE_CURRENT_BINARY_DIR set ${CMAKE_CURRENT_BINARY_DIR})
+
+    # Directory for artifacts.
+    file(RELATIVE_PATH relative_path ${CMAKE_SOURCE_DIR} ${FILEPATH})
+    test_environment(${FILENAME} ARTIFACT_DIR set ${CMAKE_SOURCE_DIR}/artifacts/${relative_path})
+
+endfunction()
+
 add_subdirectory(test)
 add_subdirectory(tools)
+add_subdirectory(utils)

--- a/tests/python/test/CMakeLists.txt
+++ b/tests/python/test/CMakeLists.txt
@@ -1,19 +1,2 @@
-function(add_one_test FILE)
-
-    add_test(
-        NAME    tests_python_test_${FILE}
-        COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_SOURCE_DIR}/tests/python/test/test_${FILE}.py
-                    -vvv -s --log-cli-level=info
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    )
-
-    test_environment(tests_python_test_${FILE} PYTHONPATH path_list_prepend ${CMAKE_SOURCE_DIR}/python)
-    test_environment(tests_python_test_${FILE} EXECUTABLE set $<TARGET_FILE:tests_cpp_cuda_${FILE}>)
-    test_environment(tests_python_test_${FILE} COMPILE_COMMANDS set ${CMAKE_BINARY_DIR}/compile_commands.json)
-
-endfunction()
-
-add_one_test(graph)
-add_one_test(saxpy)
-
-test_environment(tests_python_test_graph CMAKE_CUDA_COMPILER_ID set ${CMAKE_CUDA_COMPILER_ID})
+add_pytest(graph)
+add_pytest(saxpy)

--- a/tests/python/test/test_saxpy.py
+++ b/tests/python/test/test_saxpy.py
@@ -13,7 +13,14 @@ class TestSaxpy(reprospect.TestCase):
     """
     General test class.
     """
+    NAME = 'tests_cpp_cuda_saxpy'
+
     TARGET_SOURCE = pathlib.Path('tests') / 'cpp' / 'cuda' / 'test_saxpy.cpp'
+
+    @property
+    @typeguard.typechecked
+    def executable(self) -> pathlib.Path:
+        return self.CMAKE_BINARY_DIR / self.TARGET_SOURCE.parent / self.NAME
 
 class TestSASS(TestSaxpy):
     """
@@ -27,7 +34,7 @@ class TestSASS(TestSaxpy):
     @pytest.fixture(scope = 'class')
     @typeguard.typechecked
     def cuobjdump(self) -> CuObjDump:
-        return CuObjDump.extract(file = self.EXECUTABLE, arch = self.arch, sass = True, cwd = self.cwd, cubin = self.cubin.name)[0]
+        return CuObjDump.extract(file = self.executable, arch = self.arch, sass = True, cwd = self.cwd, cubin = self.cubin.name)[0]
 
     @pytest.fixture(scope = 'class')
     @typeguard.typechecked
@@ -57,7 +64,7 @@ class TestNCU(TestSaxpy):
     def report(self) -> ncu.Report:
         session = ncu.Session(output = self.cwd / 'ncu')
         session.run(
-            executable = self.EXECUTABLE,
+            executable = self.executable,
             nvtx_includes = self.NVTX_INCLUDES,
             cwd = self.cwd,
             metrics = self.METRICS,

--- a/tests/python/tools/CMakeLists.txt
+++ b/tests/python/tools/CMakeLists.txt
@@ -1,25 +1,3 @@
-function(add_pytest FILE)
-
-    add_test(
-        NAME tests_python_tools_${FILE}
-        COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test_${FILE}.py -vvv -s --log-cli-level=info
-    )
-
-    test_environment(tests_python_tools_${FILE} PYTHONPATH path_list_prepend ${CMAKE_SOURCE_DIR}/python)
-    test_environment(tests_python_tools_${FILE} PYTHONPATH path_list_prepend ${CMAKE_SOURCE_DIR})
-    test_environment(tests_python_tools_${FILE} CMAKE_BINARY_DIR set ${CMAKE_BINARY_DIR})
-    test_environment(tests_python_tools_${FILE} CMAKE_CUDA_ARCHITECTURES set ${CMAKE_CUDA_ARCHITECTURES})
-    test_environment(tests_python_tools_${FILE} CMAKE_CURRENT_BINARY_DIR set ${CMAKE_CURRENT_BINARY_DIR})
-    test_environment(tests_python_tools_${FILE} CMAKE_CUDA_COMPILER set ${CMAKE_CUDA_COMPILER})
-    test_environment(tests_python_tools_${FILE} CMAKE_CUDA_COMPILER_ID set ${CMAKE_CUDA_COMPILER_ID})
-    test_environment(tests_python_tools_${FILE} CMAKE_CUDA_COMPILER_LAUNCHER set ${CMAKE_CUDA_COMPILER_LAUNCHER})
-
-    # Directory for artifacts.
-    file(RELATIVE_PATH relative_path ${CMAKE_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/test_${FILE}.py")
-    test_environment(tests_python_tools_${FILE} ARTIFACT_DIR set ${CMAKE_SOURCE_DIR}/artifacts/${relative_path})
-
-endfunction()
-
 add_pytest(architecture)
 add_pytest(binaries)
 add_pytest(cacher)

--- a/tests/python/tools/test_sass.py
+++ b/tests/python/tools/test_sass.py
@@ -4,6 +4,7 @@ import pathlib
 import pytest
 import typeguard
 
+from reprospect.utils import cmake
 from reprospect.tools import sass, binaries
 
 from tests.python.tools.test_binaries import Parameters, PARAMETERS, get_compilation_output
@@ -33,6 +34,14 @@ ISETP_NE_U32_AND = \
         /*00c0*/                   ISETP.NE.U32.AND P0, PT, R0.reuse, RZ, PT ;       /* 0x000000ff0000720c */
                                                                                      /* 0x040fe40003f05070 */
 """
+
+@pytest.fixture(scope = 'session')
+@typeguard.typechecked
+def cmake_file_api() -> cmake.FileAPI:
+    return cmake.FileAPI(
+        build_path = pathlib.Path(os.environ['CMAKE_BINARY_DIR']),
+        inspect = {'cache' : 2, 'toolchains' : 1},
+    )
 
 class TestSASSDecoder:
     """
@@ -103,7 +112,7 @@ class TestSASSDecoder:
 
     @pytest.mark.parametrize("parameters", PARAMETERS, ids = str)
     @typeguard.typechecked
-    def test_from_cuobjdump(self, parameters : Parameters) -> None:
+    def test_from_cuobjdump(self, parameters : Parameters, cmake_file_api : cmake.FileAPI) -> None:
         """
         Read `SASS` dumped from `cuobjdump`.
         """
@@ -113,6 +122,7 @@ class TestSASSDecoder:
             cwd = TMPDIR,
             arch = parameters.arch,
             object = True,
+            cmake_file_api = cmake_file_api,
         )
 
         cuobjdump = binaries.CuObjDump(file = output, arch = parameters.arch, sass = True)

--- a/tests/python/utils/CMakeLists.txt
+++ b/tests/python/utils/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_pytest(cmake)

--- a/tests/python/utils/test_cmake.py
+++ b/tests/python/utils/test_cmake.py
@@ -1,0 +1,35 @@
+import logging
+import os
+import pathlib
+
+from reprospect.utils import cmake
+
+class TestFileAPI:
+    """
+    Tests for :py:class:`reprospect.utils.cmake.FileAPI`.
+    """
+    def test_cache(self) -> None:
+        """
+        Check that cache variables are read correctly.
+        """
+        reader = cmake.FileAPI(build_path = pathlib.Path(os.environ['CMAKE_BINARY_DIR']), inspect = {'cache' : 2})
+
+        assert reader.cache['ReProspect_ENABLE_TESTS'].name  == 'ReProspect_ENABLE_TESTS'
+        assert reader.cache['ReProspect_ENABLE_TESTS'].value == 'ON'
+
+    def test_toolchains(self) -> None:
+        """
+        Check toolchain information.
+        """
+        reader = cmake.FileAPI(build_path = pathlib.Path(os.environ['CMAKE_BINARY_DIR']), inspect = {'toolchains' : 1})
+
+        assert 'CUDA' in reader.toolchains
+        assert 'CXX'  in reader.toolchains
+
+        assert reader.toolchains['CUDA'].id in ['NVIDIA', 'Clang']
+
+        for language, compiler in reader.toolchains.items():
+            logging.info(f'For language {language}:')
+            logging.info(f'\t- compiler ID     : {compiler.id}')
+            logging.info(f'\t- compiler path   : {compiler.path}')
+            logging.info(f'\t- compiler version: {compiler.version}')


### PR DESCRIPTION
This PR streamlines our approach to communicate information from `CMake` to our tests. We now let `CMake` write cache variables and build system information to json files. And we use an existing Python package to parse them.