### PR TITLE
mypyc: compile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,6 +331,12 @@ jobs:
                 . ${{ github.job }}/bin/activate
                 reprospect-install-nsight-systems --help
 
+            - name: Extensibility.
+              run: |
+                  . ${{ github.job }}/bin/activate
+                  pip install -U pytest
+                  python3 -m pytest -vvv -s --log-cli-level=info tests/python/test_extensibility.py
+
     documentation:
         needs: [setup-job-matrix, tests]
         runs-on: [self-hosted, linux, docker, amd64]

--- a/docs/source/tests.rst
+++ b/docs/source/tests.rst
@@ -6,6 +6,7 @@ Tests
    :caption: Contents:
 
    tests/nvtx
+   tests/python/extensibility
    tests/python/parameters
    tests/python/test
    tests/python/tools

--- a/docs/source/tests/python/extensibility.rst
+++ b/docs/source/tests/python/extensibility.rst
@@ -1,0 +1,4 @@
+Extensibility
+=============
+
+.. automodule:: tests.python.test_extensibility

--- a/examples/kokkos/view/example_allocation_tracing.py
+++ b/examples/kokkos/view/example_allocation_tracing.py
@@ -16,7 +16,7 @@ from reprospect.utils import detect
 if sys.version_info >= (3, 11):
     from enum import StrEnum
 else:
-    from backports.strenum import StrEnum
+    from backports.strenum.strenum import StrEnum
 
 if sys.version_info >= (3, 12):
     from typing import override

--- a/python/reprospect/tools/architecture.py
+++ b/python/reprospect/tools/architecture.py
@@ -9,10 +9,39 @@ import semantic_version
 if sys.version_info >= (3, 11):
     from enum import StrEnum
 else:
-    from backports.strenum import StrEnum
+    from backports.strenum.strenum import StrEnum
+
+CUDA_SUPPORT : typing.Final[dict[int, semantic_version.SimpleSpec]] = {
+    70 : semantic_version.SimpleSpec('>=9,<=12.9'),
+    75 : semantic_version.SimpleSpec('>=10'),
+    80 : semantic_version.SimpleSpec('>=11.2'),
+    86 : semantic_version.SimpleSpec('>=11.2'),
+    87 : semantic_version.SimpleSpec('>=11.5'),
+    89 : semantic_version.SimpleSpec('>=11.8'),
+    90 : semantic_version.SimpleSpec('>=11.8'),
+    100 : semantic_version.SimpleSpec('>=12.8'),
+    103 : semantic_version.SimpleSpec('>=12.9'),
+    110 : semantic_version.SimpleSpec('>=13.0'),
+    120 : semantic_version.SimpleSpec('>=12.8'),
+    121 : semantic_version.SimpleSpec('>=12.9'),
+}
+"""
+CUDA Toolkit support.
+
+References:
+
+* https://docs.nvidia.com/cuda/archive/12.8.0/cuda-compiler-driver-nvcc/index.html#gpu-feature-list
+* https://docs.nvidia.com/cuda/archive/12.9.1/cuda-compiler-driver-nvcc/index.html#gpu-feature-list
+* https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-feature-list
+
+.. note::
+
+    It is declared at module scope because of https://github.com/mypyc/mypyc/issues/1122, though it should be declared
+    as :py:data:`typing.Final` within :py:class:`ComputeCapability`.
+"""
 
 @functools.total_ordering
-@dataclasses.dataclass(frozen = True, slots = True)
+@dataclasses.dataclass(frozen = True, slots = True, kw_only = True)
 class ComputeCapability:
     """
     Compute capability.
@@ -23,30 +52,6 @@ class ComputeCapability:
     """
     major : int
     minor : int
