### PR TITLE
Tools: parametrize tests in architecture

### DIFF
--- a/python/reprospect/tools/architecture.py
+++ b/python/reprospect/tools/architecture.py
@@ -119,17 +119,17 @@ class NVIDIAFamily(StrEnum):
         See :cite:`nvidia-cuda-gpu-compute-capability`.
         """
         value = cc.as_int if isinstance(cc, ComputeCapability) else cc
-        if value in [70, 72]:
+        if value in (70, 72):
             return NVIDIAFamily.VOLTA
         if value == 75:
             return NVIDIAFamily.TURING
-        if value in [80, 86, 87]:
+        if value in (80, 86, 87):
             return NVIDIAFamily.AMPERE
         if value == 89:
             return NVIDIAFamily.ADA
         if value == 90:
             return NVIDIAFamily.HOPPER
-        if value in [100, 103, 110, 120]:
+        if value in (100, 103, 110, 120, 121):
             return NVIDIAFamily.BLACKWELL
         raise ValueError(f"unsupported compute capability {cc}")
 

--- a/tests/python/tools/test_architecture.py
+++ b/tests/python/tools/test_architecture.py
@@ -8,6 +8,8 @@ import semantic_version
 
 from reprospect.tools.architecture import CUDA_SUPPORT, ComputeCapability, NVIDIAFamily, NVIDIAArch
 
+from tests.python.parameters import Parameters, PARAMETERS
+
 class TestComputeCapability:
     """
     Tests for :py:class:`reprospect.tools.architecture.ComputeCapability`.
@@ -94,6 +96,14 @@ class TestNVIDIAArch:
     def test_repr(self) -> None:
         assert repr(NVIDIAArch.from_compute_capability(86)) == "NVIDIAArch(family=<NVIDIAFamily.AMPERE: 'AMPERE'>, compute_capability=ComputeCapability(major=8, minor=6))"
 
-    def test_str_cycle(self) -> None:
-        arch = NVIDIAArch.from_compute_capability(70)
-        assert NVIDIAArch.from_str(str(arch)) == arch
+    @pytest.mark.parametrize('parameters', PARAMETERS, ids = str)
+    def test_str_cycle(self, parameters : Parameters) -> None:
+        assert NVIDIAArch.from_str(str(parameters.arch)) == parameters.arch
+
+    @pytest.mark.parametrize('parameters', PARAMETERS, ids = str)
+    def test_cc_cycle(self, parameters : Parameters) -> None:
+        assert NVIDIAArch.from_compute_capability(parameters.arch.compute_capability.as_int) == parameters.arch
+
+    @pytest.mark.parametrize('parameters', PARAMETERS, ids = str)
+    def test_in_cuda_support(self, parameters : Parameters) -> None:
+        assert parameters.arch.compute_capability.as_int in CUDA_SUPPORT


### PR DESCRIPTION
This PR parametrizes some tests in architecture. This way, we better ensure that our `CUDA_SUPPORT` dictionary and our `from_compute_capability` method cover the architectures that we want.

Partially extracted from:
- #230 