### PR TITLE
cicd: add ubuntu 22.04 case

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,6 +216,7 @@ jobs:
                       CXX_COMPILER=${{ matrix.compilers.CXX.path }}
                       DOXYGEN_VERSION=1_14_0
                       GOOGLEBENCHMARK_VERSION=1.9.4
+                      PYTHON_VERSION=${{ matrix.ubuntu_version == '24.04' && '3.12' || '3.10' }}
                   labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 
             - uses: docker/build-push-action@v6.18.0

--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -16,25 +16,28 @@ AVAILABLE_RUNNER_ARCHES = (
 )
 
 @typeguard.typechecked
-def get_base_name_tag_digest(version : str) -> tuple[str, str, str]:
+def get_base_name_tag_digest(cuda_version : str, ubuntu_version : str) -> tuple[str, str, str]:
     """
     Get `Docker` base image name, tag and digest.
     """
-    match version:
-        case '12.6.3':
-            tag = f'{version}-devel-ubuntu24.04'
+    match (cuda_version, ubuntu_version):
+        case ('12.6.3', '22.04'):
+            tag = f'12.6.3-devel-ubuntu22.04'
+            digest = 'sha256:d49bb8a4ff97fb5fe477947a3f02aa8c0a53eae77e11f00ec28618a0bcaa2ad1'
+        case ('12.6.3', '24.04'):
+            tag = f'12.6.3-devel-ubuntu24.04'
             digest = 'sha256:badf6c452e8b1efea49d0bb956bef78adcf60e7f87ac77333208205f00ac9ade'
-        case '12.8.1':
-            tag = f'{version}-devel-ubuntu24.04'
+        case ('12.8.1', '24.04'):
+            tag = f'12.8.1-devel-ubuntu24.04'
             digest = 'sha256:520292dbb4f755fd360766059e62956e9379485d9e073bbd2f6e3c20c270ed66'
-        case '13.0.0':
-            tag = f'{version}-devel-ubuntu24.04'
+        case ('13.0.0', '24.04'):
+            tag = f'13.0.0-devel-ubuntu24.04'
             digest = 'sha256:1e8ac7a54c184a1af8ef2167f28fa98281892a835c981ebcddb1fad04bdd452d'
-        case '13.0.1':
-            tag = f'{version}-devel-ubuntu24.04'
+        case ('13.0.1', '24.04'):
+            tag = f'13.0.1-devel-ubuntu24.04'
             digest = 'sha256:7d2f6a8c2071d911524f95061a0db363e24d27aa51ec831fcccf9e76eb72bc92'
         case _:
-            raise ValueError(version)
+            raise ValueError((cuda_version, ubuntu_version))
     return ('nvidia/cuda', tag, digest)
 
 @dataclasses.dataclass
@@ -102,7 +105,7 @@ def complete_job_impl(*, partial : dict, args : argparse.Namespace) -> dict:
     # Name and tag of the image.
     name = 'cuda-' + '-'.join(list(dict.fromkeys([partial['compilers']['CXX'].ID, partial['compilers']['CXX'].version, partial['compilers']['CUDA'].ID])))
 
-    base_name, base_tag, base_digest = get_base_name_tag_digest(version = partial['cuda_version'])
+    base_name, base_tag, base_digest = get_base_name_tag_digest(cuda_version = partial['cuda_version'], ubuntu_version = partial['ubuntu_version'])
 
     arch = NVIDIAArch.from_compute_capability(cc = partial.pop('nvidia_compute_capability'))
     partial['nvidia_arch'] = str(arch)
