### PR TITLE
cicd(tests): increase coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,8 +204,7 @@ jobs:
                 include: ${{ fromJSON(needs.setup-job-matrix.outputs.matrix_tests) }}
         env: ${{ matrix.environment }}
         runs-on: ${{ matrix.runs-on }}
-        container:
-            image: ${{ matrix.kokkos }}
+        container: ${{ matrix.examples.container }}
         steps:
             - uses: actions/checkout@v5
 
@@ -228,8 +227,7 @@ jobs:
                 include: ${{ fromJSON(needs.setup-job-matrix.outputs.matrix_tests) }}
         env: ${{ matrix.environment }}
         runs-on: ${{ matrix.runs-on }}
-        container:
-            image: ${{ matrix.image }}
+        container: ${{ matrix.install-as-package-and-test.container }}
         steps:
             # Since it is still a private repository, let's avoid authentication burden by
             # installing from the files directly.
@@ -241,7 +239,7 @@ jobs:
                 rm -rf install-from/
 
             - run: |
-                python -c "import reprospect.tools.device_properties as u; print(u.Cuda().get_device_name(device = 0))"
+                python -c "from reprospect.utils.detect import GPUDetector as u; print(u.get())"
 
             - run: |
                 reprospect-install-nsight-systems --help

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(Python 3.12 REQUIRED Interpreter)
 
 include(cmake/functions/environment.cmake)
 include(cmake/functions/path_helper.cmake)
+include(cmake/modules/detect.cmake)
 include(cmake/modules/Warnings.cmake)
 
 # Ask CMake to dump file-based detailed information about the build system.

--- a/cmake/modules/detect.cmake
+++ b/cmake/modules/detect.cmake
@@ -1,0 +1,31 @@
+# Detect GPUs.
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${CMAKE_SOURCE_DIR}/python
+            ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/python/reprospect/utils/detect.py --sep=\; --cc
+    OUTPUT_VARIABLE ReProspect_DETECTED_GPUS
+    COMMAND_ERROR_IS_FATAL ANY
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+if(ReProspect_DETECTED_GPUS)
+    message(STATUS "${CMAKE_PROJECT_NAME} detected the following GPU compute capability: ${ReProspect_DETECTED_GPUS}.")
+else()
+    message(STATUS "${CMAKE_PROJECT_NAME} did not detect any GPU.")
+endif()
+
+foreach(value IN LISTS ReProspect_DETECTED_GPUS)
+    if(NOT value MATCHES "^[0-9]+$")
+        message(FATAL_ERROR "Invalid detected compute capability value '${value}'.")
+    endif()
+endforeach()
+
+# For now, we only support CMAKE_CUDA_ARCHITECTURES that contain exactly 1 value.
+list(LENGTH CMAKE_CUDA_ARCHITECTURES CMAKE_CUDA_ARCHITECTURES_LENGTH)
+if(NOT CMAKE_CUDA_ARCHITECTURES_LENGTH EQUAL 1)
+    message(FATAL_ERROR "${CMAKE_PROJECT_NAME} requires that CMAKE_CUDA_ARCHITECTURES(=${CMAKE_CUDA_ARCHITECTURES}) contains exactly 1 architecture.")
+endif()
+
+# The CMAKE_CUDA_ARCHITECTURES might be suffixed with "-real" or "-virtual",
+# see also https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html.
+# We strip any such suffix to ease checking inclusion in the detected GPU architectures.
+set(ReProspect_ENABLED_CUDA_ARCHITECTURE "${CMAKE_CUDA_ARCHITECTURES}")
+list(TRANSFORM ReProspect_ENABLED_CUDA_ARCHITECTURE REPLACE "-real$|-virtual$" "")

--- a/docs/source/tests/python/utils.rst
+++ b/docs/source/tests/python/utils.rst
@@ -5,3 +5,8 @@ Utils
 ~~~~~~~
 
 .. automodule:: tests.python.utils.test_cmake
