### PR TITLE
Housekeeping: split `test_binaries`

### DIFF
--- a/docs/source/tests/python/compilation.rst
+++ b/docs/source/tests/python/compilation.rst
@@ -2,3 +2,5 @@ Compilation
 ===========
 
 .. automodule:: tests.python.compilation
+
+.. automodule:: tests.python.test_compilation

--- a/docs/source/tests/python/tools.rst
+++ b/docs/source/tests/python/tools.rst
@@ -9,11 +9,11 @@ Architecture
 Binaries
 ~~~~~~~~
 
-.. automodule:: tests.python.tools.test_binaries
-
 .. toctree::
    :maxdepth: 4
 
+   tools/binaries/cuobjdump
+   tools/binaries/demangle
    tools/binaries/elf
 
 Cacher

--- a/docs/source/tests/python/tools/binaries/cuobjdump.rst
+++ b/docs/source/tests/python/tools/binaries/cuobjdump.rst
@@ -1,0 +1,4 @@
+cuobjdump
+=========
+
+.. automodule:: tests.python.tools.binaries.test_cuobjdump

--- a/docs/source/tests/python/tools/binaries/demangle.rst
+++ b/docs/source/tests/python/tools/binaries/demangle.rst
@@ -1,0 +1,4 @@
+demangle
+========
+
+.. automodule:: tests.python.tools.binaries.test_demangle

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -28,6 +28,8 @@ function(add_pytest FILE)
 
 endfunction()
 
+add_pytest(compilation)
+
 add_subdirectory(test)
 add_subdirectory(tools)
 add_subdirectory(utils)

--- a/tests/python/test_compilation.py
+++ b/tests/python/test_compilation.py
@@ -1,0 +1,98 @@
+import pathlib
+import typing
+
+import pytest
+
+from reprospect.utils import cmake
+
+from tests.python.compilation import get_compilation_output
+from tests.python.parameters  import Parameters, PARAMETERS
+
+@pytest.mark.parametrize('parameters', PARAMETERS, ids = str)
+class TestResourceUsage:
+    """
+    All tests related to reading resource usage from compilation output.
+    """
+    class TestSharedMemory:
+        """
+        When the kernel uses shared memory.
+        """
+        FILE : typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / 'tools' / 'binaries' / 'assets' / 'shared_memory.cu'
+
+        def test(self, workdir, parameters : Parameters, cmake_file_api : cmake.FileAPI) -> None:
+            """
+            Check how shared memory is reported in the compilation output.
+            """
+            _, compilation = get_compilation_output(
+                source = self.FILE,
+                cwd = workdir,
+                arch = parameters.arch,
+                object_file = True,
+                resource_usage = True,
+                cmake_file_api = cmake_file_api,
+            )
+
+            assert f"Compiling entry function '_Z20shared_memory_kernelPfj' for '{parameters.arch.as_sm}'" in compilation, compilation
+
+            if parameters.arch.compute_capability < 90:
+                assert f'Used 10 registers, used 1 barriers, {128 * 4} bytes smem, 364 bytes cmem[0]' in compilation, compilation
+            else:
+                assert f'Used 10 registers, used 1 barriers, {128 * 4} bytes smem' in compilation, compilation
+
+    class TestWideLoadStore:
+        """
+        When the kernel uses wide loads and stores.
+        """
+        FILE : typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / 'tools' / 'binaries' / 'assets' / 'wide_load_store.cu'
+
+        def test(self, workdir : pathlib.Path, parameters : Parameters, cmake_file_api : cmake.FileAPI) -> None:
+            """
+            Check how wide loads and stores influence the compilation result.
+            """
+            _, compilation = get_compilation_output(
+                source = self.FILE,
+                cwd = workdir,
+                arch = parameters.arch,
+                object_file = True,
+                resource_usage = True,
+                cmake_file_api = cmake_file_api,
+            )
+
+            assert f"Compiling entry function '_Z22wide_load_store_kernelP15MyAlignedStructIdEPKS0_' for '{parameters.arch.as_sm}'" in compilation, compilation
+
+            if parameters.arch.compute_capability < 90:
+                assert 'Used 12 registers, used 0 barriers, 368 bytes cmem[0]' in compilation, compilation
+            elif parameters.arch.compute_capability < 100:
+                expt_regs = {
+                    'NVIDIA' : 14,
+                    'Clang' : 12,
+                }[cmake_file_api.toolchains['CUDA']['compiler']['id']]
+                assert f'Used {expt_regs} registers, used 0 barriers' in compilation, compilation
+            else:
+                assert 'Used 12 registers, used 0 barriers' in compilation, compilation
+
+    class TestSaxpy:
+        """
+        When the kernel performs a `saxpy`.
+        """
+        FILE : typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / 'tools' / 'assets' / 'saxpy.cu'
+
+        def test(self, workdir, parameters : Parameters, cmake_file_api : cmake.FileAPI) -> None:
+            """
+            Check compilation result.
+            """
+            _, compilation = get_compilation_output(
+                source = self.FILE,
+                cwd = workdir,
+                arch = parameters.arch,
+                object_file = True,
+                resource_usage = True,
+                cmake_file_api = cmake_file_api,
+            )
+
+            assert f"Compiling entry function '_Z12saxpy_kernelfPKfPfj' for '{parameters.arch.as_sm}'" in compilation, compilation
+
+            if parameters.arch.compute_capability < 90:
+                assert 'Used 10 registers, used 0 barriers, 380 bytes cmem[0]' in compilation, compilation
+            else:
+                assert 'Used 10 registers, used 0 barriers' in compilation, compilation

