### PR TITLE
test(sass): minor refactoring

### DIFF
--- a/python/reprospect/test/sass.py
+++ b/python/reprospect/test/sass.py
@@ -99,7 +99,7 @@ class PatternBuilder:
         return rf'(?P<{group}>{s})'
 
     @staticmethod
-    def groups(s : int | str, groups = typing.Iterable[str]) -> str:
+    def groups(s : int | str, groups : typing.Iterable[str]) -> str:
         """
         Wrap a pattern in named capture groups.
         """


### PR DESCRIPTION
* remove `typeguard`
* split `PatternBuild.group` into `PatternBuilder.group` and `PatternBuilder.groups`
* using `typing.Final`

Extracted from:
- #185