### PR TITLE
tests: use `CMake` file api codemodel

### DIFF
--- a/examples/kokkos/view/example_allocation.py
+++ b/examples/kokkos/view/example_allocation.py
@@ -1,7 +1,6 @@
 import enum
 import logging
 import math
-import pathlib
 import typing
 
 import numpy
@@ -17,16 +16,15 @@ class Memory(enum.StrEnum):
     DEVICE = 'DEVICE'
     SHARED = 'MANAGED'
 
-class TestAllocation(reprospect.TestCase):
+class TestAllocation(reprospect.CMakeAwareTestCase):
     """
     Explore the behavior of `Kokkos::View` allocation under different scenarios.
     """
-    NAME = 'examples_kokkos_view_allocation'
-
-    @property
+    @classmethod
+    @typing.override
     @typeguard.typechecked
-    def executable(self) -> pathlib.Path:
-        return self.CMAKE_BINARY_DIR / 'examples' / 'kokkos' / 'view' / self.NAME
+    def get_target_name(cls) -> str:
+        return 'examples_kokkos_view_allocation'
 
 @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
 class TestNSYS(TestAllocation):

--- a/python/reprospect/__init__.py
+++ b/python/reprospect/__init__.py
@@ -1,3 +1,3 @@
 __version__ = '0.0.6'
 
-from .test.case import TestCase
+from .test.case import TestCase, CMakeAwareTestCase

--- a/python/reprospect/test/case.py
+++ b/python/reprospect/test/case.py
@@ -1,85 +1,36 @@
-import functools
-import json
-import logging
-import os
+import abc
 import pathlib
-import typing
-
-import typeguard
 
 from reprospect.tools.architecture import NVIDIAArch
-from reprospect.tools.binaries     import get_arch_from_compile_command
+from reprospect.test.environment   import EnvironmentAwareMixin
+from reprospect.test.cmake         import CMakeMixin
 
-class EnvironmentAwareMeta(type):
+class TestCase(EnvironmentAwareMixin, abc.ABC):
     """
-    Metaclass that resolves missing class attributes from the environment.
+    Test case.
     """
-    @typeguard.typechecked
-    def __getattr__(cls, name : str) -> typing.Any:
-        return cls.read_from_env(name)
-
-class EnvironmentAware(metaclass = EnvironmentAwareMeta):
-    """
-    Base class that resolves missing class or instance attributes from the environment.
-    """
-    #: Specify convertors from environment variable values to attributes of the relevant types.
-    _TYPES: dict[str, typing.Callable[[str], typing.Any]] = {}
-
-    @typeguard.typechecked
-    @classmethod
-    def read_from_env(cls, name : str) -> typing.Any:
-        value = os.getenv(name)
-        if value is None:
-            raise AttributeError(f"{cls.__name__} has no attribute '{name}' and there is no environment variable {name!r}.")
-
-        if name in cls._TYPES:
-            value = cls._TYPES[name](value)
-
-        setattr(cls, name, value)
-
-        return value
-
-    @typeguard.typechecked
-    def __getattr__(self, name : str) -> typing.Any:
-        return self.read_from_env(name)
-
-class TestCase(EnvironmentAware):
-    """
-    Base class for carrying out analyses of a given executable.
-
-    The child class must define `NAME` (see :py:meth:`cwd`).
-    """
-    _TYPES = {
-        'CMAKE_BINARY_DIR' : pathlib.Path,
-        'CMAKE_CURRENT_BINARY_DIR' : pathlib.Path,
-    }
-
-    @functools.cached_property
-    @typeguard.typechecked
+    @property
+    @abc.abstractmethod
     def cwd(self) -> pathlib.Path:
         """
-        The working directory for the analysis.
+        Working directory for the analysis.
         """
-        cwd = self.CMAKE_CURRENT_BINARY_DIR / (self.NAME + '-case')
-        cwd.mkdir(parents = False, exist_ok = True)
-        return cwd
 
-    @functools.cached_property
-    @typeguard.typechecked
+    @property
+    @abc.abstractmethod
     def arch(self) -> NVIDIAArch:
         """
-        Retrieve the GPU architecture from the compile command database.
-
-        We assume the target file was compiled for only a single architecture.
-
-        See also https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html.
+        NVIDIA architecture for the analysis.
         """