+
+Detect GPUs
+~~~~~~~~~~~
+
+.. automodule:: tests.python.utils.test_detect

--- a/examples/kokkos/view/example_allocation.py
+++ b/examples/kokkos/view/example_allocation.py
@@ -11,6 +11,7 @@ import typeguard
 import reprospect
 
 from reprospect.tools import nsys
+from reprospect.utils import detect
 
 class Memory(enum.StrEnum):
     DEVICE = 'DEVICE'
@@ -27,6 +28,7 @@ class TestAllocation(reprospect.TestCase):
     def executable(self) -> pathlib.Path:
         return self.CMAKE_BINARY_DIR / 'examples' / 'kokkos' / 'view' / self.NAME
 
+@pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
 class TestNSYS(TestAllocation):
     """
     `nsys`-focused analysis.

--- a/python/reprospect/tools/architecture.py
+++ b/python/reprospect/tools/architecture.py
@@ -83,7 +83,7 @@ class NVIDIAFamily(enum.StrEnum):
         else:
             raise ValueError(f"unsupported compute capability {cc}")
 
-@dataclasses.dataclass(frozen = True, eq = True, match_args = True)
+@dataclasses.dataclass(frozen = True, eq = True, match_args = True, slots = True)
 class NVIDIAArch:
     """
     `NVIDIA` architecture.

--- a/python/reprospect/tools/sass.py
+++ b/python/reprospect/tools/sass.py
@@ -138,7 +138,7 @@ class ControlCode:
             reuse = reuse_flags,
         )
 
