### PR TITLE
python(typeguard): get rid of typeguard explicit markup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -410,6 +410,10 @@ jobs:
             - uses: actions/checkout@v5
 
             - run: |
+                export PYTHONPATH="$PWD/python${PYTHONPATH+:}${PYTHONPATH}"
+                mypy --strict --follow-untyped-import .github/workflows/strategy.py
+
+            - run: |
                 cd python/
                 mypy --config-file pyproject.toml
 

--- a/examples/kokkos/view/example_allocation_tracing.py
+++ b/examples/kokkos/view/example_allocation_tracing.py
@@ -6,7 +6,6 @@ import typing
 
 import numpy
 import pytest
-import typeguard
 
 import reprospect
 
@@ -36,7 +35,6 @@ class TestAllocation(reprospect.CMakeAwareTestCase):
 
     @classmethod
     @override
-    @typeguard.typechecked
     def get_target_name(cls) -> str:
         return 'examples_kokkos_view_allocation_tracing'
 
@@ -49,7 +47,6 @@ class TestNSYS(TestAllocation):
     """Size of the `Kokkos::Impl::SharedAllocationHeader` type, see https://github.com/kokkos/kokkos/blob/c1a715cab26da9407867c6a8c04b2a1d6b2fc7ba/core/src/impl/Kokkos_SharedAlloc.hpp#L23."""
 
     @pytest.fixture(scope = 'class')
-    @typeguard.typechecked
     def session(self) -> nsys.Session:
         """
         Analyse with `nsys`, use :py:class:`reprospect.tools.nsys.Cacher`.
@@ -75,12 +72,10 @@ class TestNSYS(TestAllocation):
             return cacher.session
 
     @pytest.fixture(scope = 'class')
-    @typeguard.typechecked
     def report(self, session : nsys.Session) -> nsys.Report:
         return nsys.Report(db = session.output_file_sqlite)
 
     @staticmethod
-    @typeguard.typechecked
     def get_memory_id(report : nsys.Report, memory : Memory) -> numpy.int64:
         """
         Retrieve the `id` from `ENUM_CUDA_MEM_KIND` whose `name` matches `memory`.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,6 @@ requires = [
     "rich",
     "semantic_version",
     "system-helpers>=0.0.3",
-    "typeguard",
     "typing-extensions>=4.4.0",
 
     # Requirements from requirements/requirements.python.txt that are required by mypyc.

--- a/python/reprospect/installers/nsight_systems.py
+++ b/python/reprospect/installers/nsight_systems.py
@@ -4,15 +4,14 @@ import os
 import re
 import shutil
 import subprocess
+import typing
 
 import semantic_version
-import typeguard
 
 import system_helpers.apt.install
 
-PACKAGE = 'cuda-nsight-systems'
+PACKAGE : typing.Final[str] = 'cuda-nsight-systems'
 
-@typeguard.typechecked
 def parse_args() -> argparse.Namespace:
     """
     Parse CLI arguments.
@@ -37,7 +36,6 @@ def install(*, args = argparse.Namespace) -> None:
         update = True, clean = True,
     )
 
-@typeguard.typechecked
 def detect_cuda_version() -> str:
     """
     Detect CUDA version using the following strategies:

--- a/python/reprospect/test/matchers.py
+++ b/python/reprospect/test/matchers.py
@@ -9,7 +9,6 @@ import sys
 import typing
 
 import regex
-import typeguard
 
 from reprospect.test.sass  import Matcher
 from reprospect.tools.sass import Instruction
@@ -39,13 +38,11 @@ class InSequenceAtMatcher(SequenceMatcher):
     matcher : Matcher
 
     @override
-    @typeguard.typechecked
     def matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match] | None:
         matched = self.matcher.matches(instructions[start])
         return [matched] if matched is not None else None
 
     @override
-    @typeguard.typechecked
     def assert_matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match]:
         matched = self.matches(instructions = instructions, start = start)
         if matched is None:
@@ -60,7 +57,6 @@ class ZeroOrMoreInSequenceMatcher(SequenceMatcher):
     matcher : Matcher
 
     @override
-    @typeguard.typechecked
     def matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match] | None:
         matches: list[regex.Match] = []
 
@@ -73,7 +69,6 @@ class ZeroOrMoreInSequenceMatcher(SequenceMatcher):
         return matches
 
     @override
