### PR TITLE
pylintrc: enable `useless-suppression`

### DIFF
--- a/python/reprospect/.pylintrc
+++ b/python/reprospect/.pylintrc
@@ -1,4 +1,6 @@
 [MESSAGES CONTROL]
+enable=useless-suppression
+
 disable=
     line-too-long,
     logging-fstring-interpolation,


### PR DESCRIPTION
It is disabled by default, see https://pylint.readthedocs.io/en/latest/user_guide/messages/information/useless-suppression.html.