-@dataclasses.dataclass(frozen = True)
+@dataclasses.dataclass(frozen = True, slots = True)
 class Instruction:
     """
     Represents a single `SASS` instruction with its components.

--- a/python/reprospect/utils/detect.py
+++ b/python/reprospect/utils/detect.py
@@ -1,0 +1,101 @@
+import argparse
+import io
+import logging
+import shutil
+import subprocess
+import typing
+
+import pandas
+import typeguard
+
+from reprospect.tools import architecture
+
+class GPUDetector:
+    """
+    Detect all available GPUs using `nvidia-smi`.
+
+    .. note::
+
+        By default, results are cached.
+    """
+    COLUMNS = {'uuid' : str, 'index' : int, 'name' : str, 'compute_cap' : str}
+
+    _cache : typing.Optional[pandas.DataFrame] = None
+
+    @classmethod
+    def clear_cache(cls) -> None:
+        """
+        Clear the cached `GPU` detection results.
+        """
+        cls._cache = None
+
+    @classmethod
+    @typeguard.typechecked
+    def get(cls, cache : bool = True, **kwargs) -> pandas.DataFrame:
+        if cache and cls._cache is not None:
+            return cls._cache
+
+        results = cls.detect(**kwargs)
+
+        if cache:
+            cls._cache = results
+
+        return results
+
+    @classmethod
+    @typeguard.typechecked
+    def detect(cls, enrich : bool = True) -> pandas.DataFrame:
+        """
+        Implementation of the detection.
+        """
+        CMD = ['nvidia-smi', '--query-gpu=' + ','.join(cls.COLUMNS.keys()), '--format=csv']
+
+        if shutil.which('nvidia-smi') is not None:
+            gpus = pandas.read_csv(
+                io.StringIO(subprocess.check_output(CMD).decode()),
+                sep = ',',
+                skipinitialspace = True,
+                dtype = cls.COLUMNS,
+            )
+            if not set(cls.COLUMNS.keys()).issubset(gpus.columns):
+                raise RuntimeError(gpus.columns)
+            if enrich:
+                gpus['architecture'] = gpus['compute_cap'].apply(
+                    lambda x: architecture.NVIDIAArch.from_compute_capability(int(x.replace('.', '')))
+                )
+            return gpus
+        else:
+            logging.warning("'nvidia-smi' not found.")
+            return pandas.DataFrame(columns = cls.COLUMNS)
+
+    @classmethod
+    @typeguard.typechecked
+    def count(cls, cache : bool = True) -> int:
+        """
+        Get the number of available GPUs.
+        """
+        return len(cls.get(cache = cache))
+
+def main() -> None:
+
+    parser = argparse.ArgumentParser(
+        description = 'Print the list of detected GPUs.',
+        formatter_class = argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument('--sep', type = str, required = False, default = ';', help = 'Separator between GPUs.')
+
+    parser.add_argument('--cc', action = 'store_true', help = 'Return the compute capability as an integer.')
+
+    args = parser.parse_args()
+
+    if args.cc:
+        gpus = map(lambda x: x.replace('.', ''), map(str, GPUDetector.get(enrich = False)['compute_cap']))
+    else:
+        gpus = map(str, GPUDetector.get(enrich = True)['architecture'])
+
+    print(args.sep.join(gpus), end = '')
+
+if __name__ == "__main__":
+
+    main()

--- a/python/setup.py
+++ b/python/setup.py
@@ -32,6 +32,7 @@ setup(
     entry_points = {
         'console_scripts': [
             'reprospect-install-nsight-systems = reprospect.installers.nsight_systems:main',
+            'reprospect-utils-detect-gpus = reprospect.utils.detect:main',
         ],
     },
 )

--- a/tests/cpp/cuda/CMakeLists.txt
+++ b/tests/cpp/cuda/CMakeLists.txt
@@ -14,8 +14,11 @@ function(add_one_test FILE)
 
     set_source_files_properties(${FILENAME} PROPERTIES LANGUAGE CUDA)
 
-    add_test(NAME ${EXECUTABLE} COMMAND $<TARGET_FILE:${EXECUTABLE}>)
-
+    if(ReProspect_ENABLED_CUDA_ARCHITECTURE IN_LIST ReProspect_DETECTED_GPUS)
+        add_test(NAME ${EXECUTABLE} COMMAND $<TARGET_FILE:${EXECUTABLE}>)
+    else()
+        message(WARNING "Not adding test '${EXECUTABLE}' because ${ReProspect_ENABLED_CUDA_ARCHITECTURE} is not in the detected GPUs (${ReProspect_DETECTED_GPUS}).")
+    endif()
 endfunction()
 
 find_package(CUDAToolkit REQUIRED COMPONENTS cudart nvtx3)

--- a/tests/python/test/test_graph.py
+++ b/tests/python/test/test_graph.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import pathlib
 
 import pytest
@@ -11,6 +10,7 @@ from reprospect.tools.binaries import CuObjDump
 from reprospect.tools          import ncu
 from reprospect.tools.sass     import Decoder
 from reprospect.utils          import cmake
+from reprospect.utils          import detect
 
 class TestGraph(reprospect.TestCase):
     """
@@ -69,6 +69,7 @@ class TestSASS(TestGraph):
         decoder = Decoder(code = cuobjdump.functions[self.DEMANGLED_NODE_A[cmake_file_api.toolchains['CUDA'].id]].code)
         assert len(decoder.instructions) >= 8
 
+@pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
 class TestNCU(TestGraph):
     """
     `ncu`-focused analysis.

--- a/tests/python/test/test_saxpy.py
+++ b/tests/python/test/test_saxpy.py
@@ -8,6 +8,7 @@ import reprospect
 from reprospect.tools.binaries import CuObjDump
 from reprospect.tools          import ncu
 from reprospect.tools.sass     import Decoder
+from reprospect.utils          import detect
 
 class TestSaxpy(reprospect.TestCase):
     """
@@ -45,6 +46,7 @@ class TestSASS(TestSaxpy):
     def test_instruction_count(self, decoder : Decoder) -> None:
         assert len(decoder.instructions) >= 16
 
+@pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
 class TestNCU(TestSaxpy):
     """
     `ncu`-focused analysis.

--- a/tests/python/tools/test_device_properties.py
+++ b/tests/python/tools/test_device_properties.py
@@ -4,7 +4,10 @@ import pathlib
 import re
 import unittest
 
+import pytest
+
 from reprospect.tools import device_properties
+from reprospect.utils import detect
 
 class TestCuda(unittest.TestCase):
     """