-    @typeguard.typechecked
     def assert_matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match]:
         """
         It is always matching.
@@ -88,7 +83,6 @@ class OrderedInSequenceMatcher(SequenceMatcher):
     matchers : tuple[SequenceMatcher | Matcher, ...]
 
     @override
-    @typeguard.typechecked
     def matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match] | None:
         matches : list[regex.Match] = []
         for matcher in self.matchers:
@@ -101,7 +95,6 @@ class OrderedInSequenceMatcher(SequenceMatcher):
         return matches
 
     @override
-    @typeguard.typechecked
     def assert_matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match]:
         matched = self.matches(instructions = instructions, start = start)
         if matched is None:
@@ -116,7 +109,6 @@ class UnorderedInSequenceMatcher(SequenceMatcher):
     matchers : tuple[SequenceMatcher | Matcher, ...]
 
     @override
-    @typeguard.typechecked
     def matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match] | None:
         """
         Cycle through all permutations of :py:attr:`matchers` (breaks on match).
@@ -131,7 +123,6 @@ class UnorderedInSequenceMatcher(SequenceMatcher):
         return None
 
     @override
-    @typeguard.typechecked
     def assert_matches(self, instructions : typing.Sequence[Instruction], start : int = 0) -> list[regex.Match]:
         matched = self.matches(instructions = instructions, start = start)
         if matched is None:

--- a/python/reprospect/tools/architecture.py
+++ b/python/reprospect/tools/architecture.py
@@ -5,7 +5,6 @@ import sys
 import typing
 
 import semantic_version
-import typeguard
 
 if sys.version_info >= (3, 11):
     from enum import StrEnum
@@ -50,7 +49,6 @@ class ComputeCapability:
     """
 
     @property
-    @typeguard.typechecked
     def as_int(self) -> int:
         """
         >>> from reprospect.tools.architecture import ComputeCapability
@@ -86,7 +84,6 @@ class ComputeCapability:
         major, minor = divmod(value, 10)
         return ComputeCapability(major = major, minor = minor)
 
-    @typeguard.typechecked
     def supported(self, version : semantic_version.Version) -> bool:
         """
         Check if the architecture is supported by the CUDA `version`.
@@ -110,7 +107,6 @@ class NVIDIAFamily(StrEnum):
     BLACKWELL = 'BLACKWELL'
 
     @staticmethod
-    @typeguard.typechecked
     def from_compute_capability(cc : ComputeCapability | int) -> "NVIDIAFamily":
         """
         Get the NVIDIA architecture family from a compute capability.
@@ -152,7 +148,6 @@ class NVIDIAArch:
             )
 
     @property
-    @typeguard.typechecked
     def as_compute(self) -> str:
         """
         Convert to CUDA "virtual architecture" (``compute_``).
@@ -164,14 +159,12 @@ class NVIDIAArch:
         return f'compute_{self.compute_capability.as_int}'
 
     @property
-    @typeguard.typechecked
     def as_sm(self) -> str:
         """
         Convert to CUDA "real architecture" (``sm_``).
         """
         return f'sm_{self.compute_capability.as_int}'
 
-    @typeguard.typechecked
     def __str__(self) -> str:
         return f"{self.family.name}{self.compute_capability.as_int}"
 

--- a/python/reprospect/tools/device_properties.py
+++ b/python/reprospect/tools/device_properties.py
@@ -16,7 +16,6 @@ import logging
 import typing
 
 import cuda.bindings.driver # type: ignore[import-not-found]
-import typeguard
 
 from reprospect.tools import architecture
 
@@ -31,7 +30,6 @@ class CudaRuntimeError:
     def success(self) -> bool:
         return self.value == 0
 
-    @typeguard.typechecked
     def get(self, libcudart) -> tuple[str, str]:
         """
         Get error name and string.
@@ -51,7 +49,6 @@ class CudaDriverError:
     def success(self) -> bool:
         return self.value == 0
 
-    @typeguard.typechecked
     def get(self, libcuda) -> tuple[str, str]:
         """
         Get error name and string.
@@ -72,7 +69,6 @@ class Cuda:
     libcudart : ctypes.CDLL | None = None
 
     @classmethod
-    @typeguard.typechecked
     def load(cls) -> None:
         """
         Load CUDA library.
@@ -86,7 +82,6 @@ class Cuda:
             logging.info(f"Library {cls.libcudart} loaded successfully.")
 
     @classmethod
-    @typeguard.typechecked
     def check_driver_status(cls, *, status : CudaDriverError, info : typing.Any) -> None:
         """
         Check that `status` is successful, raise otherwise.
@@ -98,7 +93,6 @@ class Cuda:
             )
 
     @classmethod
-    @typeguard.typechecked
     def check_runtime_status(cls, *, status : CudaRuntimeError, info : typing.Any) -> None:
         """
         Check that `status` is successful, raise otherwise.
@@ -110,7 +104,6 @@ class Cuda:
             )
 
     @classmethod
