### PR TITLE
tests(sass): bullet-proof any instruction matcher

### DIFF
--- a/python/reprospect/tools/binaries/cuobjdump.py
+++ b/python/reprospect/tools/binaries/cuobjdump.py
@@ -18,6 +18,7 @@ import sys
 import textwrap
 import typing
 
+import mypy_extensions
 import pandas
 import rich.console
 import rich.text
@@ -74,6 +75,7 @@ class ResourceUsage(StrEnum):
                     res[t] = int(token[2])
         return res
 
+@mypy_extensions.mypyc_attr(native_class = True)
 @dataclasses.dataclass(slots = True)
 class Function:
     """
@@ -114,6 +116,7 @@ class Function:
             console.print(self.to_table(), no_wrap = True)
         return capture.get()
 
+@mypy_extensions.mypyc_attr(native_class = True)
 class CuObjDump:
     """
     Use ``cuobjdump`` for extracting SASS, symbol table, and so on.

--- a/tests/python/test/sass/CMakeLists.txt
+++ b/tests/python/test/sass/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_pytest(any)
 add_pytest(atomic)
 add_pytest(matchers)
 add_pytest(sass)

--- a/tests/python/test/sass/test_any.py
+++ b/tests/python/test/sass/test_any.py
@@ -1,0 +1,50 @@
+import logging
+import typing
+
+from reprospect.test.sass import AnyMatcher, InstructionMatch
+
+class TestAnyMatcher:
+    """
+    Tests for :py:class:`reprospect.test.sass.AnyMatcher`.
+    """
+    INSTRUCTIONS : typing.Final[dict[str, InstructionMatch]] = {
+        'IMAD.MOV.U32 R4, R4, R5, R6' : InstructionMatch(opcode = 'IMAD', modifiers = ('MOV', 'U32'), operands = ('R4', 'R4', 'R5', 'R6')),
+        'FADD.FTZ.RN R0, R1, R2' : InstructionMatch(opcode = 'FADD', modifiers = ('FTZ', 'RN'), operands = ('R0', 'R1', 'R2')),
+        'MOV R8, c[0x0][0x140]' : InstructionMatch(opcode = 'MOV', modifiers = (), operands = ('R8', 'c[0x0][0x140]')),
+        'LDG.E.SYS R4, [R2]' : InstructionMatch(opcode = 'LDG', modifiers = ('E', 'SYS'), operands = ('R4', '[R2]')),
+        'STG.E [R2], R4' : InstructionMatch(opcode = 'STG', modifiers = ('E',), operands = ('[R2]', 'R4')),
+        'IADD3 R2, R2, 0x4, RZ' : InstructionMatch(opcode = 'IADD3', modifiers = (), operands = ('R2', 'R2', '0x4', 'RZ')),
+        'ISETP.NE.AND P0, PT, R1, RZ, PT' : InstructionMatch(opcode = 'ISETP', modifiers = ('NE', 'AND'), operands = ('P0', 'PT', 'R1', 'RZ', 'PT')),
+        'FMUL.FTZ R2, R2, R3' : InstructionMatch(opcode = 'FMUL', modifiers = ('FTZ',), operands = ('R2', 'R2', 'R3')),
+        'S2R R0, SR_CTAID.X' : InstructionMatch(opcode = 'S2R', modifiers = (), operands = ('R0', 'SR_CTAID.X')),
+        'BRA 0x240' : InstructionMatch(opcode = 'BRA', modifiers = (), operands = ('0x240',)),
+        'EXIT' : InstructionMatch(opcode = 'EXIT', modifiers = (), operands = ()),
+        'NOP' : InstructionMatch(opcode = 'NOP', modifiers = (), operands = ()),
+        'FMUL R6, R27.reuse, 0.044714998453855514526' : InstructionMatch(opcode = 'FMUL', modifiers = (), operands = ('R6', 'R27.reuse', '0.044714998453855514526')),
+        'F2FP.BF16.PACK_AB R27, R6, R27' : InstructionMatch(opcode = 'F2FP', modifiers = ('BF16', 'PACK_AB'), operands = ('R27', 'R6', 'R27')),
+        'DADD R12, |R12|, |R14|' : InstructionMatch(opcode = 'DADD', modifiers = (), operands = ('R12', '|R12|', '|R14|')),
+        'LDG.E R0, desc[UR12][R18.64]' : InstructionMatch(opcode = 'LDG', modifiers = ('E',), operands = ('R0', 'desc[UR12][R18.64]')),
+        'LDS.64 R12, [UR7+0x8]' : InstructionMatch(opcode = 'LDS', modifiers = ('64',), operands = ('R12', '[UR7+0x8]')),
+        'HFMA2 R7, -RZ, RZ, 0, 5.9604644775390625e-08' : InstructionMatch(opcode = 'HFMA2', modifiers = (), operands = ('R7', '-RZ', 'RZ', '0', '5.9604644775390625e-08')),
+        'ATOMG.E.ADD.STRONG.GPU PT, R4, desc[UR16][R4.64], R7' : InstructionMatch(opcode = 'ATOMG', modifiers = ('E', 'ADD', 'STRONG', 'GPU'), operands = ('PT', 'R4', 'desc[UR16][R4.64]', 'R7')),
+        'MEMBAR.SC.GPU' : InstructionMatch(opcode = 'MEMBAR', modifiers = ('SC', 'GPU'), operands = ()),
+        'LOP3.LUT P0, RZ, R8, R94, RZ, 0xfc, !PT' : InstructionMatch(opcode = 'LOP3', modifiers = ('LUT',), operands = ('P0', 'RZ', 'R8', 'R94', 'RZ', '0xfc', '!PT')),
+        '@!P3 LDG.E.64.CONSTANT R6, desc[UR16][R26.64]' : InstructionMatch(predicate = '@!P3', opcode = 'LDG', modifiers = ('E', '64', 'CONSTANT'), operands = ('R6', 'desc[UR16][R26.64]')),
+        '@!UP0 UIMAD UR7, UR10, 0xc, URZ' : InstructionMatch(predicate = '@!UP0', opcode = 'UIMAD', modifiers = (), operands = ('UR7', 'UR10', '0xc', 'URZ')),
+        '@UP0 LDCU.64 UR12, c[0x0][0x388]' : InstructionMatch(predicate = '@UP0', opcode = 'LDCU', modifiers = ('64',), operands = ('UR12', 'c[0x0][0x388]')),
+        'RET.REL.NODEC R4 0x0' : InstructionMatch(opcode = 'RET', modifiers = ('REL', 'NODEC'), operands = ('R4', '0x0')),
+        '@!PT LDS RZ, [RZ]' : InstructionMatch(predicate = '@!PT', opcode = 'LDS', modifiers = (), operands = ('RZ', '[RZ]')),
+    }
+    """
+    Zoo of real SASS instructions.
+    """
+
+    def test(self) -> None:
+        for instruction, expected in self.INSTRUCTIONS.items():
+            matched = AnyMatcher().matches(inst = instruction)
+
+            logging.info(instruction)
+            logging.info(matched)
+
+            assert matched is not None
+            assert matched == expected


