### PR TITLE
Utils: use our own dictionaries in `Cmake` file `API`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,7 @@ jobs:
               with:
                   context: .
                   platforms: ${{ matrix.platform }}
-                  push: true # ${{ github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs['build-images']) }}
+                  push: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs['build-images']) }}
                   file: docker/dockerfile
                   tags: ${{ matrix.image }}
                   cache-from: type=registry,ref=${{ matrix.image }}
@@ -222,7 +222,7 @@ jobs:
               with:
                   context: .
                   platforms: ${{ matrix.platform }}
-                  push: true # ${{ github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs['build-images']) }}
+                  push: ${{ github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs['build-images']) }}
                   file: docker/dockerfile.kokkos
                   tags: ${{ matrix.kokkos }}
                   cache-from: type=registry,ref=${{ matrix.kokkos }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ include(cmake/modules/Warnings.cmake)
 cmake_file_api(QUERY API_VERSION 1
   CACHE 2
   TOOLCHAINS 1
+  CODEMODEL 2
 )
 
 if(ReProspect_ENABLE_TESTS)

--- a/python/reprospect/utils/cmake.py
+++ b/python/reprospect/utils/cmake.py
@@ -1,4 +1,5 @@
 import functools
+import json
 import pathlib
 
 import cmake_file_api
@@ -7,22 +8,29 @@ import typeguard
 
 class FileAPI:
     """
-    Thin wrapper for https://github.com/madebr/python-cmake-file-api.
+    Retrieve information about the CMake buildsystem.
+
+    References:
+
+    * https://cmake.org/cmake/help/latest/manual/cmake-file-api.7.html
+    * https://github.com/madebr/python-cmake-file-api.
     """
     CACHE_VERSION = 2
     TOOLCHAINS_VERSION = 1
+    CODEMODEL_VERSION = 2
 
-    typeguard.typechecked
-    def __init__(self, build_path : pathlib.Path) -> None:
-        """
-        Use our wrapper for cache variables and toolchain information.
-        """
-        self.reader = cmake_file_api.reply.v1.api.CMakeFileApiV1(build_path = build_path)
+    @typeguard.typechecked
+    def __init__(self, cmake_build_directory : pathlib.Path) -> None:
+        self.reader = cmake_file_api.reply.v1.api.CMakeFileApiV1(build_path = cmake_build_directory)
+        self.cmake_reply_path = cmake_build_directory / '.cmake' / 'api' / 'v1' / 'reply'
 
     @functools.cached_property
     @typeguard.typechecked
     def cache(self) -> dict:
-        cache_json = self.reader._create_reply_path() / self.reader.index().reply.stateless[(cmake_file_api.kinds.kind.ObjectKind.CACHE, self.CACHE_VERSION)].jsonFile
+        """
+        Retrieve the CMake cache.
+        """
+        cache_json = self.cmake_reply_path / self.reader.index().reply.stateless[(cmake_file_api.kinds.kind.ObjectKind.CACHE, self.CACHE_VERSION)].jsonFile
 
         with cache_json.open('rb') as file:
             entries = ijson.items(file, 'entries.item')
@@ -34,7 +42,10 @@ class FileAPI:
     @functools.cached_property
     @typeguard.typechecked
     def toolchains(self) -> dict:
-        toolchains_json = self.reader._create_reply_path() / self.reader.index().reply.stateless[(cmake_file_api.kinds.kind.ObjectKind.TOOLCHAINS, self.TOOLCHAINS_VERSION)].jsonFile
+        """
+        Retrieve the toolchains information.
+        """
+        toolchains_json = self.cmake_reply_path / self.reader.index().reply.stateless[(cmake_file_api.kinds.kind.ObjectKind.TOOLCHAINS, self.TOOLCHAINS_VERSION)].jsonFile
 
         with toolchains_json.open('rb') as file:
             toolchains = ijson.items(file, 'toolchains.item')
@@ -42,3 +53,32 @@ class FileAPI:
                 toolchain['language']: {k: v for k, v in toolchain.items() if k != 'language'}
                 for toolchain in toolchains
             }
+
+    @functools.cached_property
+    @typeguard.typechecked
+    def codemodel_configuration(self) -> dict:
+        """
+        Retrieve the codemodel information, and extract the information available for the build configuration.
+
+        This function assumes that there is only a single build configuration.
+        """
+        codemodel_json = self.cmake_reply_path / self.reader.index().reply.stateless[(cmake_file_api.kinds.kind.ObjectKind.CODEMODEL, self.CODEMODEL_VERSION)].jsonFile
+
+        with codemodel_json.open('rb') as file:
+            configurations = list(ijson.items(file, 'configurations.item'))
+
+        assert len(configurations) == 1, "Handling of multiple CMake configurations not implemented."
+
+        return configurations[0]
+
+    @functools.lru_cache(maxsize = 128)
+    @typeguard.typechecked
+    def target(self, name : str) -> dict:
+        """
+        Retrieve the information available for the target `name`.
+        """
+        for target in self.codemodel_configuration['targets']:
+            if target['name'] == name:
+                with (self.cmake_reply_path / target['jsonFile']).open() as file:
+                    return json.load(file)
+        raise ValueError(f'Target {name!r} not found.')

--- a/tests/python/test/test_graph.py
+++ b/tests/python/test/test_graph.py
@@ -35,7 +35,7 @@ class TestGraph(reprospect.TestCase):
     @typeguard.typechecked
     def cmake_cuda_compiler(cls) -> dict:
         return cmake.FileAPI(
-            build_path = cls.CMAKE_BINARY_DIR
+            cmake_build_directory = cls.CMAKE_BINARY_DIR
         ).toolchains['CUDA']['compiler']
 
 class TestSASS(TestGraph):

--- a/tests/python/tools/test_binaries.py
+++ b/tests/python/tools/test_binaries.py
@@ -22,7 +22,7 @@ TMPDIR = pathlib.Path(os.environ['CMAKE_CURRENT_BINARY_DIR']) if 'CMAKE_CURRENT_
 @typeguard.typechecked
 def cmake_file_api() -> cmake.FileAPI:
     return cmake.FileAPI(
-        build_path = pathlib.Path(os.environ['CMAKE_BINARY_DIR']),
+        cmake_build_directory = pathlib.Path(os.environ['CMAKE_BINARY_DIR']),
     )
 
 def test_get_arch_from_compile_command(cmake_file_api) -> None:

--- a/tests/python/tools/test_sass.py
+++ b/tests/python/tools/test_sass.py
@@ -40,7 +40,7 @@ ISETP_NE_U32_AND = \
 @typeguard.typechecked
 def cmake_file_api() -> cmake.FileAPI:
     return cmake.FileAPI(
-        build_path = pathlib.Path(os.environ['CMAKE_BINARY_DIR']),
+        cmake_build_directory = pathlib.Path(os.environ['CMAKE_BINARY_DIR']),
     )
 
 class TestSASSDecoder:


### PR DESCRIPTION
- The motivation is to read as efficiently as possible from the `CMake` json files. This will become especially needed later when we'll read the code model as well.
- To further optimize read time, this PR also installs the `ijson` package.