--- a/tests/python/tools/CMakeLists.txt
+++ b/tests/python/tools/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_pytest(architecture)
-add_pytest(binaries)
 add_pytest(cacher)
 add_pytest(device_properties)
 add_pytest(ncu)

--- a/tests/python/tools/binaries/CMakeLists.txt
+++ b/tests/python/tools/binaries/CMakeLists.txt
@@ -1,1 +1,3 @@
+add_pytest(cuobjdump)
+add_pytest(demangle)
 add_pytest(elf)

--- a/tests/python/tools/binaries/test_cuobjdump.py
+++ b/tests/python/tools/binaries/test_cuobjdump.py
@@ -1,126 +1,16 @@
 import logging
 import pathlib
-import shutil
 import typing
 
 import pytest
 import rich.console
 
 from reprospect.tools.architecture import NVIDIAArch
-from reprospect.tools.binaries     import CuObjDump, CuppFilt, LlvmCppFilt, Function, ResourceType, ResourceUsage
+from reprospect.tools.binaries     import CuObjDump, CuppFilt, Function, ResourceType, ResourceUsage
 from reprospect.utils              import cmake
 
 from tests.python.compilation import get_compilation_output, get_cubin_name
 from tests.python.parameters  import Parameters, PARAMETERS
-
-@pytest.mark.parametrize('parameters', PARAMETERS, ids = str)
-class TestResourceUsage:
-    """
-    All tests related to reading resource usage from compilation output.
-    """
-    class TestSharedMemory:
-        """
-        When the kernel uses shared memory.
-        """
-        FILE : typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / 'binaries' / 'assets' / 'shared_memory.cu'
-
-        def test(self, workdir, parameters : Parameters, cmake_file_api : cmake.FileAPI) -> None:
-            """
-            Check how shared memory is reported in the compilation output.
-            """
-            _, compilation = get_compilation_output(
-                source = self.FILE,
-                cwd = workdir,
-                arch = parameters.arch,
-                object_file = True,
-                resource_usage = True,
-                cmake_file_api = cmake_file_api,
-            )
-
-            assert f"Compiling entry function '_Z20shared_memory_kernelPfj' for '{parameters.arch.as_sm}'" in compilation, compilation
-
-            if parameters.arch.compute_capability < 90:
-                assert f'Used 10 registers, used 1 barriers, {128 * 4} bytes smem, 364 bytes cmem[0]' in compilation, compilation
-            else:
-                assert f'Used 10 registers, used 1 barriers, {128 * 4} bytes smem' in compilation, compilation
-
-    class TestWideLoadStore:
-        """
-        When the kernel uses wide loads and stores.
-        """
-        FILE : typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / 'binaries' / 'assets' / 'wide_load_store.cu'
-
-        def test(self, workdir : pathlib.Path, parameters : Parameters, cmake_file_api : cmake.FileAPI) -> None:
-            """
-            Check how wide loads and stores influence the compilation result.
-            """
-            _, compilation = get_compilation_output(
-                source = self.FILE,
-                cwd = workdir,
-                arch = parameters.arch,
-                object_file = True,
-                resource_usage = True,
-                cmake_file_api = cmake_file_api,
-            )
-
-            assert f"Compiling entry function '_Z22wide_load_store_kernelP15MyAlignedStructIdEPKS0_' for '{parameters.arch.as_sm}'" in compilation, compilation
-
-            if parameters.arch.compute_capability < 90:
-                assert 'Used 12 registers, used 0 barriers, 368 bytes cmem[0]' in compilation, compilation
-            elif parameters.arch.compute_capability < 100:
-                expt_regs = {
-                    'NVIDIA' : 14,
-                    'Clang' : 12,
-                }[cmake_file_api.toolchains['CUDA']['compiler']['id']]
-                assert f'Used {expt_regs} registers, used 0 barriers' in compilation, compilation
-            else:
-                assert 'Used 12 registers, used 0 barriers' in compilation, compilation
-
-    class TestSaxpy:
-        """
-        When the kernel performs a `saxpy`.
-        """
-        FILE : typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / 'assets' / 'saxpy.cu'
-
-        def test(self, workdir, parameters : Parameters, cmake_file_api : cmake.FileAPI) -> None:
-            """
-            Check compilation result.
-            """
-            _, compilation = get_compilation_output(
-                source = self.FILE,
-                cwd = workdir,
-                arch = parameters.arch,
-                object_file = True,
-                resource_usage = True,
-                cmake_file_api = cmake_file_api,
-            )
-
-            assert f"Compiling entry function '_Z12saxpy_kernelfPKfPfj' for '{parameters.arch.as_sm}'" in compilation, compilation
-
-            if parameters.arch.compute_capability < 90:
-                assert 'Used 10 registers, used 0 barriers, 380 bytes cmem[0]' in compilation, compilation
-            else:
-                assert 'Used 10 registers, used 0 barriers' in compilation, compilation
-
-class TestCuppFilt:
-    """
-    Test :py:class:`reprospect.tools.binaries.CuppFilt`.
-    """
-    def test_demangle(self):
-        assert CuppFilt.demangle(s = '_Z5saxpyfPKfPfj') == 'saxpy(float, const float *, float *, unsigned int)'
-
-@pytest.mark.skipif(
-    shutil.which(LlvmCppFilt.get_executable()) is None, reason = f'requires that {LlvmCppFilt.get_executable()} is installed'
-)
-class TestLlvmCppFilt:
-    """
-    Test :py:class:`reprospect.tools.binaries.LlvmCppFilt`.
-    """
-    def test_demangle(self):
-        MANGLED = '_Z24add_and_increment_kernelILj0ETpTnjJEEvPj'
-        assert LlvmCppFilt.demangle(s = MANGLED) == 'void add_and_increment_kernel<0u>(unsigned int*)'
-        # cu++filt cannot demangle this symbol.
-        assert CuppFilt.demangle(s = MANGLED).startswith('_Z')
 
 class TestFunction:
     """
@@ -194,8 +84,8 @@ class TestCuObjDump:
         """
         When the kernel performs a `saxpy`.
         """
-        CPP_FILE  : typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / 'assets' / 'saxpy.cpp'
-        CUDA_FILE : typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / 'assets' / 'saxpy.cu'
+        CPP_FILE  : typing.Final[pathlib.Path] = pathlib.Path(__file__).parent.parent / 'assets' / 'saxpy.cpp'
+        CUDA_FILE : typing.Final[pathlib.Path] = pathlib.Path(__file__).parent.parent / 'assets' / 'saxpy.cu'
         SYMBOL    : typing.Final[str] = '_Z12saxpy_kernelfPKfPfj'
         SIGNATURE : typing.Final[str] = CuppFilt.demangle(SYMBOL)
 
@@ -316,8 +206,8 @@ class TestCuObjDump:
 
             ``__device__`` functions have been inlined.
         """