-        with open(self.CMAKE_BINARY_DIR / 'compile_commands.json', mode = 'r', encoding = 'utf-8') as fin:
-            commands = json.load(fin)
-        logging.info(f'Looking for {self.TARGET_SOURCE} in {commands}')
-        archs = get_arch_from_compile_command(cmd = next(filter(
-            lambda x: str(self.TARGET_SOURCE) in x['file'],
-            commands))['command']
-        )
-        assert len(archs) == 1
-        return archs.pop()
+
+    @property
+    @abc.abstractmethod
+    def executable(self) -> pathlib.Path:
+        """
+        Executable for the analysis.
+        """
+
+class CMakeAwareTestCase(CMakeMixin, TestCase):
+    """
+    Test case with CMake integration.
+    """

--- a/python/reprospect/test/cmake.py
+++ b/python/reprospect/test/cmake.py
@@ -1,0 +1,94 @@
+import abc
+import functools
+import logging
+import json
+import pathlib
+import typing
+
+import typeguard
+
+from reprospect.tools.architecture import NVIDIAArch
+from reprospect.tools.binaries     import get_arch_from_compile_command
+from reprospect.utils              import cmake
+
+class CMakeMixin(abc.ABC):
+    """
+    Mixin to integrate with CMake build system.
+    """
+    _REQUIRED_ATTRIBUTES_WITH_DEFAULT_FROM_ENV = {
+        'CMAKE_BINARY_DIR': pathlib.Path,
+        'CMAKE_CURRENT_BINARY_DIR': pathlib.Path,
+    }
+
+    @classmethod
+    @abc.abstractmethod
+    def get_target_name(cls) -> str:
+        pass
+
+    @functools.cached_property
+    @typeguard.typechecked
+    def cwd(self) -> pathlib.Path:
+        """
+        Get working directory for the analysis based on the CMake current binary directory.
+        """
+        cwd = self.CMAKE_CURRENT_BINARY_DIR / (self.get_target_name() + '-case')
+        cwd.mkdir(parents = False, exist_ok = True)
+        return cwd
+
+    @functools.cached_property
+    @typeguard.typechecked
+    def arch(self) -> NVIDIAArch:
+        """
+        Retrieve the NVIDIA architecture from the CMake compile command database.
+
+        We assume the target file was compiled for only a single architecture.
+
+        See also https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html.
+        """
+        with open(self.CMAKE_BINARY_DIR / 'compile_commands.json', 'r', encoding = 'utf-8') as fin:
+            commands = json.load(fin)
+        target_source = next(self.target_sources)
+        logging.info(f'Looking for {target_source} in {commands}')
+        archs = get_arch_from_compile_command(cmd = next(filter(
+            lambda x: str(target_source) in x['file'],
+            commands))['command']
+        )
+        assert len(archs) == 1
+        return archs.pop()
+
+    @functools.cached_property
+    @typeguard.typechecked
+    def cmake_file_api(self) -> cmake.FileAPI:
+        return cmake.FileAPI(cmake_build_directory = self.CMAKE_BINARY_DIR)
+
+    @functools.cached_property
+    @typeguard.typechecked
+    def target(self) -> dict:
+        """
+        Retrieve the target information from the CMake codemodel database.
+        """
+        return self.cmake_file_api.target(self.get_target_name())
+
+    @functools.cached_property
+    @typeguard.typechecked
+    def target_sources(self) -> typing.Iterator[pathlib.Path]:
+        """
+        Retrieve the target source from the CMake codemodel database.
+        """
+        return map(lambda source: pathlib.Path(source['path']), self.target['sources'])
+
+    @functools.cached_property
+    @typeguard.typechecked
+    def executable(self) -> pathlib.Path:
+        """
+        Retrieve the executable for the analysis from the CMake codemodel database.
+        """
+        return self.CMAKE_BINARY_DIR / self.target['paths']['build'] / self.target['nameOnDisk']
+
+    @functools.cached_property
+    @typeguard.typechecked
+    def toolchains(self) -> dict:
+        """
+        Retrieve the toolchains information from the read CMake file API.
+        """
+        return self.cmake_file_api.toolchains