@@ -189,6 +192,7 @@ def main(*, args : argparse.Namespace) -> None:
 
     matrix.extend(complete_job({
         'cuda_version' : '12.8.1',
+        'ubuntu_version' : '24.04',
         'compilers' : {'CXX' : Compiler(ID = 'gnu', version = '13'), 'CUDA' : Compiler(ID = 'nvidia')},
         'nvidia_compute_capability' : 70,
         'platforms' : ['linux/amd64', 'linux/arm64'],
@@ -196,6 +200,7 @@ def main(*, args : argparse.Namespace) -> None:
 
     matrix.extend(complete_job({
         'cuda_version' : '13.0.1',
+        'ubuntu_version' : '24.04',
         'compilers' : {'CXX' : Compiler(ID = 'gnu', version = '14'), 'CUDA' : Compiler(ID = 'nvidia')},
         'nvidia_compute_capability' : 120,
         'platforms' : ['linux/amd64', 'linux/arm64'],
@@ -203,22 +208,31 @@ def main(*, args : argparse.Namespace) -> None:
 
     matrix.extend(complete_job({
         'cuda_version' : '12.6.3',
+        'ubuntu_version' : '22.04',
+        'compilers' : {'CXX' : Compiler(ID = 'gnu', version = '12'), 'CUDA' : Compiler(ID = 'nvidia')},
+        'nvidia_compute_capability' : 75,
+        'platforms' : ['linux/amd64'],
+    }, args = args))
+
+    matrix.extend(complete_job({
+        'cuda_version' : '12.6.3',
+        'ubuntu_version' : '24.04',
         'compilers' : {'CXX' : Compiler(ID = 'gnu', version = '13'), 'CUDA' : Compiler(ID = 'nvidia')},
         'nvidia_compute_capability' : 89,
         'platforms' : ['linux/amd64'],
-        'tests' : True,
     }, args = args))
 
     matrix.extend(complete_job({
         'cuda_version' : '13.0.0',
+        'ubuntu_version' : '24.04',
         'compilers' : {'CXX' : Compiler(ID = 'gnu', version = '14'), 'CUDA' : Compiler(ID = 'nvidia')},
         'nvidia_compute_capability' : 86,
         'platforms' : ['linux/amd64'],
-        'tests' : True,
     }, args = args))
 
     matrix.extend(complete_job({
         'cuda_version' : '12.8.1',
+        'ubuntu_version' : '24.04',
         'compilers' : {'CXX' : Compiler(ID = 'clang', version = '19'), 'CUDA' : Compiler(ID = 'nvidia')},
         'nvidia_compute_capability' : 70,
         'platforms' : ['linux/amd64'],
@@ -226,6 +240,7 @@ def main(*, args : argparse.Namespace) -> None:
 
     matrix.extend(complete_job({
         'cuda_version' : '13.0.0',
+        'ubuntu_version' : '24.04',
         'compilers' : {'CXX' : Compiler(ID = 'clang', version = '20'), 'CUDA' : Compiler(ID = 'nvidia')},
         'nvidia_compute_capability' : 120,
         'platforms' : ['linux/amd64'],
@@ -233,6 +248,7 @@ def main(*, args : argparse.Namespace) -> None:
 
     matrix.extend(complete_job({
         'cuda_version' : '12.8.1',
+        'ubuntu_version' : '24.04',
         'compilers' : {'CXX' : Compiler(ID = 'clang', version = '21')},
         'nvidia_compute_capability' : 120,
         'platforms' : ['linux/amd64'],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.28 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.27 FATAL_ERROR)
 
 # Retrieve the version.
 file(READ "${CMAKE_SOURCE_DIR}/python/reprospect/__init__.py" VERSION_FILE_CONTENTS)
@@ -18,7 +18,7 @@ set(CMAKE_CXX_STANDARD 20)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-find_package(Python 3.12 REQUIRED Interpreter)
+find_package(Python 3.10 REQUIRED Interpreter)
 
 include(cmake/functions/environment.cmake)
 include(cmake/functions/path_helper.cmake)
@@ -26,7 +26,8 @@ include(cmake/modules/detect.cmake)
 include(cmake/modules/Warnings.cmake)
 
 # Ask CMake to dump file-based detailed information about the build system.
-# See also https://cmake.org/cmake/help/latest/manual/cmake-file-api.7.html
+# See also https://cmake.org/cmake/help/latest/manual/cmake-file-api.7.html.
+# Note that this requires CMake 3.27 or newer.
 cmake_file_api(QUERY API_VERSION 1
   CACHE 2
   TOOLCHAINS 1

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -31,6 +31,15 @@ RUN --mount=target=/requirements/requirements.system.txt,type=bind,source=requir
     set -ex
 
     apt-helpers install-packages --update --clean --requirement /requirements/requirements.system.txt
+
+    # CMake.
+    apt-helpers install-packages --update --packages ca-certificates lsb-release gpg wget
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+    apt update
+    rm /usr/share/keyrings/kitware-archive-keyring.gpg
+    apt-helpers install-packages --packages kitware-archive-keyring
+    apt-helpers install-packages --clean --packages cmake
 EOF
 
 # Install Clang compiler.

--- a/examples/kokkos/view/example_allocation.py
+++ b/examples/kokkos/view/example_allocation.py
@@ -1,6 +1,6 @@
-import enum
 import logging
 import math
+import sys
 import typing
 
 import numpy
@@ -12,7 +12,17 @@ import reprospect
 from reprospect.tools import nsys
 from reprospect.utils import detect
 
-class Memory(enum.StrEnum):
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+class Memory(StrEnum):
     DEVICE = 'DEVICE'
     SHARED = 'MANAGED'
 
@@ -21,7 +31,7 @@ class TestAllocation(reprospect.CMakeAwareTestCase):
     Explore the behavior of `Kokkos::View` allocation under different scenarios.
     """
     @classmethod
-    @typing.override
+    @override
     @typeguard.typechecked
     def get_target_name(cls) -> str:
         return 'examples_kokkos_view_allocation'
@@ -99,8 +109,8 @@ class TestNSYS(TestAllocation):
             cuda_api_trace_allocation   = report.get_events(table = 'CUPTI_ACTIVITY_KIND_RUNTIME', accessors = ['AllocationProfiling', memory_space, str(size), 'allocation'])
             cuda_api_trace_deallocation = report.get_events(table = 'CUPTI_ACTIVITY_KIND_RUNTIME', accessors = ['AllocationProfiling', memory_space, str(size), 'deallocation'])
 
-            logging.info(f'Events during allocation: {cuda_api_trace_allocation['name']}.')
-            logging.info(f'Events during deallocation: {cuda_api_trace_deallocation['name']}.')
+            logging.info(f"Events during allocation: {cuda_api_trace_allocation['name']}.")
+            logging.info(f"Events during deallocation: {cuda_api_trace_deallocation['name']}.")
 
             # Allocation goes through the expected Cuda API calls.
             assert len(cuda_api_trace_allocation['name']) == len(expt_cuda_api_calls_allocation)

--- a/python/reprospect/test/sass.py
+++ b/python/reprospect/test/sass.py
@@ -36,6 +36,7 @@ References:
 import abc
 import dataclasses
 import os
+import sys
 import types
 import typing
 
@@ -45,6 +46,11 @@ import typeguard
 
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.tools.sass         import Instruction
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 class PatternBuilder:
     """
@@ -150,7 +156,7 @@ class PatternBuilder:
             pattern += cls.optional(cls.OFFSET)
         elif offset is True:
             pattern += cls.OFFSET
-        return rf'\[{cls.group(pattern, groups = ['operands', 'address'])}\]'
+        return rf"\[{cls.group(pattern, groups = ['operands', 'address'])}\]"
 
     @classmethod
     @typeguard.typechecked
@@ -168,7 +174,7 @@ class PatternBuilder:
             pattern += cls.optional(cls.OFFSET)
         elif offset is True:
             pattern += cls.OFFSET
-        return rf'\[({cls.group(pattern, groups = ['operands', 'address'])})\]'
+        return rf"\[({cls.group(pattern, groups = ['operands', 'address'])})\]"
 
     @classmethod
     @typeguard.typechecked
@@ -223,7 +229,7 @@ class PatternMatcher(Matcher):
     """
     pattern : str | regex.Pattern
 
-    @typing.override
+    @override
     @typeguard.typechecked
     def matches(self, inst : Instruction | str) -> typing.Optional[regex.Match]:
         if isinstance(inst, str):
@@ -314,7 +320,7 @@ class LoadGlobalMatcher(ArchitectureAwarePatternMatcher):
         self.params = types.SimpleNamespace(size = size, cache = cache)
         super().__init__(arch = arch)
 
-    @typing.override
+    @override
     @typeguard.typechecked
     def _build_pattern(self) -> str:
         match self.arch.compute_capability.as_int:
@@ -346,7 +352,7 @@ class StoreGlobalMatcher(ArchitectureAwarePatternMatcher):
         self.params = types.SimpleNamespace(size = size)
         super().__init__(arch = arch)
 
-    @typing.override
+    @override
     @typeguard.typechecked
     def _build_pattern(self) -> str:
         match self.arch.compute_capability.as_int:
@@ -423,6 +429,8 @@ class ReductionMatcher(ArchitectureAwarePatternMatcher):
         )
         super().__init__(arch = arch)
 
+    @override
+    @typeguard.typechecked
     def _build_pattern(self) -> str:
         if self.params.dtype is not None:
             match self.params.dtype[0]:
@@ -498,6 +506,8 @@ class AtomicMatcher(VersionAwarePatternMixin, ArchitectureAwarePatternMatcher):
         VersionAwarePatternMixin.__init__(self, version = version)
         ArchitectureAwarePatternMatcher.__init__(self, arch = arch)
 
+    @override
+    @typeguard.typechecked
     def _build_pattern(self) -> str: # pylint: disable=too-many-branches
         # CAS has a different operand structure.
         # For instance:

--- a/python/reprospect/tools/architecture.py
+++ b/python/reprospect/tools/architecture.py
@@ -1,11 +1,16 @@
 import dataclasses
-import enum
 import functools
 import re
+import sys
 import typing
 
 import semantic_version
 import typeguard
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
 
 @functools.total_ordering
 @dataclasses.dataclass(frozen = True, slots = True)
@@ -94,7 +99,7 @@ class ComputeCapability:
         """
         return version in self.CUDA_SUPPORT[self.as_int]
 
-class NVIDIAFamily(enum.StrEnum):
+class NVIDIAFamily(StrEnum):
     """
     Supported NVIDIA architecture families.
     """

--- a/python/reprospect/tools/binaries.py
+++ b/python/reprospect/tools/binaries.py
@@ -1,11 +1,11 @@
 import abc
 import dataclasses
-import enum
 import io
 import logging
 import pathlib
 import re
 import subprocess
+import sys
 import textwrap
 import typing
 
@@ -16,6 +16,16 @@ import rich.table
 import typeguard
 
 from reprospect.tools.architecture import NVIDIAArch
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from backports.strenum import StrEnum
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 PATTERNS = [
     re.compile(r'-arch=sm_(\d+)'),
@@ -61,8 +71,8 @@ class CuppFilt(DemanglerMixin):
     """
     Convenient wrapper for ``cu++filt``.
     """
-    @typing.override
     @classmethod
+    @override
     @typeguard.typechecked
     def get_executable(cls) -> str:
         return 'cu++filt'
@@ -71,13 +81,13 @@ class LlvmCppFilt(DemanglerMixin):
     """
     Convenient wrapper for ``llvm-cxxfilt``.
     """
-    @typing.override
     @classmethod
+    @override
     @typeguard.typechecked
     def get_executable(cls) -> str:
         return 'llvm-cxxfilt'
 
-class ResourceUsage(enum.StrEnum):
+class ResourceUsage(StrEnum):
     """
     Support for resource usage fields.
 

--- a/python/reprospect/tools/cacher.py
+++ b/python/reprospect/tools/cacher.py
@@ -128,7 +128,7 @@ class Cacher:
 
                 self.populate(directory = directory, **kwargs)
 
-                entry = Cacher.Entry(cached = False, digest = hexdigest, timestamp = datetime.datetime.now(datetime.UTC), directory = directory)
+                entry = Cacher.Entry(cached = False, digest = hexdigest, timestamp = datetime.datetime.now(datetime.timezone.utc), directory = directory)
 
                 cursor.execute(
                     f'REPLACE INTO {self.TABLE} (hash, timestamp) VALUES (?, ?)',

--- a/python/reprospect/tools/nsys.py
+++ b/python/reprospect/tools/nsys.py
@@ -9,6 +9,7 @@ import shlex
 import shutil
 import sqlite3
 import subprocess
+import sys
 import typing
 
 import blake3
@@ -19,6 +20,11 @@ import typeguard
 from reprospect.tools import cacher
 from reprospect.utils import ldd
 from reprospect.utils import rich_helpers
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 class Session:
     """
@@ -298,13 +304,13 @@ class Report:
 
             return self.events.iloc[sorted(previous)]
 
-        @typing.override
+        @override
         @typeguard.typechecked
         def to_tree(self) -> rich.tree.Tree:
             @typeguard.typechecked
             def add_branch(*, tree : rich.tree.Tree, nodes : pandas.DataFrame) -> None:
                 for _, node in nodes.iterrows():
-                    branch = tree.add(f'{node['text']} ({node['eventTypeName']})')
+                    branch = tree.add(f"{node['text']} ({node['eventTypeName']})")
                     if node['children'].any():
                         add_branch(tree = branch, nodes = self.events.loc[node['children']])
 
@@ -404,7 +410,7 @@ ORDER BY NVTX_EVENTS.start ASC, NVTX_EVENTS.end DESC
 
         filtered = filtered.squeeze()
 
-        logging.info(f'Events will be filtered in the time frame {filtered['start']} -> {filtered['end']}.')
+        logging.info(f"Events will be filtered in the time frame {filtered['start']} -> {filtered['end']}.")
 
         query = f"""
 SELECT
@@ -454,7 +460,7 @@ class Cacher(cacher.Cacher):
         super().__init__(directory = directory if directory is not None else pathlib.Path(os.environ['HOME']) / '.nsys-cache')
         self.session = session
 
-    @typing.override
+    @override
     @typeguard.typechecked
     def hash(self, *, # pylint: disable=arguments-differ
         executable : pathlib.Path,
@@ -501,6 +507,7 @@ class Cacher(cacher.Cacher):
 
         return hasher
 
+    @override
     @typeguard.typechecked
     def populate(self, directory : pathlib.Path, **kwargs) -> Session.Command:
         """

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,4 @@
+backports.strenum
 blake3
 cmake_file_api @ git+https://github.com/madebr/python-cmake-file-api@v0.0.8.3
 ijson
@@ -7,3 +8,4 @@ rich
 semantic_version
 system-helpers @ git+https://github.com/uliegecsm/system-helpers@0.0.3
 typeguard
+typing-extensions>=4.4.0

--- a/python/setup.py
+++ b/python/setup.py
@@ -12,6 +12,7 @@ requirements = filter(None, requirements.read_text().splitlines())
 setup(
     name             = 'reprospect',
     version          = version,
+    python_requires  = '>=3.10',
     license          = 'MIT',
     url              = 'https://github.com/uliegecsm/reprospect',
     install_requires = [

--- a/requirements/requirements.python.txt
+++ b/requirements/requirements.python.txt
@@ -2,7 +2,7 @@ matplotlib
 myst-nb>=1.3.0
 nvtx>=0.2.13
 pylint>=4.0.1
-sphinx>=8.2
+sphinx>=8.1
 sphinx-rtd-theme>=3.0.2
 sphinx-github-style>=1.2.2
 sphinxcontrib-bibtex>=2.6.5

--- a/requirements/requirements.system.txt
+++ b/requirements/requirements.system.txt
@@ -1,4 +1,3 @@
 ccache
-cmake
 pdf2svg
 texlive-latex-extra

--- a/tests/python/test/sass/test_atomic.py
+++ b/tests/python/test/sass/test_atomic.py
@@ -194,7 +194,7 @@ __global__ void cas(My128Struct* __restrict__ const dst, const My128Struct* __re
                 logging.warning('The 128-bit atomicCAS() does not compile with Clang.')
                 expecting_failure = True
             case _:
-                raise ValueError(f'unsupported compiler {cmake_file_api.toolchains['CUDA']['compiler']}')
+                raise ValueError(f"unsupported compiler {cmake_file_api.toolchains['CUDA']['compiler']}")
 
         kwargs = {'arch' : parameters.arch, 'file' : FILE, 'cmake_file_api' : cmake_file_api}
 

--- a/tests/python/test/test_graph.py
+++ b/tests/python/test/test_graph.py
@@ -1,6 +1,6 @@
 import logging
 import pathlib
-import typing
+import sys
 
 import pytest
 import typeguard
@@ -12,12 +12,17 @@ from reprospect.tools          import ncu
 from reprospect.tools.sass     import Decoder
 from reprospect.utils          import detect
 
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
 class TestGraph(reprospect.CMakeAwareTestCase):
     """
     General test class.
     """
     @classmethod
-    @typing.override
+    @override
     @typeguard.typechecked
     def get_target_name(cls) -> str:
         return 'tests_cpp_cuda_graph'

--- a/tests/python/test/test_saxpy.py
+++ b/tests/python/test/test_saxpy.py
@@ -1,5 +1,5 @@
 import pathlib
-import typing
+import sys
 
 import pytest
 import typeguard
@@ -11,6 +11,11 @@ from reprospect.tools          import ncu
 from reprospect.tools.sass     import Decoder
 from reprospect.utils          import detect
 
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
 class TestSaxpy(reprospect.CMakeAwareTestCase):
     """
     General test class.
@@ -20,7 +25,7 @@ class TestSaxpy(reprospect.CMakeAwareTestCase):
     TARGET_SOURCE = pathlib.Path('tests') / 'cpp' / 'cuda' / 'test_saxpy.cpp'
 
     @classmethod
-    @typing.override
+    @override
     @typeguard.typechecked
     def get_target_name(cls) -> str:
         return 'tests_cpp_cuda_saxpy'

--- a/tests/python/tools/test_binaries.py
+++ b/tests/python/tools/test_binaries.py
@@ -82,7 +82,7 @@ def get_compilation_output(*,
             case 'Clang':
                 cmd += ['-x', 'cuda']
             case _:
-                raise ValueError(f'unsupported compiler ID {cmake_file_api.toolchains['CUDA']['compiler']['id']}')
+                raise ValueError(f"unsupported compiler ID {cmake_file_api.toolchains['CUDA']['compiler']['id']}")
 
     # Clang tends to add a lot of debug code otherwise.
     cmd.append('-O3')
@@ -103,7 +103,7 @@ def get_compilation_output(*,
             if resource_usage:
                 cmd += ['-Xcuda-ptxas', '-v',]
         case _:
-            raise ValueError(f'unsupported compiler ID {cmake_file_api.toolchains['CUDA']['compiler']['id']}')
+            raise ValueError(f"unsupported compiler ID {cmake_file_api.toolchains['CUDA']['compiler']['id']}")
 
     cmd += [
         '-c', source,

--- a/tests/python/tools/test_ncu.py
+++ b/tests/python/tools/test_ncu.py
@@ -193,7 +193,7 @@ class TestSession:
                 assert NODE_A_MANGLED + '-0' in results.keys()
                 assert all(f'add_and_increment_kernel-{idx}' in results.keys() for idx in range(1, 4))
             case _:
-                raise ValueError(f'unsupported compiler ID {cmake_cuda_compiler['id']}')
+                raise ValueError(f"unsupported compiler ID {cmake_cuda_compiler['id']}")
 
         # Check global load/store for each node, and aggregated as well.
         SIGNATURES = {

--- a/tests/python/utils/test_cmake.py
+++ b/tests/python/utils/test_cmake.py
@@ -44,9 +44,9 @@ class TestFileAPI:
         for language, toolchain in cmake_file_api.toolchains.items():
             compiler = toolchain['compiler']
             logging.info(f'For language {language}:')
-            logging.info(f'\t- compiler ID     : {compiler['id']}')
-            logging.info(f'\t- compiler path   : {compiler['path']}')
-            logging.info(f'\t- compiler version: {compiler['version']}')
+            logging.info(f"\t- compiler ID     : {compiler['id']}")
+            logging.info(f"\t- compiler path   : {compiler['path']}")
+            logging.info(f"\t- compiler version: {compiler['version']}")
 
     @typeguard.typechecked
     def test_codemodel_configuration(self, cmake_file_api) -> None:


### PR DESCRIPTION
Let's see.

These is a birds-eye view of the changes:
- On `ubuntu` 22.04, we get `Python` 3.10, so our minimum `Python` version is now set to 3.10.
- On `ubuntu` 22.04, we get `CMake` 3.22, which doesn't know `cmake_file_api`. So we now install the latest `CMake` in our images. I changed the `CMake` minimum version to 3.27, which is the oldest that can do `cmake_file_api`. 
- On `Python` 3.10, we don't have `@typing.override`. It has been back ported to `typing-extensions`. And so to keep our annotations, I replaced all of them with `@typing_extensions.override`.
- On `Python` 3.10, we don't have `enum.StrEnum`. And so we now derive from both `enum.Enum` and `str` and we add a custom `__str__` operator to get the same behavior.
- `Python` 3.10 sometimes struggles with nested quotes in strings, especially when the inner quotes read from a dictionary. So we now use single and double quotes in such cases.

References:
- https://typing-extensions.readthedocs.io/en/latest/#typing_extensions.override