-
-    CUDA_SUPPORT : typing.ClassVar[dict[int, semantic_version.SimpleSpec]] = {
-        70 : semantic_version.SimpleSpec('>=9,<=12.9'),
-        75 : semantic_version.SimpleSpec('>=10'),
-        80 : semantic_version.SimpleSpec('>=11.2'),
-        86 : semantic_version.SimpleSpec('>=11.2'),
-        87 : semantic_version.SimpleSpec('>=11.5'),
-        89 : semantic_version.SimpleSpec('>=11.8'),
-        90 : semantic_version.SimpleSpec('>=11.8'),
-        100 : semantic_version.SimpleSpec('>=12.8'),
-        103 : semantic_version.SimpleSpec('>=12.9'),
-        110 : semantic_version.SimpleSpec('>=13.0'),
-        120 : semantic_version.SimpleSpec('>=12.8'),
-        121 : semantic_version.SimpleSpec('>=12.9'),
-    }
-    """
-    CUDA Toolkit support.
-
-    References:
-
-    * https://docs.nvidia.com/cuda/archive/12.8.0/cuda-compiler-driver-nvcc/index.html#gpu-feature-list
-    * https://docs.nvidia.com/cuda/archive/12.9.1/cuda-compiler-driver-nvcc/index.html#gpu-feature-list
-    * https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-feature-list
-    """
 
     @property
     def as_int(self) -> int:
@@ -93,7 +98,7 @@ class ComputeCapability:
         >>> NVIDIAArch.from_str('VOLTA70').compute_capability.supported(version = Version('13.0.0'))
         False
         """
-        return version in self.CUDA_SUPPORT[self.as_int]
+        return version in CUDA_SUPPORT[self.as_int]
 
 class NVIDIAFamily(StrEnum):
     """

--- a/python/reprospect/tools/binaries/cuobjdump.py
+++ b/python/reprospect/tools/binaries/cuobjdump.py
@@ -29,7 +29,7 @@ from reprospect.tools.binaries.demangle import CuppFilt, LlvmCppFilt
 if sys.version_info >= (3, 11):
     from enum import StrEnum
 else:
-    from backports.strenum import StrEnum
+    from backports.strenum.strenum import StrEnum
 
 class ResourceUsage(StrEnum):
     """

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,6 +5,10 @@ from mypyc.build import mypycify
 setup(
     ext_modules = mypycify(
         [
+            'reprospect/test/matchers.py',
+            'reprospect/test/sass.py',
+            'reprospect/tools/architecture.py',
+            'reprospect/tools/binaries/cuobjdump.py',
             'reprospect/tools/ncu.py',
             'reprospect/tools/sass.py',
             'reprospect/utils/cmake.py',

--- a/tests/python/test_extensibility.py
+++ b/tests/python/test_extensibility.py
@@ -1,0 +1,99 @@
+"""
+Ensure that the distributed package supports user extensions.
+
+``mypyc`` compilation can inadvertently seal classes, preventing inheritance.
+This module verifies that :py:mod:`reprospect` extension points (*e.g.*,
+:py:class:`reprospect.test.sass.InstructionMatcher`) remain
+subclassable after compilation, allowing users to extend :py:mod:`reprospect` capabilities.
+"""
+
+import inspect
+import logging
+import sys
+import typing
+
+import pytest
+import regex
+
+from reprospect.tools.sass    import Instruction, ControlCode
+from reprospect.test.sass     import InstructionMatcher, PatternMatcher, FloatAddMatcher
+from reprospect.test.matchers import OrderedInSequenceMatcher
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+class NewInstructionMatcher(InstructionMatcher):
+    """
+    Faking a matcher for some unforeseen use case.
+    """
+    @override
+    def matches(self, inst : str | Instruction) -> regex.Match[str] | None:
+        return regex.match(r'.*', inst.instruction if isinstance(inst, Instruction) else inst)
+
+class NewPatternMatcher(PatternMatcher):
+    """
+    Faking a matcher for some unforeseen use case.
+    """
+    def __init__(self):
+        super().__init__(pattern = r'(NOP|DADD|DMUL).*')
+
+class CannotBeExtended(FloatAddMatcher):
+    """
+    :py:class:`reprospect.test.sass.FloatAddMatcher` was not marked as extensible.
+    """
+
+class TestInspect:
+    """
+    Use :py:mod:`inspect` to retrieve the provenance of objects.
+    """
+    def test_Instruction(self) -> None:
+        logging.info(inspect.getfile(Instruction))
+
+    def test_InstructionMatcher(self) -> None:
+        logging.info(inspect.getfile(InstructionMatcher))
+
+    def test_OrderedInSequenceMatcher(self) -> None:
+        logging.info(inspect.getfile(OrderedInSequenceMatcher))
+
+class TestInstructionMatching:
+    """
+    Match instructions with :py:class:`NewInstructionMatcher` and :py:class:`NewPatternMatcher`.
+    """
+    CONTROLCODE : typing.Final[ControlCode] = ControlCode(
+        stall_count = 5, yield_flag = False, read = 7, write = 7,
+        wait = [True, False, False, False, False, False],
+        reuse = {'A' : False, 'B' : False, 'C' : False, 'D' : False},
+    )
+
+    DADD : typing.Final[Instruction] = Instruction(offset = 0, instruction = 'DADD R4, R4, c[0x0][0x180]', hex = '0x0', control = CONTROLCODE)
+    DMUL : typing.Final[Instruction] = Instruction(offset = 0, instruction = 'DMUL R6, R6, c[0x0][0x188]', hex = '0x1', control = CONTROLCODE)
+    NOP  : typing.Final[Instruction] = Instruction(offset = 0, instruction = 'NOP',                        hex = '0x2', control = CONTROLCODE)
+
+    def test_NewInstructionMatcher(self) -> None:
+        result = OrderedInSequenceMatcher(matchers = (
+            NewInstructionMatcher(),
+            NewInstructionMatcher(),
+            NewInstructionMatcher(),
+        )).matches(instructions = (self.DADD, self.DMUL, self.NOP))
+
+        assert result is not None
+
+        assert len(result) == 3
+
+    def test_NewPatternMatcher(self) -> None:
+        result = OrderedInSequenceMatcher(matchers = (
+            NewPatternMatcher(),
+            NewPatternMatcher(),
+            NewPatternMatcher(),
+        )).matches(instructions = (self.DADD, self.DMUL, self.NOP))
+
+        assert result is not None
+
+        assert len(result) == 3
+
+class TestCannotBeExtended:
+    def test(self) -> None:
+        with pytest.raises(TypeError, match = 'interpreted classes cannot inherit from compiled'):
+            CannotBeExtended()

--- a/tests/python/tools/test_architecture.py
+++ b/tests/python/tools/test_architecture.py
@@ -6,7 +6,7 @@ import subprocess
 import pytest
 import semantic_version
 
-from reprospect.tools.architecture import ComputeCapability, NVIDIAFamily, NVIDIAArch
+from reprospect.tools.architecture import CUDA_SUPPORT, ComputeCapability, NVIDIAFamily, NVIDIAArch
 
 class TestComputeCapability:
     """
@@ -36,12 +36,17 @@ class TestComputeCapability:
             subprocess.check_output(['nvcc', '--list-gpu-code']).decode().splitlines(),
         )
         CUDA_VERSION = semantic_version.Version(os.environ['CUDA_VERSION'])
+        count = 0
         for cc in supported:
-            if cc not in ComputeCapability.CUDA_SUPPORT:
-                continue
-            logging.info(f'Checking that {cc!r} is supported by CUDA {CUDA_VERSION}.')
-            assert CUDA_VERSION in ComputeCapability.CUDA_SUPPORT[cc.as_int]
-            assert cc.supported(version = CUDA_VERSION)
+            if cc.as_int not in CUDA_SUPPORT:
+                logging.info(f'{cc!r} is supported by CUDA {CUDA_VERSION} but is not listed in the CUDA support list.')
+            else:
+                logging.info(f'{cc!r} is supported by CUDA {CUDA_VERSION}.')
+                assert CUDA_VERSION in CUDA_SUPPORT[cc.as_int]
+                assert cc.supported(version = CUDA_VERSION)
+                count += 1
+
+        assert count > 0
 
         # VOLTA70 is supported until CUDA 13.
         assert not ComputeCapability.from_int(70).supported(version = semantic_version.Version('13.0.0'))