--- a/python/reprospect/test/environment.py
+++ b/python/reprospect/test/environment.py
@@ -1,0 +1,33 @@
+import os
+import typing
+
+import typeguard
+
+class EnvironmentAwareMixin:
+    """
+    Base class that resolves missing instance attributes from the environment.
+
+    .. note::
+        A missing attribute is read the first time from the environment, and is then set as an attribute,
+        such that an update of the environment won't affect the attribute value in subsequent calls.
+    """
+    #: Specify convertors from environment variable values to attributes of the relevant types.
+    _REQUIRED_ATTRIBUTES_WITH_DEFAULT_FROM_ENV : typing.ClassVar[dict[str, typing.Callable[[str], typing.Any]]] = {}
+
+    @typeguard.typechecked
+    @classmethod
+    def read_from_env(cls, name : str) -> typing.Any:
+        value = os.getenv(name)
+        if value is None:
+            raise AttributeError(f'{cls.__name__} has no attribute {name!r} and there is no environment variable {name!r}.')
+
+        if name in cls._REQUIRED_ATTRIBUTES_WITH_DEFAULT_FROM_ENV:
+            value = cls._REQUIRED_ATTRIBUTES_WITH_DEFAULT_FROM_ENV[name](value)
+
+        setattr(cls, name, value)
+
+        return value
+
+    @typeguard.typechecked
+    def __getattr__(self, name : str) -> typing.Any:
+        return self.read_from_env(name)

--- a/tests/python/test/test_environment.py
+++ b/tests/python/test/test_environment.py
@@ -2,20 +2,20 @@ import os
 
 import pytest
 
-from reprospect.test.case import EnvironmentAware
+from reprospect.test.environment import EnvironmentAwareMixin
 
-class TestEnvironmentAware:
+class TestEnvironmentAwareMixin:
     """
-    Tests for :py:class:`reprospect.test.case.EnvironmentAware`.
+    Tests for :py:class:`reprospect.test.environment.EnvironmentAwareMixin`.
     """
-    class MyClass(EnvironmentAware):
+    class MyClass(EnvironmentAwareMixin):
         def __init__(self):
             self.my_var = 42
 
     @pytest.fixture(scope = 'function')
     @staticmethod
     def instance():
-        return TestEnvironmentAware.MyClass()
+        return TestEnvironmentAwareMixin.MyClass()
 
     def test_is_attribute(self, instance):
         """

--- a/tests/python/test/test_saxpy.py
+++ b/tests/python/test/test_saxpy.py
@@ -1,4 +1,5 @@
 import pathlib
+import typing
 
 import pytest
 import typeguard
@@ -10,7 +11,7 @@ from reprospect.tools          import ncu
 from reprospect.tools.sass     import Decoder
 from reprospect.utils          import detect
 
-class TestSaxpy(reprospect.TestCase):
+class TestSaxpy(reprospect.CMakeAwareTestCase):
     """
     General test class.
     """
@@ -18,10 +19,11 @@ class TestSaxpy(reprospect.TestCase):
 
     TARGET_SOURCE = pathlib.Path('tests') / 'cpp' / 'cuda' / 'test_saxpy.cpp'
 
-    @property
+    @classmethod
+    @typing.override
     @typeguard.typechecked
-    def executable(self) -> pathlib.Path:
-        return self.CMAKE_BINARY_DIR / self.TARGET_SOURCE.parent / self.NAME
+    def get_target_name(cls) -> str:
+        return 'tests_cpp_cuda_saxpy'
 
 class TestSASS(TestSaxpy):
     """

--- a/tests/python/utils/test_cmake.py
+++ b/tests/python/utils/test_cmake.py
@@ -73,6 +73,9 @@ class TestFileAPI:
             assert 'build'  in target['paths']
             assert 'source' in target['paths']
             assert 'nameOnDisk' in target
+            assert 'sources' in target
+            assert len(target['sources']) == 1
+            assert 'path' in target['sources'][0]
 
         with pytest.raises(ValueError, match = 'Target \'some-random-name\' not found.'):
             cmake_file_api.target(name = 'some-random-name')


### PR DESCRIPTION
This PR:
- uses the `CMake` file api codemodel to extract information about the targets
- uses a "Mixin" to get this info to the tests