-    @typeguard.typechecked
     def check_driver_api_call(cls, *, func : str) -> typing.Any:
         """
         Wrap CUDA driver API call `func` to raise an exception if the call is not successful.
@@ -125,7 +118,6 @@ class Cuda:
         return wrapper
 
     @classmethod
-    @typeguard.typechecked
     def check_runtime_api_call(cls, *, func : str) -> typing.Any:
         """
         Wrap CUDA runtime API call `func` to raise an exception if the call is not successful.
@@ -139,13 +131,11 @@ class Cuda:
             return status
         return wrapper
 
-    @typeguard.typechecked
     def __init__(self, flags : int = 0) -> None:
         self.load()
         self.check_driver_api_call(func = 'cuInit')(flags)
 
     @functools.cached_property
-    @typeguard.typechecked
     def device_count(self) -> int:
         """
         Wrap ``cudaGetDeviceCount``.
@@ -154,7 +144,6 @@ class Cuda:
         self.check_runtime_api_call(func = 'cudaGetDeviceCount')(ctypes.byref(count))
         return count.value
 
-    @typeguard.typechecked
     def get_device_attribute(self, *, value_type : typing.Type, attribute : cuda.bindings.driver.CUdevice_attribute, device : int) -> typing.Any:
         """
         Retrieve an attribute of `device`.
@@ -163,7 +152,6 @@ class Cuda:
         self.check_runtime_api_call(func = 'cudaDeviceGetAttribute')(ctypes.byref(value), attribute.value, device)
         return value.value
 
-    @typeguard.typechecked
     def get_device_compute_capability(self, *, device : int) -> architecture.ComputeCapability:
         """
         Get compute capability of `device`.
@@ -177,7 +165,6 @@ class Cuda:
         )
         return architecture.ComputeCapability(major = cc_major.value, minor = cc_minor.value)
 
-    @typeguard.typechecked
     def get_device_name(self, *, device : int, length : int = 150) -> str:
         """
         Get name of `device`.
@@ -186,7 +173,6 @@ class Cuda:
         self.check_driver_api_call(func = 'cuDeviceGetName')(ctypes.c_char_p(name), len(name), device)
         return name.split(b"\0", 1)[0].decode()
 
-    @typeguard.typechecked
     def get_device_total_memory(self, *, device : int) -> int:
         """
         Get device total memory.

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -12,5 +12,4 @@ regex
 rich
 semantic_version
 system-helpers>=0.0.3
-typeguard
 typing-extensions>=4.4.0

--- a/requirements/requirements.python.txt
+++ b/requirements/requirements.python.txt
@@ -9,4 +9,5 @@ sphinx-github-style>=1.2.2
 sphinxcontrib-bibtex>=2.6.5
 sphinxcontrib-tikz>=0.4.20
 sphinxemoji>=0.3.1
+typeguard
 types-regex

--- a/tests/nvtx/test_nvtx.py
+++ b/tests/nvtx/test_nvtx.py
@@ -2,10 +2,8 @@ import contextlib
 import logging
 
 import nvtx
-import typeguard
 
 @contextlib.contextmanager
-@typeguard.typechecked
 def push_pop_range(domain : nvtx.Domain, **kwargs):
     domain.push_range(attributes = domain.get_event_attributes(**kwargs))
     try:
@@ -14,7 +12,6 @@ def push_pop_range(domain : nvtx.Domain, **kwargs):
         domain.pop_range()
 
 @contextlib.contextmanager
-@typeguard.typechecked
 def start_end_range(domain : nvtx.Domain, **kwargs):
     range_id = domain.start_range(attributes = domain.get_event_attributes(**kwargs))
     try:
@@ -69,7 +66,6 @@ class TestNVTX:
         assert reg is not None
 
     @classmethod
-    @typeguard.typechecked
     def intricated(cls, domain) -> None:
         """
         Build a situation with many intricated ranges.

--- a/tests/python/test/sass/test_atomic.py
+++ b/tests/python/test/sass/test_atomic.py
@@ -6,7 +6,6 @@ import subprocess
 import pytest
 import regex
 import semantic_version
-import typeguard
 
 from reprospect.tools.sass import Instruction
 from reprospect.test.sass  import AtomicMatcher, PatternBuilder
@@ -16,7 +15,6 @@ from tests.python.parameters import Parameters, PARAMETERS
 from tests.python.test.sass.test_sass import get_decoder
 
 @pytest.fixture(scope = 'session')
