### PR TITLE
tests(graph): refactor cubin property to return string type

### DIFF
--- a/tests/python/test/test_graph.py
+++ b/tests/python/test/test_graph.py
@@ -1,5 +1,4 @@
 import logging
-import pathlib
 import sys
 import typing
 
@@ -36,8 +35,8 @@ class TestSASS(TestGraph):
     SASS-focused analysis.
     """
     @property
-    def cubin(self) -> pathlib.Path:
-        return self.cwd / f'graph.1.{self.arch.as_sm}.cubin'
+    def cubin(self) -> str:
+        return f'graph.1.{self.arch.as_sm}.cubin'
 
     @pytest.fixture(scope = 'class')
     def cuobjdump(self) -> CuObjDump:
@@ -46,7 +45,7 @@ class TestSASS(TestGraph):
             arch = self.arch,
             sass = True,
             cwd = self.cwd,
-            cubin = self.cubin.name,
+            cubin = self.cubin,
             demangler = self.demangler,
         )[0]
 


### PR DESCRIPTION
Changed the return type of the 'cubin' property to string and updated its usage in the 'cuobjdump' fixture.

Extracted from:
- #220 