### PR TITLE
cicd: use docker image with docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,15 +139,50 @@ jobs:
                       --registry=ghcr.io \
                       --repository=${{ github.repository }} >> $GITHUB_OUTPUT
 
-    build-images:
-        needs: [setup-job-matrix, setup-skips]
+    build-images-image:
+        needs: [setup-skips]
         runs-on: [self-hosted, linux, docker, amd64]
         container:
             image: docker:latest
         permissions:
             contents: read
             packages: write
-            pull-requests: read
+        if: ${{ needs.setup-skips.outputs.build-images == 'true' }}
+        steps:
+            - uses: actions/checkout@v5
+
+            - uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - uses: docker/setup-qemu-action@v3
+
+            - uses: docker/setup-buildx-action@v3
+
+            - uses: docker/build-push-action@v6.18.0
+              with:
+                  context: null
+                  platforms: linux/amd64,linux/arm64
+                  push: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs['build-images']) }}
+                  file: docker/dockerfile.build-images
+                  tags: ghcr.io/${{ github.repository }}/build-images:latest
+                  cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/build-images:latest
+                  cache-to: type=inline
+                  labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
+
+    build-images:
+        needs: [setup-job-matrix, build-images-image, setup-skips]
+        runs-on: [self-hosted, linux, docker, amd64]
+        container:
+            image: ghcr.io/${{ github.repository }}/build-images:latest
+        services:
+            docker:
+                image: docker:dind
+        permissions:
+            contents: read
+            packages: write
         strategy:
             fail-fast: false
             matrix:

--- a/docker/dockerfile.build-images
+++ b/docker/dockerfile.build-images
@@ -1,0 +1,11 @@
+FROM ubuntu:24.04@sha256:66460d557b25769b102175144d538d88219c077c678a49af4afca6fbfc1b5252
+
+RUN <<EOF
+    set -ex
+
+    apt update
+
+    apt --yes install docker.io
+
+    apt clean && rm -rf /var/lib/apt/lists/*
+EOF


### PR DESCRIPTION
Extracted from #143.

The idea is that we cannot use the `docker:latest` image because for our `ARM64` runner, we hit many issues related to https://github.com/actions/runner/pull/3665 (the problem is mainly due to Alpine support).

Instead, we use a `ubuntu:24.04` image with `docker` inside.