-@typeguard.typechecked
 def cmake_file_api() -> cmake.FileAPI:
     return cmake.FileAPI(
         cmake_build_directory = pathlib.Path(os.environ['CMAKE_BINARY_DIR']),

--- a/tests/python/test/sass/test_sass.py
+++ b/tests/python/test/sass/test_sass.py
@@ -7,7 +7,6 @@ import typing
 import pytest
 import regex
 import semantic_version
-import typeguard
 
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.tools.binaries     import CuObjDump
@@ -54,7 +53,6 @@ __global__ void elementwise_add_restrict_wide(float4* __restrict__ const dst, co
 """Element-wise add with 128-bit ``float4``."""
 
 @functools.lru_cache(maxsize = 128)
-@typeguard.typechecked
 def get_decoder(*, cwd : pathlib.Path, arch : NVIDIAArch, file : pathlib.Path, cmake_file_api : cmake.FileAPI, **kwargs) -> tuple[Decoder, pathlib.Path]:
     """
     Compile the code in `file` for `arch` and return a :py:class:`reprospect.tools.sass.Decoder`.
@@ -205,7 +203,6 @@ __global__ void elementwise_add_ldg(int* const dst, const int* const src) {
 }
 """
 
-    @typeguard.typechecked
     def test_elementwise_add_restrict(self, request, workdir, parameters : Parameters, cmake_file_api : cmake.FileAPI) -> None:
         """
         Test loads with :py:const:`CODE_ELEMENTWISE_ADD_RESTRICT`.
@@ -252,7 +249,6 @@ __global__ void elementwise_add_ldg(int* const dst, const int* const src) {
         load = [(inst, matched) for inst in decoder.instructions if (matched := matcher.matches(inst))]
         assert len(load) == 2
 
-    @typeguard.typechecked
     def test_elementwise_add_restrict_wide(self, request, workdir, parameters : Parameters, cmake_file_api : cmake.FileAPI) -> None:
         """
         Test wide loads with :py:const:`CODE_ELEMENTWISE_ADD_RESTRICT_WIDE`.
@@ -304,7 +300,6 @@ class TestStoreGlobalMatcher:
     """
     Tests for :py:class:`reprospect.test.sass.StoreGlobalMatcher`.
     """
-    @typeguard.typechecked
     def test_elementwise_add_restrict(self, request, workdir, parameters : Parameters, cmake_file_api : cmake.FileAPI) -> None:
         """
         Test store with :py:const:`CODE_ELEMENTWISE_ADD_RESTRICT`.

--- a/tests/python/test/test_saxpy.py
+++ b/tests/python/test/test_saxpy.py
@@ -2,7 +2,6 @@ import pathlib
 import sys
 
 import pytest
-import typeguard
 
 import reprospect
 
@@ -26,7 +25,6 @@ class TestSaxpy(reprospect.CMakeAwareTestCase):
 
     @classmethod
     @override
-    @typeguard.typechecked
     def get_target_name(cls) -> str:
         return 'tests_cpp_cuda_saxpy'
 
@@ -35,21 +33,17 @@ class TestSASS(TestSaxpy):
     SASS-focused analysis.
     """
     @property
-    @typeguard.typechecked
     def cubin(self) -> pathlib.Path:
         return self.cwd / f'saxpy.1.{self.arch.as_sm}.cubin'
 
     @pytest.fixture(scope = 'class')
-    @typeguard.typechecked
     def cuobjdump(self) -> CuObjDump:
         return CuObjDump.extract(file = self.executable, arch = self.arch, sass = True, cwd = self.cwd, cubin = self.cubin.name)[0]
 
     @pytest.fixture(scope = 'class')
-    @typeguard.typechecked
     def decoder(self, cuobjdump : CuObjDump) -> Decoder:
         return Decoder(code = cuobjdump.sass)
 
-    @typeguard.typechecked
     def test_instruction_count(self, decoder : Decoder) -> None:
         assert len(decoder.instructions) >= 16
 
@@ -69,7 +63,6 @@ class TestNCU(TestSaxpy):
     ]
 
     @pytest.fixture(scope = 'class')
-    @typeguard.typechecked
     def report(self) -> ncu.Report:
         session = ncu.Session(output = self.cwd / 'ncu')
         session.run(
@@ -82,11 +75,9 @@ class TestNCU(TestSaxpy):
         return ncu.Report(session = session)
 
     @pytest.fixture(scope = 'class')
-    @typeguard.typechecked
     def results(self, report : ncu.Report) -> ncu.ProfilingResults:
         return report.extract_metrics_in_range(0, metrics = self.METRICS)
 
-    @typeguard.typechecked
     def test_result_count(self, report : ncu.Report, results : ncu.ProfilingResults) -> None:
         """
         Check how many ranges and results there are in the report.


### PR DESCRIPTION
It's kept for tests with the typeguard plugin.