### PR TITLE
ctest(pytest): mark ctest as skipped if all pytest are skipped

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(Python 3.10 REQUIRED Interpreter)
 
 include(cmake/functions/environment.cmake)
 include(cmake/functions/path_helper.cmake)
+include(cmake/functions/pytest_skip.cmake)
 include(cmake/modules/detect.cmake)
 include(cmake/modules/Warnings.cmake)
 

--- a/cmake/functions/pytest_skip.cmake
+++ b/cmake/functions/pytest_skip.cmake
@@ -1,0 +1,13 @@
+# Mark a test as skipped if all collected tests were marked as skipped.
+#
+# The test is marked as skipped if pytest outputs a message similar to:
+#   === 1 skipped in 0.01s ===
+#
+# See also https://cmake.org/cmake/help/latest/prop_test/SKIP_REGULAR_EXPRESSION.html#prop_test:SKIP_REGULAR_EXPRESSION.
+function(pytest_skip_mark TESTNAME)
+    set_property(
+        TEST ${TESTNAME}
+        PROPERTY
+            SKIP_REGULAR_EXPRESSION "=== [0-9]+ skipped in [0-9.]+s ==="
+    )
+endfunction()

--- a/docs/source/analysis.rst
+++ b/docs/source/analysis.rst
@@ -28,7 +28,7 @@ API tracing |:movie_camera:|
 
 See for example:
 
-* :py:class:`examples.kokkos.view.example_allocation.TestNSYS`
+* :py:class:`examples.kokkos.view.example_allocation_tracing.TestNSYS`
 
 From sources to binaries |:bricks:|
 -----------------------------------

--- a/docs/source/examples/kokkos/view/allocation.rst
+++ b/docs/source/examples/kokkos/view/allocation.rst
@@ -1,4 +1,4 @@
 `Kokkos::View` allocation
 =========================
 
-.. automodule:: examples.kokkos.view.example_allocation
+.. automodule:: examples.kokkos.view.example_allocation_tracing

--- a/examples/kokkos/CMakeLists.txt
+++ b/examples/kokkos/CMakeLists.txt
@@ -21,6 +21,8 @@ function(add_one_example FILE)
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 
+    pytest_skip_mark(${EXECUTABLE})
+
     test_environment(${EXECUTABLE} PYTHONPATH path_list_prepend ${CMAKE_SOURCE_DIR}/python)
     test_environment(${EXECUTABLE} CMAKE_BINARY_DIR set ${CMAKE_BINARY_DIR})
     test_environment(${EXECUTABLE} CMAKE_CURRENT_BINARY_DIR set ${CMAKE_CURRENT_BINARY_DIR})

--- a/examples/kokkos/view/CMakeLists.txt
+++ b/examples/kokkos/view/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_one_example(allocation)
-test_environment(examples_kokkos_view_allocation KOKKOS_TOOLS_NVTX_CONNECTOR_LIB set $<TARGET_FILE:KokkosTools::kp_nvtx_connector>)
+add_one_example(allocation_tracing)
+test_environment(examples_kokkos_view_allocation_tracing KOKKOS_TOOLS_NVTX_CONNECTOR_LIB set $<TARGET_FILE:KokkosTools::kp_nvtx_connector>)

--- a/examples/kokkos/view/example_allocation_tracing.cpp
+++ b/examples/kokkos/view/example_allocation_tracing.cpp
@@ -9,7 +9,7 @@
 /**
  * @file
  *
- * Companion of @ref examples/kokkos/view/example_allocation.py.
+ * Companion of @ref examples/kokkos/view/example_allocation_tracing.py.
  */
 
 namespace reprospect::examples::kokkos::view

--- a/examples/kokkos/view/example_allocation_tracing.py
+++ b/examples/kokkos/view/example_allocation_tracing.py
@@ -38,7 +38,7 @@ class TestAllocation(reprospect.CMakeAwareTestCase):
     @override
     @typeguard.typechecked
     def get_target_name(cls) -> str:
-        return 'examples_kokkos_view_allocation'
+        return 'examples_kokkos_view_allocation_tracing'
 
 @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason = 'needs a GPU')
 class TestNSYS(TestAllocation):

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -16,6 +16,8 @@ function(add_pytest FILE)
     test_environment(${FILENAME} CMAKE_BINARY_DIR set ${CMAKE_BINARY_DIR})
     test_environment(${FILENAME} CMAKE_CURRENT_BINARY_DIR set ${CMAKE_CURRENT_BINARY_DIR})
 
+    pytest_skip_mark(${FILENAME})
+
     # Directory for artifacts.
     file(RELATIVE_PATH relative_path ${CMAKE_SOURCE_DIR} ${FILEPATH})
     test_environment(${FILENAME} ARTIFACT_DIR set ${CMAKE_SOURCE_DIR}/artifacts/${relative_path})


### PR DESCRIPTION
Typical output:
```bash
Run ctest --preset=gnu-nvidia
Test project /__w/reprospect/reprospect/build-with-gnu-nvidia
    Start 1: examples_kokkos_view_allocation_tracing
1/1 Test #1: examples_kokkos_view_allocation_tracing ...***Skipped   1.00 sec
100% tests passed, 0 tests failed out of 1
Total Test time (real) =   1.00 sec
The following tests did not run:
	  1 - examples_kokkos_view_allocation_tracing (Skipped)
```