### PR TITLE
test(sass): build powerful matchers by combining instruction matchers

### DIFF
--- a/docs/source/tests/python/test.rst
+++ b/docs/source/tests/python/test.rst
@@ -11,4 +11,6 @@ SASS instruction matcher
 
 .. automodule:: tests.python.test.sass.test_atomic
 
+.. automodule:: tests.python.test.sass.test_matchers
+
 .. automodule:: tests.python.test.sass.test_sass

--- a/python/reprospect/test/matchers.py
+++ b/python/reprospect/test/matchers.py
@@ -1,0 +1,139 @@
+"""
+Combine matchers from :py:mod:`reprospect.test.sass` into sequence matchers.
+"""
+
+import abc
+import dataclasses
+import itertools
+import sys
+import typing
+
+import regex
+import typeguard
+
+from reprospect.test.sass  import Matcher
+from reprospect.tools.sass import Instruction
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+class SequenceMatcher(abc.ABC):
+    """
+    Base class for matchers of a sequence of instructions.
+    """
+    @abc.abstractmethod
+    def matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match] | None:
+        pass
+
+    @abc.abstractmethod
+    def assert_matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match]:
+        pass
+
+@dataclasses.dataclass(slots = True, frozen = True)
+class InSequenceAtMatcher(SequenceMatcher):
+    """
+    Check that the element matches exactly, raise otherwise.
+    """
+    matcher : Matcher
+
+    @override
+    @typeguard.typechecked
+    def matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match] | None:
+        matched = self.matcher.matches(instructions[start])
+        return [matched] if matched is not None else None
+
+    @override
+    @typeguard.typechecked
+    def assert_matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match]:
+        matched = self.matches(instructions = instructions, start = start)
+        if matched is None:
+            raise RuntimeError(f'{self.matcher!r} did not match {instructions[start]!r}.')
+        return matched
+
+@dataclasses.dataclass(slots = True, frozen = True)
+class ZeroOrMoreInSequenceMatcher(SequenceMatcher):
+    """
+    Match zero or more times.
+    """
+    matcher : Matcher
+
+    @override
+    @typeguard.typechecked
+    def matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match] | None:
+        matches: list[regex.Match] = []
+
+        for instruction in instructions[start:]:
+            if (matched := self.matcher.matches(instruction)) is not None:
+                matches.append(matched)
+            else:
+                break
+
+        return matches
+
+    @override
+    @typeguard.typechecked
+    def assert_matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match]:
+        """
+        It is always matching.
+        """
+        return self.matches(instructions = instructions, start = start)
+
+@dataclasses.dataclass(slots = True, frozen = True)
+class OrderedInSequenceMatcher(SequenceMatcher):
+    """
+    Match a sequence of matchers in the order they are provided.
+    """
+    matchers : tuple[SequenceMatcher | Matcher]
+
+    @override
+    @typeguard.typechecked
+    def matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match] | None:
+        matches = []
+        for matcher in self.matchers:
+            if isinstance(matcher, Matcher) and (matched := matcher.matches(inst = instructions[start + len(matches)])) is not None:
+                matches.append(matched)
+            elif isinstance(matcher, SequenceMatcher) and (matched := matcher.matches(instructions = instructions, start = start + len(matches))) is not None:
+                matches.extend(matched)
+            else:
+                return None
+        return matches
+
+    @override
+    @typeguard.typechecked
+    def assert_matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match]:
+        matched = self.matches(instructions = instructions, start = start)
+        if matched is None:
+            raise RuntimeError(f'{self.matchers!r} did not match {instructions[start:start + len(self.matchers)]!r}.')
+        return matched
+
+@dataclasses.dataclass(slots = True, frozen = True)
+class UnorderedInSequenceMatcher(SequenceMatcher):
+    """
+    Match a sequence of matchers in some permutation of the order they are provided.
+    """
+    matchers : tuple[SequenceMatcher | Matcher]
+
+    @override
+    @typeguard.typechecked
+    def matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match] | None:
+        """
+        Cycle through all permutations of :py:attr:`matchers` (breaks on match).
+
+        .. note::
+
+            The implementation can be further optimized because it currently re-matches for each new permutation.
+        """
+        for permutation in itertools.permutations(self.matchers):
+            if (matched := OrderedInSequenceMatcher(matchers = permutation).matches(instructions = instructions, start = start)) is not None:
+                return matched
+        return None
+
+    @override
+    @typeguard.typechecked
+    def assert_matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match]:
+        matched = self.matches(instructions = instructions, start = start)
+        if matched is None:
+            raise RuntimeError(f'No permutation of {self.matchers!r} did match {instructions[start:start + len(self.matchers)]!r}.')
+        return matched

