### PR TITLE
pytest: centralized configuration file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -335,7 +335,9 @@ jobs:
               run: |
                   . ${{ github.job }}/bin/activate
                   pip install -U pytest
-                  python3 -m pytest -vvv -s --log-cli-level=info tests/python/test_extensibility.py
+                  python3 -m pytest \
+                      --config-file=tests/python/.pytest.ini \
+                      tests/python/test_extensibility.py
 
     documentation:
         needs: [setup-job-matrix, tests]

--- a/examples/kokkos/CMakeLists.txt
+++ b/examples/kokkos/CMakeLists.txt
@@ -17,7 +17,7 @@ function(add_one_example FILE)
     add_test(
         NAME ${EXECUTABLE}
         COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/example_${FILE}.py
-                    -vvv -s --log-cli-level=info
+                    --config-file=${CMAKE_SOURCE_DIR}/tests/python/.pytest.ini
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 

--- a/tests/nvtx/CMakeLists.txt
+++ b/tests/nvtx/CMakeLists.txt
@@ -6,6 +6,6 @@ add_test(
                 --backtrace=none
                 --cpuctxsw=none
                 ${Python_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test_nvtx.py
-                    -vvv -s --log-cli-level=info
+                    --config-file=${CMAKE_SOURCE_DIR}/tests/python/.pytest.ini
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )

--- a/tests/python/.pytest.ini
+++ b/tests/python/.pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+addopts =
+    --strict-config
+    -vvv
+    -s
+    --log-cli-level=info
+filterwarnings =
+    error::pytest.PytestCollectionWarning

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -10,8 +10,8 @@ function(add_pytest FILE)
         NAME ${FILENAME}
         COMMAND ${Python_EXECUTABLE} -m pytest
                     --typeguard-packages=reprospect
+                    --config-file=${CMAKE_SOURCE_DIR}/tests/python/.pytest.ini
                     ${FILEPATH}
-                    -vvv -s --log-cli-level=info
     )
 
     test_environment(${FILENAME} PYTHONPATH path_list_prepend ${CMAKE_SOURCE_DIR}/python)


### PR DESCRIPTION
The main goal of this configuration file is to enforce failure of `pytest` on collection warning.