### PR TITLE
test(sass): atomic cas operands missing

### DIFF
--- a/python/reprospect/test/sass.py
+++ b/python/reprospect/test/sass.py
@@ -127,9 +127,9 @@ class PatternBuilder:
         if modifiers:
             for modifier in filter(None, modifiers):
                 if isinstance(modifier, str) and modifier.startswith('?'):
-                    opcode += PatternBuilder.optional('.' + PatternBuilder.group(modifier[1::], group = 'modifiers'))
+                    opcode += PatternBuilder.optional(r'\.' + PatternBuilder.group(modifier[1::], group = 'modifiers'))
                 else:
-                    opcode += '.' + PatternBuilder.group(modifier, group = 'modifiers')
+                    opcode += r'\.' + PatternBuilder.group(modifier, group = 'modifiers')
         return opcode
 
     @classmethod
@@ -480,7 +480,7 @@ class AtomicMatcher(ArchitectureAwarePatternMatcher):
         #   {pred}, {dest}, [{addr}], {compare}, {newval}
         match self.params.operation:
             case 'CAS':
-                operands = rf'PT, {PatternBuilder.regz()}, {{addr}}, {PatternBuilder.reg()}, {PatternBuilder.reg()}'
+                operands = rf'{PatternBuilder.predt()}, {PatternBuilder.regz()}, {{addr}}, {PatternBuilder.reg()}, {PatternBuilder.reg()}'
                 dtype = [self.params.dtype[1]] if self.params.dtype is not None and self.params.dtype[1] > 32 else []
             case _:
                 operands = rf'{PatternBuilder.predt()}, {PatternBuilder.regz()}, {{addr}}, {PatternBuilder.reg()}'

--- a/tests/python/test/sass/test_atomic.py
+++ b/tests/python/test/sass/test_atomic.py
@@ -173,7 +173,8 @@ __global__ void cas(My128Struct* __restrict__ const dst, const My128Struct* __re
         assert len(matched.captures('opcode')) == 1
         assert 'modifiers' in matched.capturesdict()
         assert len(matched.captures('address')) == 1
-        assert len(matched.captures('operands')) == 4
+        assert len(matched.captures('operands')) == 5
+        assert matched.captures('operands')[0] == 'PT'
 
     def test_atomicCAS_128(self, request, parameters : Parameters, cmake_file_api : cmake.FileAPI):
         """


### PR DESCRIPTION
Will conflict with #168 so it will come **after** in the merge train :train: 