### PR TITLE
Tools: use `nsys export` to export `sqlite`

### DIFF
--- a/python/reprospect/tools/nsys.py
+++ b/python/reprospect/tools/nsys.py
@@ -156,10 +156,9 @@ class Session:
         Export report to ``.sqlite``.
         """
         cmd : tuple[str | pathlib.Path, ...] = (
-            'nsys', 'stats',
-            '--force-overwrite=true',
-            '--force-export=true',
-            f'--sqlite={self.output_file_sqlite}',
+            'nsys', 'export',
+            '--type', 'sqlite',
+            f'--output={self.output_file_sqlite}',
             self.output_file_nsys_rep,
         )
 


### PR DESCRIPTION
Extracted from:
- #241

The motivation is that using `nsys stats` triggers `nsys` not only to export the `sqlite` but also to produce several reports. Using `nsys exports` allows to do only the export.

- https://docs.nvidia.com/nsight-systems/UserGuide/index.html#cli-stats-command-switch-options