### PR TITLE
tests(parameters): return always in same order

### DIFF
--- a/tests/python/parameters.py
+++ b/tests/python/parameters.py
@@ -16,7 +16,7 @@ def architectures(version : semantic_version.Version = semantic_version.Version(
     """
     Get the list of architectures to test, that are supported by `version`.
     """
-    return tuple({
+    return tuple(
         arch for cc in [
             70,
             75,
@@ -27,6 +27,6 @@ def architectures(version : semantic_version.Version = semantic_version.Version(
             100,
             120,
         ] if (arch := NVIDIAArch.from_compute_capability(cc = cc)).compute_capability.supported(version = version)
-    })
+    )
 
 PARAMETERS : typing.Final[tuple[Parameters, ...]] = tuple(Parameters(arch = arch) for arch in architectures())


### PR DESCRIPTION
1. Avoid intermediate set.
2. Allows `pytest-xdist` plugin (https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#order-and-amount-of-test-must-be-consistent).