@@ -19,6 +22,7 @@ class TestCuda(unittest.TestCase):
         assert self.INCLUDE_DIR.is_dir()
         assert (self.INCLUDE_DIR / 'cuda.h').is_file()
 
+    @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
     def test_initialize(self):
         """
         Test it can be successfully loaded.
@@ -28,6 +32,7 @@ class TestCuda(unittest.TestCase):
         assert type(device_properties.Cuda.cuda)   is ctypes.CDLL
         assert type(device_properties.Cuda.cudart) is ctypes.CDLL
 
+    @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
     def test_check_driver_status(self):
         """
         Check the proper handling of `Cuda` driver API error codes.
@@ -39,6 +44,7 @@ class TestCuda(unittest.TestCase):
         except RuntimeError as e:
             assert str(e) == "My random information string. failed with error code CudaDriverError(value=100) (CUDA_ERROR_NO_DEVICE): no CUDA-capable device is detected"
 
+    @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
     def test_check_runtime_status(self):
         """
         Check the proper handling of `Cuda` runtime API error codes.
@@ -50,12 +56,14 @@ class TestCuda(unittest.TestCase):
         except RuntimeError as e:
             assert str(e) == "My random information string. failed with error code CudaRuntimeError(value=201) (cudaErrorDeviceUninitialized): invalid device context"
 
+    @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
     def test_device_count(self):
         """
         There must be at least one device.
         """
         assert device_properties.Cuda().device_count > 0
 
+    @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
     def test_get_device_attribute(self):
         """
         Retrieve a few device attributes.
@@ -79,6 +87,7 @@ class TestCuda(unittest.TestCase):
             for attribute in attributes:
                 logging.info(f'{attribute.name}: {cuda.get_device_attribute(value_type = ctypes.c_int, attribute = device_properties.CudaDeviceAttribute.TOTAL_CONSTANT_MEMORY, device = device)}')
 
+    @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
     def test_get_device_compute_capability(self):
         """
         Retrieve the compute capability of all devices available.
@@ -89,6 +98,7 @@ class TestCuda(unittest.TestCase):
             cc = cuda.get_device_compute_capability(device = device)
             logging.info(f'Compute capability of device {device} is {cc}.')
 
+    @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
     def test_get_device_name(self):
         """
         Get the device name.
@@ -100,6 +110,7 @@ class TestCuda(unittest.TestCase):
             assert isinstance(cc, str)
             logging.info(f'Name of device {device} is {cc}.')
 
+    @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
     def test_get_device_total_memory(sell):
         """
         Get the device total memory.

--- a/tests/python/tools/test_ncu.py
+++ b/tests/python/tools/test_ncu.py
@@ -10,6 +10,7 @@ import typeguard
 
 from reprospect.utils import cmake
 from reprospect.tools import ncu
+from reprospect.utils import detect
 
 TMPDIR = pathlib.Path(os.environ['CMAKE_CURRENT_BINARY_DIR']) if 'CMAKE_CURRENT_BINARY_DIR' in os.environ else None
 
@@ -21,6 +22,7 @@ def cmake_file_api() -> cmake.FileAPI:
         inspect = {'toolchains' : 1},
     )
 
+@pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
 class TestSession:
     """
     Test :py:class:`reprospect.tools.ncu.Session`.
@@ -287,6 +289,7 @@ class TestCacher:
 
                 assert hash_a.digest() != hash_b.digest()
 
+    @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
     def test_cache_hit(self):
         """
         The cacher should hit on the second call.

--- a/tests/python/tools/test_nsys.py
+++ b/tests/python/tools/test_nsys.py
@@ -10,9 +10,11 @@ import semantic_version
 import typeguard
 
 from reprospect.tools.nsys import Report, Session, strip_cuda_api_suffix, Cacher
+from reprospect.utils      import detect
 
 TMPDIR = pathlib.Path(os.environ['CMAKE_CURRENT_BINARY_DIR']) if 'CMAKE_CURRENT_BINARY_DIR' in os.environ else None
 
+@pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
 class TestSession:
     """
     Test :py:class:`reprospect.tools.nsys.Session`.