-        CUDA_FILE : typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / 'binaries' / 'assets' / 'many.cu'
-        CPP_FILE  : typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / 'binaries' / 'assets' / 'many.cpp'
+        CUDA_FILE : typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / 'assets' / 'many.cu'
+        CPP_FILE  : typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / 'assets' / 'many.cpp'
 
         SYMBOLS : typing.Final[dict[str, str]] = {
             '_Z6say_hiv' : 'say_hi()',

--- a/tests/python/tools/binaries/test_demangle.py
+++ b/tests/python/tools/binaries/test_demangle.py
@@ -1,0 +1,25 @@
+import shutil
+
+import pytest
+
+from reprospect.tools.binaries import CuppFilt, LlvmCppFilt
+
+class TestCuppFilt:
+    """
+    Test :py:class:`reprospect.tools.binaries.CuppFilt`.
+    """
+    def test_demangle(self):
+        assert CuppFilt.demangle(s = '_Z5saxpyfPKfPfj') == 'saxpy(float, const float *, float *, unsigned int)'
+
+@pytest.mark.skipif(
+    shutil.which(LlvmCppFilt.get_executable()) is None, reason = f'requires that {LlvmCppFilt.get_executable()} is installed'
+)
+class TestLlvmCppFilt:
+    """
+    Test :py:class:`reprospect.tools.binaries.LlvmCppFilt`.
+    """
+    def test_demangle(self):
+        MANGLED = '_Z24add_and_increment_kernelILj0ETpTnjJEEvPj'
+        assert LlvmCppFilt.demangle(s = MANGLED) == 'void add_and_increment_kernel<0u>(unsigned int*)'
+        # cu++filt cannot demangle this symbol.
+        assert CuppFilt.demangle(s = MANGLED).startswith('_Z')


### PR DESCRIPTION
This PR splits `test_binaries.py` into:
- `tools/binaries/test_cuobjdump.py`
- `tools/binaries/test_demangle.py`
- `test_compilation.py`

The code is just moved. There are no changes, except a few changes to paths when needed.