### PR TITLE
python(requirements): add `pytest-xdist`

### DIFF
--- a/requirements/requirements.python.txt
+++ b/requirements/requirements.python.txt
@@ -3,6 +3,7 @@ mypy>=1.18.2
 myst-nb>=1.3.0
 nvtx>=0.2.13
 pylint>=4.0.1
+pytest-xdist>=3.8.0
 sphinx>=8.1
 sphinx-rtd-theme>=3.0.2
 sphinx-github-style>=1.2.2


### PR DESCRIPTION
For running tests in parallel.