### PR TITLE
CICD: add flag `Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON`

### DIFF
--- a/docker/kokkos.sh
+++ b/docker/kokkos.sh
@@ -25,6 +25,7 @@ cmake_args_kokkos+=(
     "-DKokkos_ENABLE_CUDA=ON"
     "-DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=ON"
     "-DKokkos_ARCH_${KOKKOS_ARCH}=ON"
+    "-DKokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON"
     "-DCMAKE_INSTALL_PREFIX=/opt/kokkos-${KOKKOS_SHA}/${KOKKOS_INSTALL_SUFFIX}"
 )
 


### PR DESCRIPTION
This PR:
- adds the flag `Kokkos_ENABLE_COMPILE_AS_CMAKE_LANGUAGE=ON` to the `Kokkos` configure

Currently, without this flag, the `KokkosTargets.cmake` has these few lines:

```
set_target_properties(Kokkos::kokkoscore PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "\$<\$<COMPILE_LANGUAGE:CXX>:KOKKOS_DEPENDENCE>"
  INTERFACE_COMPILE_FEATURES "cxx_std_20"
  INTERFACE_COMPILE_OPTIONS "\$<\$<COMPILE_LANGUAGE:CXX>:>;\$<\$<COMPILE_LANGUAGE:CXX>:-x;cuda;--cuda-gpu-arch=sm_120>;\$<\$<COMPILE_LANGUAGE:CXX>:>"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "Kokkos::CUDA;Kokkos::LIBDL"
  INTERFACE_LINK_OPTIONS "\$<\$<LINK_LANGUAGE:CXX>:-DKOKKOS_DEPENDENCE>"
)
```

With the change of this PR, these few lines become:

```
set_target_properties(Kokkos::kokkoscore PROPERTIES
  INTERFACE_COMPILE_DEFINITIONS "\$<\$<COMPILE_LANGUAGE:CUDA>:KOKKOS_DEPENDENCE>"
  INTERFACE_COMPILE_FEATURES "cxx_std_20"
  INTERFACE_COMPILE_OPTIONS "\$<\$<COMPILE_LANGUAGE:CUDA>:>;\$<\$<COMPILE_LANGUAGE:CUDA>:-extended-lambda;-Wext-lambda-captures-this>;\$<\$<COMPILE_LANGUAGE:CUDA>:>"
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "Kokkos::CUDA;Kokkos::LIBDL"
  INTERFACE_LINK_OPTIONS "-DKOKKOS_DEPENDENCE"
)
```

And so the goal of this PR is to ensure that compile options like `-extended-lambda` are picked up when we compile our examples, for which we set CUDA as the compile language.