### PR TITLE
tools(ncu): add `single_query_next` to profiling results

### DIFF
--- a/tests/python/test/test_graph.py
+++ b/tests/python/test/test_graph.py
@@ -102,9 +102,11 @@ class TestNCU(TestGraph):
         """
         Check metric `launch__registers_per_thread_allocated` for graph node A.
         """
-        def matcher(value : ncu.ProfilingMetrics) -> bool:
-            return value['demangled'] == TestGraph.DEMANGLED_NODE_A[self.toolchains['CUDA']['compiler']['id']]
+        def matcher(value : tuple[str, ncu.ProfilingMetrics]) -> bool:
+            return value[1]['demangled'] == TestGraph.DEMANGLED_NODE_A[self.toolchains['CUDA']['compiler']['id']]
 
-        [metrics] = list(filter(matcher, results.iter_metrics(accessors = ())))
+        [(key, metrics)] = filter(matcher, results.iter_metrics(accessors = ()))
+
+        logging.info(f'Kernel {key!r} matched. Its metrics are {metrics}.')
 
         assert metrics['launch__registers_per_thread_allocated'] == 512


### PR DESCRIPTION
This PR:
- refactors our `ProfilingResults` class; we now avoid inheriting from dict; instead, we build it up as a strongly typed tree 
- adds `query_single_next` to `ProfilingResults` (as well as the helper `query_single_next_metrics`)
- makes the example used in the test a bit more realistic

Remaining issue:
- Many of the metric values retrieved from `ncu_report` are `float`. Which is a bit surprising for counts like numbers of instructions. Probably for a follow-up to see what's going on.