### PR TITLE
examples(kokkos): desul atomic

### DIFF
--- a/docs/source/examples/kokkos/atomic/add.rst
+++ b/docs/source/examples/kokkos/atomic/add.rst
@@ -2,6 +2,7 @@
 ==========================
 
 .. automodule:: examples.kokkos.atomic.add
+.. automodule:: examples.kokkos.atomic.example_add_complex64
 .. automodule:: examples.kokkos.atomic.example_add_complex128
 .. automodule:: examples.kokkos.atomic.example_add_double256
 .. automodule:: examples.kokkos.atomic.example_add_int128

--- a/examples/kokkos/atomic/CMakeLists.txt
+++ b/examples/kokkos/atomic/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_one_example(add_complex64)
 add_one_example(add_complex128)
 add_one_example(add_double256)
 add_one_example(add_int128)

--- a/examples/kokkos/atomic/example_add_complex64.cpp
+++ b/examples/kokkos/atomic/example_add_complex64.cpp
@@ -1,0 +1,22 @@
+#include "add.hpp"
+
+/**
+ * @file
+ *
+ * Companion of @ref examples/kokkos/atomic/example_add_complex64.py.
+ */
+
+int main(int argc, char* argv[])
+{
+    Kokkos::ScopeGuard guard {argc, argv};
+    {
+        using scalar_t = Kokkos::complex<float>;
+
+        static_assert( sizeof(scalar_t) == 8);
+        static_assert(alignof(scalar_t) == 8);
+
+        static_assert(std::is_trivially_copyable_v<scalar_t>);
+
+        ::reprospect::examples::kokkos::atomic::AtomicAdd<scalar_t>::run(Kokkos::Cuda{}, scalar_t{1, 2});
+    }
+}

--- a/examples/kokkos/atomic/example_add_complex64.py
+++ b/examples/kokkos/atomic/example_add_complex64.py
@@ -1,0 +1,96 @@
+import logging
+import re
+import sys
+import typing
+
+from reprospect.test.sass.composite import instruction_is, unordered_interleaved_instructions_are, interleaved_instructions_are
+from reprospect.test.sass.composite_impl import SequenceMatcher, UnorderedInterleavedInSequenceMatcher
+from reprospect.test.sass.controlflow.block import BasicBlockMatcher, BasicBlockWithParentMatcher
+from reprospect.test.sass.instruction import (
+    AtomicMatcher,
+    Fp32AddMatcher,
+    InstructionMatch,
+    LoadGlobalMatcher,
+    RegisterMatcher,
+)
+from reprospect.tools.architecture import NVIDIAArch
+from reprospect.tools.sass import Decoder, ControlFlow
+from reprospect.tools.sass.controlflow import Graph
+
+from examples.kokkos.atomic import add
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+class Operation(typing.Protocol):
+    def build(self, load: InstructionMatch) -> SequenceMatcher:
+        ...
+
+class AtomicCAS:
+    def __init__(self, arch: NVIDIAArch, operation: Operation) -> None:
+        self.arch: typing.Final[NVIDIAArch] = arch
+        self.operation: typing.Final[Operation] = operation
+
+    def match(self, cfg: Graph) -> None:
+        # First, find the global load from memory.
+        matcher_ldg = LoadGlobalMatcher(arch=self.arch, size=64, readonly=False)
+        block_ldg, [matched_ldg] = BasicBlockMatcher(matcher=matcher_ldg).assert_matches(cfg=cfg)
+        logging.info(matched_ldg)
+
+        # Then, match the operation with the CAS.
+        matcher_op = self.operation.build(load=matched_ldg)
+        matcher_cas = instruction_is(AtomicMatcher(
+            arch=self.arch,
+            operation='CAS',
+            dtype=(None, 64),
+            scope='DEVICE',
+            consistency='STRONG',
+            memory='',
+        )).with_operand(index=3, operand=matched_ldg.operands[0])
+
+        _, matched = BasicBlockWithParentMatcher(parent=block_ldg, matcher=interleaved_instructions_are(matcher_op, matcher_cas)).assert_matches(cfg=cfg)
+
+        assert len(matched) == 3
+
+        assert matched[2].operands[4] in (matched[0].operands[0], matched[1].operands[1])
+
+class AddComplex64:
+    """
+    Addition of two 64-bit complex values.
+    """
+    def build(self, load: InstructionMatch) -> UnorderedInterleavedInSequenceMatcher:
+
+        assert (load_reg := RegisterMatcher(special=False).match(reg=load.operands[0])) is not None
+        assert load_reg.index is not None
+
+        reg_real = f'{load_reg.rtype}{load_reg.index}'
+        reg_imag = f'{load_reg.rtype}{load_reg.index + 1}'
+
+        return unordered_interleaved_instructions_are(
+            instruction_is(Fp32AddMatcher()).with_operand(index=1, operand=reg_real),
+            instruction_is(Fp32AddMatcher()).with_operand(index=1, operand=reg_imag),
+        )
+
+class TestAtomicAddComplex64(add.TestCase):
+    """
+    Verify that :code:`Kokkos::atomic_add` for :code:`Kokkos::complex<float>` maps to an atomic CAS-based implementation.
+    """
+    @classmethod
+    @override
+    def get_target_name(cls) -> str:
+        return 'examples_kokkos_atomic_add_complex64'
+
+    SIGNATURE_MATCHER: typing.ClassVar[re.Pattern[str]] = re.compile(
+        r'AtomicAddFunctor<Kokkos::View<Kokkos::complex<float>\s*\*\s*, Kokkos::CudaSpace>>',
+    )
+
+    def test_cas_based_atomic(self, decoder: Decoder) -> None:
+        """
+        This test proves that it uses the atomic CAS-based atomic by looking for an instruction sequence pattern.
+        """
+        AtomicCAS(
+            arch=self.arch,
+            operation=AddComplex64(),
+        ).match(cfg=ControlFlow.analyze(instructions=decoder.instructions))


### PR DESCRIPTION
This PR adds 2 tests:
- `Kokkos::atomic_add` with `Kokkos::complex<double>`, that is expected to **never** match to a 128-bit hardware atomic add, but *could* possibly one day use a `atomicCAS`.
- `Kokkos::atomic_add` with `__int128_t` that for now also uses the `desul` lock-array but recent `Kokkos` versions should use hardware 128-bits atomic add when supported (compute capability >= 9.0).
