### PR TITLE
Update mc cp command to use recursive option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -433,4 +433,4 @@ jobs:
               run: |
                 mc alias set MC_HOST_COSTMO ${{ vars.MC_HOST_COSTMO_URL }} ${{ secrets.MC_HOST_COSTMO_USER }} ${{ secrets.MC_HOST_COSTMO_PASSWORD }}
                 mc mb --ignore-existing MC_HOST_COSTMO/reprospect
-                mc cp python/dist/ MC_HOST_COSTMO/reprospect/
+                mc cp --recursive python/dist/ MC_HOST_COSTMO/reprospect/


### PR DESCRIPTION
```bash
Added `MC_HOST_COSTMO` successfully.
Bucket created successfully `MC_HOST_COSTMO/reprospect`. mc: <ERROR> Unable to prepare URL for copying. To copy or move 'python/dist/' the --recursive flag is required.
```