### PR TITLE
python(requirements): mypy extensions

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,6 +10,7 @@ requires = [
     "blake3",
     "cmake_file_api @ git+https://github.com/madebr/python-cmake-file-api@fc02aa8522b7f793643412124ee938f8d0dc7ef9",
     "ijson",
+    "mypy_extensions",
     "pandas",
     "regex",
     "rich",

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,6 +6,7 @@ blake3
 cmake_file_api @ git+https://github.com/madebr/python-cmake-file-api@fc02aa8522b7f793643412124ee938f8d0dc7ef9
 
 ijson
+mypy_extensions
 pandas
 regex
 rich


### PR DESCRIPTION
Needs to mark some classes as "subclassable" even after compilation with `mypyc`:
```python
@mypy_extensions.mypyc_attr(allow_interpreted_subclasses = True)
class ...:
    pass
```

Needed in:
- #185 