### PR TITLE
Tools: make `symtab` a cached property of `CuObjDump`

### DIFF
--- a/python/reprospect/tools/binaries/__init__.py
+++ b/python/reprospect/tools/binaries/__init__.py
@@ -1,10 +1,11 @@
-from .cuobjdump import CuObjDump, Function, ResourceUsage
+from .cuobjdump import CuObjDump, Function, ResourceType, ResourceUsage
 from .demangle  import CuppFilt, LlvmCppFilt
 
 __all__ = [
     'CuObjDump',
     'Function',
+    'ResourceType',
     'ResourceUsage',
     'CuppFilt',
-    'LlvmCppFilt'
+    'LlvmCppFilt',
 ]

--- a/tests/python/test/sass/test_sass.py
+++ b/tests/python/test/sass/test_sass.py
@@ -62,7 +62,7 @@ def get_decoder(*, cwd : pathlib.Path, arch : NVIDIAArch, file : pathlib.Path, c
         source = file,
         cwd = cwd,
         arch = arch,
-        object = True,
+        object_file = True,
         resource_usage = False,
         cmake_file_api = cmake_file_api,
         **kwargs,

--- a/tests/python/tools/test_sass.py
+++ b/tests/python/tools/test_sass.py
@@ -160,7 +160,7 @@ class TestSASSDecoder:
             source = CUDA_FILE,
             cwd = workdir,
             arch = parameters.arch,
-            object = True,
+            object_file = True,
             cmake_file_api = cmake_file_api,
         )
 


### PR DESCRIPTION
This PR makes `symtab` a cached property of `CuObjDump`.

Motivated by:
- #186 

Drive-by: 
- rename `ResourceUsage` as `ResourceType` 
- rename `ResourceUsageDict` as `ResourceUsage`
- rename `Function` as `CuObjDumpFunction` to prepare for `NVDisasmFunction`

Follow-up for:
- #208