### PR TITLE
tools(ncu): mypyc

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,6 +6,7 @@ requires = [
     # mypyc requires that runtime dependencies are also installed
     # during the build, since it parses the code base.
     # For now, the only solution is to copy-paste the list here.
+    "attrs",
     "backports.strenum",
     "blake3",
     "cmake_file_api @ git+https://github.com/madebr/python-cmake-file-api@fc02aa8522b7f793643412124ee938f8d0dc7ef9",

--- a/python/reprospect/tools/cacher.py
+++ b/python/reprospect/tools/cacher.py
@@ -8,7 +8,6 @@ import sqlite3
 import typing
 
 import blake3
-import typeguard
 
 class Cacher(abc.ABC):
     """
@@ -29,7 +28,7 @@ class Cacher(abc.ABC):
     Inspired by ``ccache``, see also https://ccache.dev/manual/4.12.1.html#_how_ccache_works.
     """
     #: Name of the table.
-    TABLE : str = 'defaulted'
+    TABLE : typing.ClassVar[str]
 
     @dataclasses.dataclass(frozen = True)
     class Entry:
@@ -45,7 +44,6 @@ class Cacher(abc.ABC):
         # Directory wherein files are stored.
         directory : pathlib.Path
 
-    @typeguard.typechecked
     def __init__(self, directory : str | pathlib.Path) -> None:
         """
         :param directory: Where the cacher stores all files.
@@ -59,7 +57,6 @@ class Cacher(abc.ABC):
 
         self.database : typing.Optional[sqlite3.Connection] = None
 
-    @typeguard.typechecked
     def __enter__(self) -> 'Cacher':
         """
         Connect to the database.
@@ -67,12 +64,10 @@ class Cacher(abc.ABC):
         self.database = self.create_db(file = self.file) if not self.file.is_file() else sqlite3.connect(self.file)
         return self
 
-    @typeguard.typechecked
     def __exit__(self, *args, **kwargs) -> None:
         assert self.database is not None
         self.database.close()
 
-    @typeguard.typechecked
     def create_db(self, file : pathlib.Path) -> sqlite3.Connection:
         """
         Create the `SQLITE` database.
@@ -89,7 +84,6 @@ class Cacher(abc.ABC):
         db.commit()
         return db
 
-    @typeguard.typechecked
     def hash(self, **kwargs) -> blake3.blake3:
         """
         This method is intended to be overridden in a child class with the specifics of your case.
@@ -102,11 +96,9 @@ class Cacher(abc.ABC):
         return hasher
 
     @abc.abstractmethod
-    @typeguard.typechecked
     def populate(self, directory : pathlib.Path, **kwargs) -> typing.Any:
         pass
 
-    @typeguard.typechecked
     def get(self, **kwargs) -> 'Cacher.Entry':
         """
         Serve cached entry on cache hit, populate on cache miss.

--- a/python/reprospect/tools/nsys.py
+++ b/python/reprospect/tools/nsys.py
@@ -457,7 +457,7 @@ class Cacher(cacher.Cacher):
         The cache should not be shared between machines, since there may be differences between machines
         that influence the results but are not included in the hashing.
     """
-    TABLE : str = 'nsys'
+    TABLE : typing.ClassVar[str] = 'nsys'
 
     @typeguard.typechecked
     def __init__(self, session : Session, directory : typing.Optional[str | pathlib.Path] = None):

--- a/python/reprospect/utils/ldd.py
+++ b/python/reprospect/utils/ldd.py
@@ -2,14 +2,11 @@ import pathlib
 import re
 import subprocess
 
-import typeguard
-
-@typeguard.typechecked
 def get_shared_dependencies(*, file : str | pathlib.Path) -> list[pathlib.Path]:
     """
     Get the list of shared object dependencies.
 
-    It assumes that `ldd` output follows::
+    It assumes that ``ldd`` output follows::
 
         libname => /path/to/lib.so (address)
     """

--- a/python/setup.py
+++ b/python/setup.py
@@ -5,6 +5,7 @@ from mypyc.build import mypycify
 setup(
     ext_modules = mypycify(
         [
+            'reprospect/tools/ncu.py',
             'reprospect/tools/sass.py',
             'reprospect/utils/cmake.py',
             'reprospect/utils/detect.py',

--- a/tests/python/tools/test_cacher.py
+++ b/tests/python/tools/test_cacher.py
@@ -4,8 +4,6 @@ import sys
 import tempfile
 import typing
 
-import typeguard
-
 from reprospect.tools.cacher import Cacher
 
 if sys.version_info >= (3, 12):
@@ -14,8 +12,9 @@ else:
     from typing_extensions import override
 
 class DummyImplementation(Cacher):
+    TABLE : typing.ClassVar[str] = 'dummy'
+
     @override
-    @typeguard.typechecked
     def populate(self, directory : pathlib.Path, **kwargs) -> typing.Any:
         logging.info(f'Populating within {directory} with {kwargs}.')
 

--- a/tests/python/tools/test_ncu.py
+++ b/tests/python/tools/test_ncu.py
@@ -32,11 +32,11 @@ class TestSession:
     GRAPH = pathlib.Path(os.environ['CMAKE_BINARY_DIR']) / 'tests' / 'cpp' / 'cuda' / 'tests_cpp_cuda_graph' if 'CMAKE_BINARY_DIR' in os.environ else None
     SAXPY = pathlib.Path(os.environ['CMAKE_BINARY_DIR']) / 'tests' / 'cpp' / 'cuda' / 'tests_cpp_cuda_saxpy' if 'CMAKE_BINARY_DIR' in os.environ else None
 
-    def test_collect_basic_metrics_saxpy_with_nvtx_filtering(self):
+    def test_collect_basic_metrics_saxpy_with_nvtx_filtering(self) -> None:
         """
         Collect a few basic metrics for the :py:attr:`SAXPY` executable and filter by NVTX.
         """
-        METRICS = [
+        METRICS : tuple[ncu.Metric, ...] = (
             # Metric with full name provided.
             ncu.Metric(name = 'launch__registers_per_thread_allocated'),
             # Metric with roll-up.
@@ -47,9 +47,9 @@ class TestSession:
             # A few L1TEX cache metrics.
             ncu.L1TEXCache.GlobalLoad.Instructions(),
             ncu.L1TEXCache.GlobalLoad.Sectors(),
-        ]
+        )
 
-        EXPT_METRICS_AND_METADATA = [
+        EXPT_METRICS_AND_METADATA = (
             'launch__registers_per_thread_allocated',
             'smsp__inst_executed.sum',
             'launch__block_dim_x',
@@ -62,7 +62,7 @@ class TestSession:
             'L1/TEX cache global load sectors.sum',
             'mangled',
             'demangled',
-        ]
+        )
 
         session = ncu.Session(output = TMPDIR / 'report-saxpy-basics')
 
@@ -128,7 +128,7 @@ class TestSession:
         """
         Collect a metric with correlations for the :py:attr:`SAXPY` executable.
         """
-        METRICS = [ncu.MetricCorrelation(name = 'sass__inst_executed_per_opcode')]
+        METRICS = (ncu.MetricCorrelation(name = 'sass__inst_executed_per_opcode'),)
 
         session = ncu.Session(output = TMPDIR / 'report-saxpy-correlated')
 
@@ -160,11 +160,11 @@ class TestSession:
         """
         Collect a few basic metrics for the :py:attr:`GRAPH` executable.
         """
-        METRICS = [
+        METRICS = (
             # A few L1TEX cache metrics.
             ncu.L1TEXCache.GlobalLoad.Sectors(),
             ncu.L1TEXCache.GlobalStore.Sectors(),
-        ]
+        )
 
         session = ncu.Session(output = TMPDIR / 'report-graph-basics')
 
@@ -351,11 +351,11 @@ class TestCacher:
         """
         The cacher should hit on the second call.
         """
-        METRICS = [
+        METRICS = (
             # A few L1TEX cache metrics.
             ncu.L1TEXCache.GlobalLoad.Sectors(),
             ncu.L1TEXCache.GlobalStore.Sectors(),
-        ]
+        )
 
         FILES = ['report-cached.log', 'report-cached.ncu-rep']
 


### PR DESCRIPTION
`mypyc` does not support nested classes:
- https://github.com/mypyc/mypyc/issues/897

The trick is to go from:
```python
import enum

class Outer:
    class Inner(enum.StrEnum):
        VALUE = 'value'

# Users would do Outer.Inner.VALUE
```
to
```python
import enum
import typing

class OuterInner(enum.StrEnum):
    VALUE = 'value'

class Outer:
    Inner : typing.Final[typing.Type[OuterInner]] = OuterInner

# Users can still do Outer.Inner.VALUE
```