### PR DESCRIPTION
I've bullet-proofed it using the following, which loops over all the cubins embedded in `libcublas.so`.
```python
    def test_hard(self) -> None:
        import pathlib
        import subprocess

        from reprospect.tools.architecture import NVIDIAArch
        from reprospect.tools.binaries     import CuObjDump
        from reprospect.tools.sass         import Decoder

        WORKDIR = pathlib.Path('/workspaces/cuda-helpers/build')

        WORKDIR.mkdir(parents = True, exist_ok = True)

        ARCH = NVIDIAArch.from_str('BLACKWELL120')

        CUBLAS = pathlib.Path('/usr/local/cuda-12.8/targets/x86_64-linux/lib/libcublas.so')

        assert CUBLAS.is_file()

        subprocess.check_call(('cuobjdump', '--extract-elf', 'libcublas', '--gpu-architecture', ARCH.as_sm, CUBLAS), cwd = WORKDIR)

        for file in WORKDIR.glob(pattern = 'libcublas.*.cubin'):
            logging.info(file)

            cuobjdump = CuObjDump(file = file, arch = ARCH, sass = True)

            logging.info(f'There are {len(cuobjdump.functions)} functions.')

            counter = 0

            matcher = AnyMatcher()

            for function in cuobjdump.functions:
                decoder = Decoder(code = cuobjdump.functions[function].code)

                counter += len(decoder.instructions)

                for instruction in decoder.instructions:
                    assert matcher.matches(inst = instruction) is not None

            logging.info(f'Parsed {counter} SASS instructions.')
```

Typical output for one cubin:
```bash
7: INFO     root:test_any.py:73 /workspaces/cuda-helpers/build/libcublas.195.sm_120.cubin
7: INFO     root:cuobjdump.py:149 Extracting 'SASS' from /workspaces/cuda-helpers/build/libcublas.195.sm_120.cubin using ('cuobjdump', '--gpu-architecture', 'sm_120', '--dump-sass', '--dump-resource-usage', PosixPath('/workspaces/cuda-helpers/build/libcublas.195.sm_120.cubin')).
7: INFO     root:test_any.py:77 There are 10 functions.
7: INFO     root:test_any.py:91 Parsed 110640 SASS instructions.
```