--- a/tests/python/test/sass/CMakeLists.txt
+++ b/tests/python/test/sass/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_pytest(atomic)
+add_pytest(matchers)
 add_pytest(sass)

--- a/tests/python/test/sass/test_matchers.py
+++ b/tests/python/test/sass/test_matchers.py
@@ -1,0 +1,198 @@
+import random
+
+import pytest
+
+from reprospect.test          import sass
+from reprospect.test.matchers import InSequenceAtMatcher, \
+                                     OrderedInSequenceMatcher, \
+                                     UnorderedInSequenceMatcher, \
+                                     ZeroOrMoreInSequenceMatcher
+from reprospect.tools.sass    import Instruction
+
+DADD = Instruction(offset = None, instruction = 'DADD R4, R4, c[0x0][0x180]', hex = None, control = None)
+DMUL = Instruction(offset = None, instruction = 'DMUL R6, R6, c[0x0][0x188]', hex = None, control = None)
+NOP  = Instruction(offset = None, instruction = 'NOP', hex = None, control = None)
+
+DADD_DMUL = (DADD, DMUL)
+"""One DADD followed by a DMUL."""
+
+DADD_NOP_DMUL = (DADD, NOP, NOP, NOP, DMUL)
+"""One DADD instruction followed by a few NOP, and a DMUL."""
+
+NOP_DMUL_NOP_DADD = (NOP, DMUL, NOP, NOP, DADD)
+"""NOP instructions with one DADD and one DMUL."""
+
+MATCHER_DADD = sass.OpcodeModsWithOperandsMatcher(instruction = 'DADD', operands = ('R4', 'R4', sass.PatternBuilder.CONSTANT))
+MATCHER_DMUL = sass.OpcodeModsWithOperandsMatcher(instruction = 'DMUL', operands = ('R6', 'R6', sass.PatternBuilder.CONSTANT))
+MATCHER_NOP  = sass.OpcodeModsMatcher(instruction = 'NOP', operands = False)
+
+class TestInSequenceAtMatcher:
+    """
+    Tests for :py:class:`reprospect.test.matchers.InSequenceAtMatcher`.
+    """
+    def test_match_first_element(self):
+        """
+        Matches the first element.
+        """
+        [matched] = InSequenceAtMatcher(matcher = MATCHER_DADD).matches(instructions = DADD_NOP_DMUL[0:1])
+
+        assert matched.group(0) == DADD.instruction
+
+    def test_match_with_start(self):
+        """
+        Matches the element pointed to by `start`.
+        """
+        [matched] = InSequenceAtMatcher(matcher = MATCHER_DADD).matches(instructions = NOP_DMUL_NOP_DADD, start = 4)
+
+        assert matched.group(0) == DADD.instruction
+
+    def test_no_match(self):
+        """
+        Raises if the first element does not match.
+        """
+        with pytest.raises(RuntimeError, match = 'did not match'):
+            InSequenceAtMatcher(matcher = MATCHER_DADD).assert_matches(instructions = list(reversed(DADD_DMUL)))
+
+class TestZeroOrMoreInSequenceMatcher:
+    """
+    Tests for :py:class:`reprospect.test.matchers.ZeroOrMoreInSequenceMatcher`.
+    """
+    def test_matches_zero(self):
+        """
+        Matches zero time with sequence :py:const:`DADD_NOP_DMUL`.
+        """
+        matched = ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP).matches(instructions = DADD_NOP_DMUL)
+
+        assert not matched
+
+    def test_assert_matches_always_true(self):
+        """
+        :py:meth:`reprospect.test.matchers.ZeroOrMoreInSequenceMatcher.assert_matches` never raises.
+        """
+        assert not ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP).assert_matches(instructions = DADD_NOP_DMUL)
+
+        assert len(ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP).assert_matches(instructions = NOP_DMUL_NOP_DADD)) == 1
+
+    def test_matches_with_start(self):
+        """
+        Matches many times, with a `start` and sequence :py:const:`DADD_NOP_DMUL`.
+        """
+        matched = ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP).matches(instructions = DADD_NOP_DMUL, start = 1)
+
+        assert len(matched) == 3 and all(x.group(0) == 'NOP' for x in matched)
+
+class TestOrderedInSequenceMatcher:
+    """
+    Tests for :py:class:`reprospect.test.matchers.OrderedInSequenceMatcher`.
+    """
+    def test_match_with_nop(self):
+        """
+        Matches the sequence :py:const:`DADD_NOP_DMUL`.
+        """
+        matched = OrderedInSequenceMatcher((
+            MATCHER_DADD,
+            ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP),
+            MATCHER_DMUL,
+        )).matches(instructions = DADD_NOP_DMUL)
+
+        assert len(matched) == 5
+        assert matched[0].group(0) == DADD.instruction
+        assert all(x.group(0) == 'NOP' for x in matched[1:-2])
+        assert matched[-1].group(0) == DMUL.instruction
+
+    def test_match(self):
+        """
+        Matches the sequence :py:const:`DADD_DMUL`.
+        """
+        matched = OrderedInSequenceMatcher(
+            matchers = (
+                MATCHER_DADD,
+                ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP),
+                MATCHER_DMUL,
+            ),
+        ).matches(instructions = DADD_DMUL)
+
+        assert len(matched) == 2
+        assert matched[0].group(0) == DADD.instruction
+        assert matched[1].group(0) == DMUL.instruction
+
+    def test_no_match(self):
+        """
+        Does not match reversed sequence :py:const:`DADD_DMUL`.
+        """
+        with pytest.raises(RuntimeError, match = 'did not match'):
+            OrderedInSequenceMatcher(
+                matchers = (
+                    MATCHER_DADD,
+                    ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP),
+                    MATCHER_DMUL,
+                ),
+            ).assert_matches(instructions = list(reversed(DADD_DMUL)))
+
+class TestUnorderedInSequenceMatcher:
+    """
+    Tests for :py:class:`reprospect.test.matchers.UnorderedInSequenceMatcher`.
+    """
+    def test_match_with_nop(self):
+        """
+        Matches the sequence :py:const:`DADD_NOP_DMUL`.
+        """
+        inners = [
+            ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP),
+            MATCHER_DMUL,
+            MATCHER_DADD,
+        ]
+
+        random.shuffle(inners)
+
+        matched = UnorderedInSequenceMatcher(matchers = inners).matches(instructions = DADD_NOP_DMUL)
+
+        assert len(matched) == 5
+
+    def test_without_nop(self):
+        """
+        Matches the sequence :py:const:`DADD_DMUL`.
+        """
+        inners = [
+            ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP),
+            MATCHER_DMUL,
+            MATCHER_DADD,
+        ]
+
+        random.shuffle(inners)
+
+        matched = UnorderedInSequenceMatcher(matchers = inners).matches(instructions = DADD_DMUL)
+
+        assert len(matched) == 2
+
+    def test_with_split_nop(self):
+        """
+        Matches the sequence :py:const:`NOP_DMUL_NOP_DADD`.
+        """
+        inners = [
+            ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP),
+            ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP),
+            MATCHER_DMUL,
+            MATCHER_DADD,
+        ]
+
+        random.shuffle(inners)
+
+        matched = UnorderedInSequenceMatcher(matchers = inners).matches(instructions = NOP_DMUL_NOP_DADD)
+
+        assert len(matched) == 5
+
+    def test_no_match(self):
+        """
+        All permutations fail on sequence :py:const:`NOP_DMUL_NOP_DADD`.
+        """
+        inners = [
+            ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP),
+            MATCHER_DMUL,
+            MATCHER_DADD,
+        ]
+
+        random.shuffle(inners)
+
+        with pytest.raises(RuntimeError, match = 'No permutation of '):
+            UnorderedInSequenceMatcher(matchers = inners).assert_matches(instructions = NOP_DMUL_NOP_DADD)


### PR DESCRIPTION
In #128 for instance, the compiler might "shuffle" two instructions, such that trying to match an exact sequence across all architectures is impossible.

It also sometimes introduces `NOP` in-between, sometimes not.

This PR tries to bring a few helpers that can combine instruction matchers to match many-instruction patterns.