@@ -171,6 +173,7 @@ class TestCacher:
 
                 assert hash_a.digest() != hash_b.digest()
 
+    @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
     def test_cache_hit(self):
         """
         The cacher should hit on the second call.
@@ -199,6 +202,7 @@ class TestCacher:
 
                 assert all(x in os.listdir(cacher.session.output_dir) for x in FILES)
 
+@pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
 class TestReport:
     """
     Test :py:class:`reprospect.tools.nsys.Report`.

--- a/tests/python/utils/CMakeLists.txt
+++ b/tests/python/utils/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_pytest(cmake)
+add_pytest(detect)

--- a/tests/python/utils/test_detect.py
+++ b/tests/python/utils/test_detect.py
@@ -1,0 +1,138 @@
+import inspect
+import sys
+import unittest.mock
+
+import pandas
+
+from reprospect.tools import architecture
+from reprospect.utils import detect
+
+class TestGPUDetector:
+    """
+    Tests for :py:class:`reprospect.utils.detect.GPUDetector`.
+    """
+    OUTPUT = """\
+index, uuid, name, compute_cap
+0, GPU-12345678-1234-1234-1234-123456789012, NVIDIA GeForce RTX 3090, 8.6
+1, GPU-87654321-4321-4321-4321-210987654321, NVIDIA A100-SXM4-40GB, 8.0
+""".encode()
+
+    def test_detect_gpus(self) -> None:
+        """
+        Test that :py:meth:`reprospect.utils.detect.GPUDetector.get` returns a properly formatted :py:class:`pandas.DataFrame`.
+        """
+        detect.GPUDetector.clear_cache()
+
+        with unittest.mock.patch('shutil.which', side_effect = ['nvidia-smi']) as mock_shutil:
+            with unittest.mock.patch('subprocess.check_output', side_effect = [self.OUTPUT]) as mock_subprocess:
+                result = detect.GPUDetector.get(cache = True)
+
+                assert isinstance(result, pandas.DataFrame)
+
+                assert sorted(['index', 'uuid', 'name', 'compute_cap', 'architecture']) == sorted(result.columns)
+
+                assert len(result) == 2
+                assert detect.GPUDetector.count() == 2
+
+                pandas.testing.assert_series_equal(result.iloc[0], pandas.Series({
+                    'index' : 0,
+                    'uuid' : 'GPU-12345678-1234-1234-1234-123456789012',
+                    'name' : 'NVIDIA GeForce RTX 3090',
+                    'compute_cap' : '8.6',
+                    'architecture' : architecture.NVIDIAArch.from_str('AMPERE86'),
+                }), check_names = False)
+
+                pandas.testing.assert_series_equal(result.iloc[1], pandas.Series({
+                    'index' : 1,
+                    'uuid' : 'GPU-87654321-4321-4321-4321-210987654321',
+                    'name' : 'NVIDIA A100-SXM4-40GB',
+                    'compute_cap' : '8.0',
+                    'architecture' : architecture.NVIDIAArch.from_str('AMPERE80'),
+                }), check_names = False)
+
+                mock_shutil.assert_called_once()
+
+                mock_subprocess.assert_called_once_with(['nvidia-smi', '--query-gpu=uuid,index,name,compute_cap', '--format=csv'])
+
+    def test_detect_gpus_no_gpu(self) -> None:
+        """
+        Test that :py:meth:`reprospect.utils.detect.GPUDetector.get` returns an empty :py:class:`pandas.DataFrame` if
+        `nvidia-smi` is not found.
+        """
+        with unittest.mock.patch('shutil.which', side_effect = [None]) as mock_shutil:
+            assert len(detect.GPUDetector.get(cache = False)) == 0
+
+            mock_shutil.assert_called_once()
+
+    def test_detect_gpus_cache(self) -> None:
+        """
+        Test that calling :py:meth:`reprospect.utils.detect.GPUDetector.get` twice
+        uses caching and only calls `nvidia-smi` once.
+        """
+        detect.GPUDetector.clear_cache()
+
+        with unittest.mock.patch('shutil.which', side_effect = ['nvidia-smi']) as mock_shutil:
+            with unittest.mock.patch('subprocess.check_output', side_effect = [self.OUTPUT]) as mock_subprocess:
+                result_first  = detect.GPUDetector.get(cache = True)
+                result_second = detect.GPUDetector.get(cache = True)
+
+                pandas.testing.assert_frame_equal(result_first, result_second)
+
+                mock_subprocess.assert_called_once()
+                mock_shutil.assert_called_once()
+
+    def test_detect_gpus_no_cache(self) -> None:
+        """
+        Test that calling :py:meth:`reprospect.utils.detect.GPUDetector.get` twice
+        when caching is disabled calls `nvidia-smi` twice.
+        """
+        detect.GPUDetector.clear_cache()
+
+        with unittest.mock.patch('shutil.which', side_effect = ['nvidia-smi'] * 2) as mock_shutil:
+            with unittest.mock.patch('subprocess.check_output', side_effect = [self.OUTPUT] * 2) as mock_subprocess:
+                result_first  = detect.GPUDetector.get(cache = False)
+                result_second = detect.GPUDetector.get(cache = False)
+
+                pandas.testing.assert_frame_equal(result_first, result_second)
+
+                assert mock_subprocess.call_count == 2
+                assert mock_shutil.call_count == 2
+
+class TestGPUDetectorAsScript:
+    """
+    Tests for :py:mod:`reprospect.utils.detect` in script mode.
+    """
+    SCRIPT = inspect.getfile(detect)
+
+    def test(self, capsys):
+        """
+        Check that the output is correctly formatted according to the arguments.
+        """
+        with unittest.mock.patch(target = 'shutil.which', side_effect = ['nvidia-smi'] * 4) as mock_shutil:
+            with unittest.mock.patch(target = 'subprocess.check_output', side_effect = [TestGPUDetector.OUTPUT] * 4) as mock_subprocess:
+                # Compute capability, ';' separator.
+                detect.GPUDetector.clear_cache()
+                sys.argv = [self.SCRIPT, '--sep=;', '--cc']
+                detect.main()
+                assert capsys.readouterr().out == "86;80"
+
+                # Compute capability, '/' separator.
+                detect.GPUDetector.clear_cache()
+                sys.argv = [self.SCRIPT, '--sep=/', '--cc']
+                detect.main()
+                assert capsys.readouterr().out == "86/80"
+
+                # Named architecture, ',' separator.
+                detect.GPUDetector.clear_cache()
+                sys.argv = [__file__, '--sep=,']
+                detect.main()
+                assert capsys.readouterr().out == "AMPERE86,AMPERE80"
+
+                # Named architecture, '|' separator.
+                detect.GPUDetector.clear_cache()
+                sys.argv = [__file__, '--sep=|']
+                detect.main()
+                assert capsys.readouterr().out == "AMPERE86|AMPERE80"
+
+                assert mock_shutil.call_count == 4
+                assert mock_subprocess.call_count == 4


### PR DESCRIPTION
This PR
* ensures we do not request the GPU ARCH label if not available in the CI runner fleet
* skips all tests that require a GPU with some nice helper

For tests that are driven by `pytest`, we always add the test with `add_test`, and from within the test, `pytest` will skip as necessary (with `pytest.mark.skipif`).

For tests that are "direct", *e.g.* `add_test(NAME ... COMMAND $<TARGET_FILE:...>)`, the easiest solution is to not add the test at all if the required GPU architecture is not detected. Note that we explored the `CTest` resource groups, but it's too complicated for such a simple case, and it marks tests that request nonexistent resources as failed instead of skipped.