### PR TITLE
tests(mypy): requirements for running `mypy`

### DIFF
--- a/requirements/requirements.python.txt
+++ b/requirements/requirements.python.txt
@@ -1,4 +1,5 @@
 matplotlib
+mypy>=1.18.2
 myst-nb>=1.3.0
 nvtx>=0.2.13
 pylint>=4.0.1
@@ -8,3 +9,4 @@ sphinx-github-style>=1.2.2
 sphinxcontrib-bibtex>=2.6.5
 sphinxcontrib-tikz>=0.4.20
 sphinxemoji>=0.3.1
+types-regex


### PR DESCRIPTION
We need `types-regex`, which is a type stub package for the `regex` package. Otheriwse, a return type hint using `regex.Match` makes `mypy` unhappy.

Extracted from:
- #177