### PR TITLE
python(requirements): use immutable git ref to allow pip caching

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,11 +1,17 @@
 backports.strenum
 blake3
-cmake_file_api @ git+https://github.com/madebr/python-cmake-file-api@v0.0.8.3
+
+# Version 0.0.8.3.
+cmake_file_api @ git+https://github.com/madebr/python-cmake-file-api@fc02aa8522b7f793643412124ee938f8d0dc7ef9
+
 ijson
 pandas
 regex
 rich
 semantic_version
-system-helpers @ git+https://github.com/uliegecsm/system-helpers@0.0.3
+
+# Version 0.0.3.
+system-helpers @ git+https://github.com/uliegecsm/system-helpers@f81d70b200db8f486102108a43349dfa89f523e4
+
 typeguard
 typing-extensions>=4.4.0


### PR DESCRIPTION
From https://pip.pypa.io/en/stable/topics/caching/#locally-built-wheels:
> Changed in version 20.0: pip now caches wheels when building from an immutable Git reference (i.e. a commit hash).


Extracted from #185.