### PR DESCRIPTION
## Speed

```python
import typeguard

# typeguard.install_import_hook('reprospect')

import reprospect.tools.architecture as u

print(u.__file__)

import timeit

def func():
    for x in ['AMPERE86', 'BLACKWELL120']:
        u.NVIDIAArch.from_str(x)

print(timeit.Timer(func).timeit(number = 100000))

# Interpreted, with install_import_hook 3.06 seconds.
# Interpreted, without                  0.51 seconds.
# Compiled                              0.48
```

```python
import typeguard
import pathlib

cfd = pathlib.Path(__file__).parent / 'tests/python/tools/test_sass'

# typeguard.install_import_hook('reprospect')

import reprospect.tools.sass as sass

print(sass.__file__)

import timeit

def func():
    d1281 = sass.Decoder(source = cfd / '12.8.1.sass')
    d1300 = sass.Decoder(source = cfd / '13.0.0.sass')

print(timeit.Timer(func).timeit(number = 10000))

# Interpreted, with install_import_hook 11.5 seconds.
# Interpreted, without                  7.6 seconds.
# Compiled                              6.47
```

1. `typeguard` really slows things down.
2. For such a simple case, compiled is a negligible improvement.

## Type safety

From `mypyc`:
> Mypyc enforces type annotations (and type comments) at runtime, raising TypeError if runtime values don’t match annotations. Value types only need to be checked in the boundaries between dynamic and static typing.


### `typeguard.typechecked` compatibility

I got a few compilation errors that disappeared simply by removing the `@typeguard.typechecked` decorator, for instance:
```bash
build/__native_3be29cdd95236b3d7f68.c: In function ‘CPyDef_sass___Decoder’:
build/__native_3be29cdd95236b3d7f68.c:5924:16: error: too few arguments to function ‘CPyDef_sass___Decoder_____init__’
 5924 |     char res = CPyDef_sass___Decoder_____init__(self);
```

And when it compiles, I often get:
> /opt/venv-3.12/lib/python3.12/site-packages/reprospect/test/cmake.py:12: InstrumentationWarning: no code associated -- not typechecking FileAPI.target

Let's check we can indeed get rid of `typeguard`.

`test.py`
```python
import pathlib

def function(a : dict[str, int]) -> list[pathlib.Path]:
    print(a)
    return [pathlib.Path(x) for x in a.keys()]
```

> mypyc test.py

> python3 -c "import test; test.function(a=5)"

```bash
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "test.py", line 3, in function
    def function(a : dict[str, int]) -> list[pathlib.Path]:
TypeError: dict object expected; got int
```

### Still relying on `@typeguard.typechecked`

We can just put the following in our tests:
```python
import typeguard

typeguard.install_import_hook('reprospect')

from reprospect.utils import cmake
```

and `typeguard` will still decorate all `reprospect` for test purposes.

## Packaging

Using `mypyc` restricts a package to a given Python version. Our release strategy could be to generate those tailored package for 3.10 and 3.12 at least, and one package without compilation as fallback.

## Miscellaneous

### Declare class-level constants as `typing.Final`

```bash
reprospect/test/sass.py:197: error: Cannot access instance attribute "REG64" through class object
reprospect/test/sass.py:197: note: (Hint: Use "x: Final = ..." or "x: ClassVar = ..." to define a class attribute)
```

### `backports.strenum`

- https://github.com/mypyc/mypyc/issues/1163