### PR TITLE
test(sass): matchers (reorganize + add int128)

### DIFF
--- a/docs/source/tests/python/test.rst
+++ b/docs/source/tests/python/test.rst
@@ -15,8 +15,8 @@ SASS instruction matcher
 
 .. automodule:: tests.python.test.sass.test_load
 
-.. automodule:: tests.python.test.sass.test_matchers
+.. automodule:: tests.python.test.sass.test_composite
 
-.. automodule:: tests.python.test.sass.test_matchers_impl
+.. automodule:: tests.python.test.sass.test_composite_impl
 
-.. automodule:: tests.python.test.sass.test_sass
+.. automodule:: tests.python.test.sass.test_instruction

--- a/reprospect/test/sass/composite.py
+++ b/reprospect/test/sass/composite.py
@@ -1,19 +1,19 @@
 """
-Thin user-facing factories for the matchers in :py:mod:`reprospect.test.matchers_impl`.
+Thin user-facing factories for the matchers in :py:mod:`reprospect.test.sass.composite_impl`.
 """
 
 import sys
 import typing
 
+from reprospect.test.sass  import composite_impl, instruction
 from reprospect.tools.sass import Instruction
-from reprospect.test       import matchers_impl, sass
 
 if sys.version_info >= (3, 12):
     from typing import override
 else:
     from typing_extensions import override
 
-class Fluentizer(sass.InstructionMatcher):
+class Fluentizer(instruction.InstructionMatcher):
     """
     .. note::
 
@@ -21,10 +21,10 @@ class Fluentizer(sass.InstructionMatcher):
     """
     __slots__ = ('matcher',)
 
-    def __init__(self, matcher : sass.InstructionMatcher) -> None:
-        self.matcher : typing.Final[sass.InstructionMatcher] = matcher
+    def __init__(self, matcher : instruction.InstructionMatcher) -> None:
+        self.matcher : typing.Final[instruction.InstructionMatcher] = matcher
 
-    def times(self, num : int) -> matchers_impl.SequenceMatcher:
+    def times(self, num : int) -> composite_impl.SequenceMatcher:
         """
         Match :py:attr:`matcher` `num` times (consecutively).
 
@@ -37,32 +37,32 @@ class Fluentizer(sass.InstructionMatcher):
         if num == 0:
             raise NotImplementedError()
         if num == 1:
-            return matchers_impl.InSequenceAtMatcher(matcher = self.matcher)
-        return matchers_impl.OrderedInSequenceMatcher(matchers = (self.matcher,) * num)
+            return composite_impl.InSequenceAtMatcher(matcher = self.matcher)
+        return composite_impl.OrderedInSequenceMatcher(matchers = (self.matcher,) * num)
 
-    def one_or_more_times(self) -> matchers_impl.OneOrMoreInSequenceMatcher:
+    def one_or_more_times(self) -> composite_impl.OneOrMoreInSequenceMatcher:
         """
         Match :py:attr:`matcher` one or more times (consecutively).
         """
-        return matchers_impl.OneOrMoreInSequenceMatcher(matcher = self.matcher)
+        return composite_impl.OneOrMoreInSequenceMatcher(matcher = self.matcher)
 
-    def zero_or_more_times(self) -> matchers_impl.ZeroOrMoreInSequenceMatcher:
+    def zero_or_more_times(self) -> composite_impl.ZeroOrMoreInSequenceMatcher:
         """
         Match :py:attr:`matcher` zero or more times (consecutively).
         """
-        return matchers_impl.ZeroOrMoreInSequenceMatcher(matcher = self.matcher)
+        return composite_impl.ZeroOrMoreInSequenceMatcher(matcher = self.matcher)
 
     @override
     @typing.final
-    def matches(self, inst : Instruction | str) -> typing.Optional[sass.InstructionMatch]:
+    def matches(self, inst : Instruction | str) -> typing.Optional[instruction.InstructionMatch]:
         return self.matcher.matches(inst = inst)
 
-def instruction_is(matcher : sass.InstructionMatcher) -> Fluentizer:
+def instruction_is(matcher : instruction.InstructionMatcher) -> Fluentizer:
     """
     Match the current instruction with `matcher`.
 
-    >>> from reprospect.test.matchers import instruction_is
-    >>> from reprospect.test.sass     import FloatAddMatcher
+    >>> from reprospect.test.sass.composite   import instruction_is
+    >>> from reprospect.test.sass.instruction import FloatAddMatcher
     >>> instruction_is(FloatAddMatcher()).matches(inst = 'FADD R2, R2, R3')
     InstructionMatch(opcode='FADD', modifiers=(), operands=('R2', 'R2', 'R3'), predicate=None, additional={'dst': ['R2']})
     >>> instruction_is(FloatAddMatcher()).one_or_more_times().matches(instructions = ('FADD R2, R2, R3', 'FADD R4, R4, R5'))
@@ -70,35 +70,35 @@ def instruction_is(matcher : sass.InstructionMatcher) -> Fluentizer:
     """
     return Fluentizer(matcher)
 
-def instructions_are(*matchers : sass.InstructionMatcher | matchers_impl.SequenceMatcher) -> matchers_impl.OrderedInSequenceMatcher:
+def instructions_are(*matchers : instruction.InstructionMatcher | composite_impl.SequenceMatcher) -> composite_impl.OrderedInSequenceMatcher:
     """
     Match a sequence of instructions against `matchers`.
 
-    >>> from reprospect.test.matchers import instructions_are
-    >>> from reprospect.test.sass     import OpcodeModsMatcher
+    >>> from reprospect.test.sass.composite   import instructions_are
+    >>> from reprospect.test.sass.instruction import OpcodeModsMatcher
     >>> instructions_are(
     ...     OpcodeModsMatcher(opcode = 'YIELD', operands = False),
     ...     instruction_is(OpcodeModsMatcher(opcode = 'NOP', operands = False)).zero_or_more_times(),
     ... ).matches(instructions = ('YIELD', 'NOP', 'NOP'))
     [InstructionMatch(opcode='YIELD', modifiers=(), operands=(), predicate=None, additional=None), InstructionMatch(opcode='NOP', modifiers=(), operands=(), predicate=None, additional=None), InstructionMatch(opcode='NOP', modifiers=(), operands=(), predicate=None, additional=None)]
     """
-    return matchers_impl.OrderedInSequenceMatcher(matchers = matchers)
+    return composite_impl.OrderedInSequenceMatcher(matchers = matchers)
 
-def unordered_instructions_are(*matchers : sass.InstructionMatcher | matchers_impl.SequenceMatcher) -> matchers_impl.UnorderedInSequenceMatcher:
+def unordered_instructions_are(*matchers : instruction.InstructionMatcher | composite_impl.SequenceMatcher) -> composite_impl.UnorderedInSequenceMatcher:
     """
     Match a sequence of instructions against `matchers` (unordered).
 
-    >>> from reprospect.test.matchers import unordered_instructions_are
-    >>> from reprospect.test.sass     import OpcodeModsMatcher
+    >>> from reprospect.test.sass.composite   import unordered_instructions_are
+    >>> from reprospect.test.sass.instruction import OpcodeModsMatcher
     >>> unordered_instructions_are(
     ...     OpcodeModsMatcher(opcode = 'YIELD', operands = False),
     ...     OpcodeModsMatcher(opcode = 'NOP', operands = False),
     ... ).matches(instructions = ('NOP', 'YIELD'))
     [InstructionMatch(opcode='NOP', modifiers=(), operands=(), predicate=None, additional=None), InstructionMatch(opcode='YIELD', modifiers=(), operands=(), predicate=None, additional=None)]
     """
-    return matchers_impl.UnorderedInSequenceMatcher(matchers = matchers)
+    return composite_impl.UnorderedInSequenceMatcher(matchers = matchers)
 
-def instructions_contain(matcher : sass.InstructionMatcher | matchers_impl.SequenceMatcher) -> matchers_impl.InSequenceMatcher:
+def instructions_contain(matcher : instruction.InstructionMatcher | composite_impl.SequenceMatcher) -> composite_impl.InSequenceMatcher:
     """
     Check that a sequence of instructions contains at least one instruction matching `matcher`.
 
@@ -106,8 +106,8 @@ def instructions_contain(matcher : sass.InstructionMatcher | matchers_impl.Seque
 
         Stops on the first match.
 
-    >>> from reprospect.test.matchers import instructions_are, instructions_contain
-    >>> from reprospect.test.sass     import OpcodeModsMatcher
+    >>> from reprospect.test.sass.composite   import instructions_are, instructions_contain
+    >>> from reprospect.test.sass.instruction import OpcodeModsMatcher
     >>> matcher = instructions_contain(instructions_are(
     ...     OpcodeModsMatcher(opcode = 'YIELD', operands = False),
     ...     OpcodeModsMatcher(opcode = 'FADD', operands = True),
@@ -117,9 +117,9 @@ def instructions_contain(matcher : sass.InstructionMatcher | matchers_impl.Seque
     >>> matcher.index
     2
     """
-    return matchers_impl.InSequenceMatcher(matcher)
+    return composite_impl.InSequenceMatcher(matcher)
 
-def any_of(*matchers : sass.InstructionMatcher | matchers_impl.SequenceMatcher) -> matchers_impl.AnyOfMatcher:
+def any_of(*matchers : instruction.InstructionMatcher | composite_impl.SequenceMatcher) -> composite_impl.AnyOfMatcher:
     """
     Match a sequence of instructions against any of the `matchers`.
 
@@ -127,8 +127,8 @@ def any_of(*matchers : sass.InstructionMatcher | matchers_impl.SequenceMatcher) 
 
         Returns the first match.
 
-    >>> from reprospect.test.matchers import any_of
-    >>> from reprospect.test.sass     import OpcodeModsMatcher
+    >>> from reprospect.test.sass.composite   import any_of
+    >>> from reprospect.test.sass.instruction import OpcodeModsMatcher
     >>> matcher = any_of(
     ...     OpcodeModsMatcher(opcode = 'YIELD', operands = False),
     ...     OpcodeModsMatcher(opcode = 'NOP', operands = False),
@@ -138,4 +138,4 @@ def any_of(*matchers : sass.InstructionMatcher | matchers_impl.SequenceMatcher) 
     >>> matcher.index is None
     True
     """
-    return matchers_impl.AnyOfMatcher(*matchers)
+    return composite_impl.AnyOfMatcher(*matchers)

--- a/reprospect/test/sass/composite_impl.py
+++ b/reprospect/test/sass/composite_impl.py
@@ -1,5 +1,5 @@
 """
-Combine matchers from :py:mod:`reprospect.test.sass` into sequence matchers.
+Combine matchers from :py:mod:`reprospect.test.sass.instruction` into sequence matchers.
 """
 
 import abc
@@ -7,8 +7,8 @@ import itertools
 import sys
 import typing
 
-from reprospect.test.sass  import InstructionMatcher, InstructionMatch
-from reprospect.tools.sass import Instruction
+from reprospect.test.sass.instruction import InstructionMatcher, InstructionMatch
+from reprospect.tools.sass            import Instruction
 
 if sys.version_info >= (3, 12):
     from typing import override
@@ -24,7 +24,7 @@ class SequenceMatcher(abc.ABC):
         """
         ..note::
 
-            The `instructions` may be consumed more than once, *e.g.* in :py:class:`reprospect.test.matchers_impl.UnorderedInSequenceMatcher`.
+            The `instructions` may be consumed more than once, *e.g.* in :py:class:`reprospect.test.sass.composite_implUnorderedInSequenceMatcher`.
             Therefore, it must be a :py:type:`typing.Sequence`, not a :py:type:`typing.Iterable`.
         """
 

--- a/reprospect/test/sass/matchers/add_int128.py
+++ b/reprospect/test/sass/matchers/add_int128.py
@@ -1,0 +1,205 @@
+import sys
+import typing
+
+from reprospect.test.sass.composite_impl import SequenceMatcher
+from reprospect.test.sass.instruction    import InstructionMatch, OpcodeModsWithOperandsMatcher, PatternBuilder, RegisterMatch
+from reprospect.tools.sass.decode        import Instruction
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+class AddInt128(SequenceMatcher):
+    """
+    Match SASS instructions originating from the addition of 2 :code:`__int128`.
+
+    It may use one of several instruction patterns:
+
+    * :py:meth:`pattern_3IADD`
+    * :py:meth:`pattern_4IADD3`
+
+    .. note::
+
+        For a simple "load, add, store" sequence, the PTX may look as follows::
+
+            ld.global.nc.v2.u64 {%rd7, %rd8}, [%rd6];
+            add.s64 %rd9, %rd3, %rd5;
+            ld.global.v2.u64 {%rd10, %rd11}, [%rd9];
+            add.cc.s64 %rd12, %rd10, %rd7;
+            addc.cc.s64 %rd13, %rd11, %rd8;
+            st.global.v2.u64 [%rd9], {%rd12, %rd13};
+
+        According to https://docs.nvidia.com/cuda/parallel-thread-execution/#extended-precision-arithmetic-instructions-add-cc, the carry-out
+        value is written in the condition code register, usually ``P0``.
+    """
+    def pattern_3IADD(self, instructions : typing.Sequence[Instruction | str]) -> list[InstructionMatch] | None:
+        """
+        Typically::
+
+            IADD.64 RZ, P0, R4, UR12
+            IADD.64 R4, R4, UR12
+            IADD.64.X R6, R6, UR14, P0
+        """
+        matched : list[InstructionMatch] = []
+
+        matcher_iadd_step_0 = OpcodeModsWithOperandsMatcher(
+            opcode = 'IADD', modifiers = ('64',),
+            operands = (
+                'RZ',
+                PatternBuilder.PRED,
+                PatternBuilder.anygpreg(reuse = None, group = 'start'),
+                PatternBuilder.anygpreg(reuse = None),
+            ),
+        )
+        if (matched_iadd_step_0 := matcher_iadd_step_0.matches(instructions[0])) is None:
+            return None
+
+        matched.append(matched_iadd_step_0)
+
+        iadd_step_0_reg_0 = RegisterMatch.parse(matched_iadd_step_0.operands[-2])
+        iadd_step_0_reg_1 = RegisterMatch.parse(matched_iadd_step_0.operands[-1])
+
+        matcher_iadd_step_1 = OpcodeModsWithOperandsMatcher(
+            opcode = 'IADD', modifiers = ('64',),
+            operands = (
+                f'{iadd_step_0_reg_0.rtype}{iadd_step_0_reg_0.index}',
+                f'{iadd_step_0_reg_0.rtype}{iadd_step_0_reg_0.index}',
+                f'{iadd_step_0_reg_1.rtype}{iadd_step_0_reg_1.index}',
+            )
+        )
+        if (matched_iadd_step_1 := matcher_iadd_step_1.matches(instructions[1])) is None:
+            return None
+
+        matched.append(matched_iadd_step_1)
+
+        iadd_step_2_reg_0 = f'{iadd_step_0_reg_0.rtype}{iadd_step_0_reg_0.index + 2}'
+        iadd_step_2_reg_1 = f'{iadd_step_0_reg_1.rtype}{iadd_step_0_reg_1.index + 2}'
+
+        matcher_iadd_step_2 = OpcodeModsWithOperandsMatcher(
+            opcode = 'IADD', modifiers = ('64', 'X',),
+            operands = (
+                iadd_step_2_reg_0,
+                iadd_step_2_reg_0,
+                iadd_step_2_reg_1,
+                matched_iadd_step_0.operands[1],
+            )
+        )
+        if (matched_iadd_step_2 := matcher_iadd_step_2.matches(instructions[2])) is None:
+            return None
+
+        matched.append(matched_iadd_step_2)
+
+        return matched
+
+    def pattern_4IADD3(self, instructions : typing.Sequence[Instruction | str]) -> list[InstructionMatch] | None:
+        """
+        Typically::
+
+            IADD3 R8, P0, R8, c[0x0][0x180], RZ
+            IADD3.X R9, P0, R9, c[0x0][0x184], RZ, P0, !PT
+            IADD3.X R10, P0, R10, c[0x0][0x188], RZ, P0, !PT
+            IADD3.X R11, R11, c[0x0][0x18c], RZ, P0, !PT
+
+        or::
+
+            IADD3 R4, P0, PT, R4, R12, RZ
+            IADD3.X R5, P0, PT, R5, R13, RZ, P0, !PT
+            IADD3.X R6, P0, PT, R6, R14, RZ, P0, !PT
+            IADD3.X R7, PT, PT, R7, R15, RZ, P0, !PT
+
+        That is, there may be one additional argument.
+        """
+        matched : list[InstructionMatch] = []
+
+        matcher_iadd3_step_0 = OpcodeModsWithOperandsMatcher(
+            opcode = 'IADD3',
+            operands = (
+                PatternBuilder.group(PatternBuilder.REG, group = 'start'),
+                PatternBuilder.PRED,
+                PatternBuilder.zero_or_one(PatternBuilder.PREDT),
+                PatternBuilder.REG,
+                PatternBuilder.any(PatternBuilder.REG, PatternBuilder.CONSTANT),
+                'RZ',
+            ),
+        )
+        if (matched_iadd3_step_0 := matcher_iadd3_step_0.matches(instructions[0])) is None:
+            return None
+
+        if matched_iadd3_step_0.operands.count(matched_iadd3_step_0.operands[0]) != 2:
+            return None
+
+        matched.append(matched_iadd3_step_0)
+
+        iadd3_step_0_reg = RegisterMatch.parse(matched_iadd3_step_0.operands[0])
+        iadd3_step_1_reg = f'{iadd3_step_0_reg.rtype}{iadd3_step_0_reg.index + 1}'
+
+        matcher_iadd3_step_1 = OpcodeModsWithOperandsMatcher(
+            opcode = 'IADD3', modifiers = ('X',),
+            operands = (
+                iadd3_step_1_reg,
+                PatternBuilder.PRED,
+                PatternBuilder.zero_or_one(PatternBuilder.PREDT),
+                iadd3_step_1_reg,
+                PatternBuilder.any(PatternBuilder.REG, PatternBuilder.CONSTANT),
+                'RZ',
+                PatternBuilder.PRED,
+                '!PT',
+            )
+        )
+        if (matched_iadd3_step_1 := matcher_iadd3_step_1.matches(instructions[1])) is None:
+            return None
+
+        matched.append(matched_iadd3_step_1)
+
+        iadd3_step_2_reg = f'{iadd3_step_0_reg.rtype}{iadd3_step_0_reg.index + 2}'
+
+        matcher_iadd3_step_2 = OpcodeModsWithOperandsMatcher(
+            opcode = 'IADD3', modifiers = ('X',),
+            operands = (
+                iadd3_step_2_reg,
+                PatternBuilder.PRED,
+                PatternBuilder.zero_or_one(PatternBuilder.PREDT),
+                iadd3_step_2_reg,
+                PatternBuilder.any(PatternBuilder.REG, PatternBuilder.CONSTANT),
+                'RZ',
+                PatternBuilder.PRED,
+                '!PT',
+            )
+        )
+        if (matched_iadd3_step_2 := matcher_iadd3_step_2.matches(instructions[2])) is None:
+            return None
+
+        matched.append(matched_iadd3_step_2)
+
+        iadd3_step_3_reg = f'{iadd3_step_0_reg.rtype}{iadd3_step_0_reg.index + 3}'
+
+        matcher_iadd3_step_3 = OpcodeModsWithOperandsMatcher(
+            opcode = 'IADD3', modifiers = ('X',),
+            operands = (
+                iadd3_step_3_reg,
+                PatternBuilder.zero_or_one(PatternBuilder.PREDT),
+                PatternBuilder.zero_or_one(PatternBuilder.PREDT),
+                iadd3_step_3_reg,
+                PatternBuilder.any(PatternBuilder.REG, PatternBuilder.CONSTANT),
+                'RZ',
+                PatternBuilder.PRED,
+                '!PT',
+            )
+        )
+        if (matched_iadd3_step_3 := matcher_iadd3_step_3.matches(instructions[3])) is None:
+            return None
+
+        matched.append(matched_iadd3_step_3)
+
+        return matched
+
+    @override
+    def matches(self, instructions : typing.Sequence[Instruction | str]) -> list[InstructionMatch] | None:
+        instruction = instructions[0].instruction if isinstance(instructions[0], Instruction) else instructions[0]
+        if instruction.startswith('IADD.64'):
+            return self.pattern_3IADD(instructions = instructions)
+        elif instruction.startswith('IADD3'):
+            return self.pattern_4IADD3(instructions = instructions)
+        else:
+            return None

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,10 @@ def enable_mypyc(dist : Distribution) -> None:
 
     ext_modules = mypycify(
         [
-            'reprospect/test/matchers.py',
-            'reprospect/test/matchers_impl.py',
-            'reprospect/test/sass.py',
+            'reprospect/test/sass/composite.py',
+            'reprospect/test/sass/composite_impl.py',
+            'reprospect/test/sass/instruction.py',
+            'reprospect/test/sass/matchers/add_int128.py',
             'reprospect/tools/architecture.py',
             'reprospect/tools/binaries/cuobjdump.py',
             'reprospect/tools/binaries/demangle.py',

--- a/tests/python/test/sass/CMakeLists.txt
+++ b/tests/python/test/sass/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_pytest(any)
 add_pytest(atomic)
 add_pytest(branch)
+add_pytest(composite_impl)
+add_pytest(composite)
+add_pytest(instruction)
 add_pytest(load)
-add_pytest(matchers)
-add_pytest(matchers_impl)
-add_pytest(sass)
+
+add_subdirectory(matchers)

--- a/tests/python/test/sass/matchers/CMakeLists.txt
+++ b/tests/python/test/sass/matchers/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_pytest(add_int128)

--- a/tests/python/test/sass/matchers/test_add_int128.py
+++ b/tests/python/test/sass/matchers/test_add_int128.py
@@ -1,0 +1,73 @@
+import logging
+import pathlib
+import re
+import subprocess
+import typing
+
+import pytest
+
+from reprospect.test.sass.composite   import instructions_contain, instruction_is
+from reprospect.test.sass.instruction import LoadGlobalMatcher, RegisterMatch
+from reprospect.test.sass.matchers    import add_int128
+from reprospect.utils                 import cmake
+
+from tests.python.parameters                 import Parameters, PARAMETERS
+from tests.python.test.sass.test_instruction import get_decoder
+
+@pytest.mark.parametrize('parameters', PARAMETERS, ids = str)
+class TestAddInt128:
+    """
+    Tests for :py:class:`reprospect.test.sass.matchers.add_int128.AddInt128`.
+    """
+    CODE_ADD_INT128 : typing.Final[str] = """\
+__global__ void add_int128(__int128_t* __restrict__ const dst, const __int128_t* __restrict__ const src)
+{
+    const auto index = blockIdx.x * blockDim.x + threadIdx.x;
+    dst[index] += src[index];
+}
+"""
+
+    EXPECTED_PTX : typing.Final[re.Pattern[str]] = re.compile(r"""\
+add\.cc\.s64 %rd\d+, %rd\d+, %rd\d+;
+addc\.cc\.s64 %rd\d+, %rd\d+, %rd\d+;
+st\.global\.v2\.(u|b)64 \[%rd\d+\], {%rd\d+, %rd\d+};
+""")
+
+    def test(self, request, parameters : Parameters, workdir : pathlib.Path, cmake_file_api : cmake.FileAPI) -> None:
+        FILE = workdir / f'{request.node.originalname}.{parameters.arch.as_sm}.cu'
+        FILE.write_text(self.CODE_ADD_INT128)
+
+        decoder, output = get_decoder(cwd = workdir, arch = parameters.arch, file = FILE, cmake_file_api = cmake_file_api, ptx = True)
+
+        ptx = subprocess.check_output(('cuobjdump', '--dump-ptx', output)).decode()
+
+        assert self.EXPECTED_PTX.search(ptx) is not None
+
+        # Find the global load of the source.
+        matcher_load_src = instructions_contain(matcher = LoadGlobalMatcher(arch = parameters.arch, size = 128, readonly = True))
+        [matched_load_src] = matcher_load_src.assert_matches(instructions = decoder.instructions)
+
+        assert matcher_load_src.index is not None
+
+        logging.info(matched_load_src)
+
+        # Find the global load of the destination.
+        matcher_load_dst = instruction_is(matcher = LoadGlobalMatcher(arch = parameters.arch, size = 128, readonly = False)).times(1)
+        [matched_load_dst] = matcher_load_dst.assert_matches(instructions = decoder.instructions[matcher_load_src.index + 1::])
+
+        logging.info(matched_load_dst)
+
+        # Find the int128 addition pattern.
+        matcher = add_int128.AddInt128()
+        matched = matcher.assert_matches(instructions = decoder.instructions[matcher_load_src.index + 2::])
+
+        logging.info(matched)
+
+        assert matched[0].additional is not None
+        assert 'start' in matched[0].additional
+
+        reg_load  = RegisterMatch.parse(matched_load_src.operands[0])
+        reg_start = RegisterMatch.parse(matched[0].additional['start'][0])
+
+        assert reg_load.rtype == reg_start.rtype
+        assert reg_load.index == reg_start.index

--- a/tests/python/test/sass/test_any.py
+++ b/tests/python/test/sass/test_any.py
@@ -3,11 +3,11 @@ import typing
 
 import pytest
 
-from reprospect.test.sass import AnyMatcher, InstructionMatch
+from reprospect.test.sass.instruction import AnyMatcher, InstructionMatch
 
 class TestAnyMatcher:
     """
-    Tests for :py:class:`reprospect.test.sass.AnyMatcher`.
+    Tests for :py:class:`reprospect.test.sass.instruction.AnyMatcher`.
     """
     INSTRUCTIONS : typing.Final[dict[str, InstructionMatch]] = {
         'IMAD.MOV.U32 R4, R4, R5, R6' : InstructionMatch(opcode = 'IMAD', modifiers = ('MOV', 'U32'), operands = ('R4', 'R4', 'R5', 'R6')),

--- a/tests/python/test/sass/test_atomic.py
+++ b/tests/python/test/sass/test_atomic.py
@@ -7,17 +7,17 @@ import pytest
 import regex
 import semantic_version
 
-from reprospect.tools.sass import Instruction
-from reprospect.test.sass  import AtomicMatcher, InstructionMatch, PatternBuilder
-from reprospect.utils      import cmake
+from reprospect.tools.sass            import Instruction
+from reprospect.test.sass.instruction import AtomicMatcher, InstructionMatch, PatternBuilder
+from reprospect.utils                 import cmake
 
-from tests.python.parameters import Parameters, PARAMETERS
-from tests.python.test.sass.test_sass import get_decoder
+from tests.python.parameters                 import Parameters, PARAMETERS
+from tests.python.test.sass.test_instruction import get_decoder
 
 @pytest.mark.parametrize('parameters', PARAMETERS, ids = str)
 class TestAtomicMatcher:
     """
-    Tests for :py:class:`reprospect.test.sass.AtomicMatcher`.
+    Tests for :py:class:`reprospect.test.sass.instruction.AtomicMatcher`.
     """
     CODE_ADD_BASED_ON_CAS = """\
 __global__ void cas({type}* __restrict__ const dst, const {type}* __restrict__ const src)

--- a/tests/python/test/sass/test_branch.py
+++ b/tests/python/test/sass/test_branch.py
@@ -2,11 +2,11 @@ import typing
 
 import pytest
 
-from reprospect.test.sass import BranchMatcher, InstructionMatch
+from reprospect.test.sass.instruction import BranchMatcher, InstructionMatch
 
 class TestBranchMatcher:
     """
-    Tests for :py:class:`reprospect.test.sass.BranchMatcher`.
+    Tests for :py:class:`reprospect.test.sass.instruction.BranchMatcher`.
     """
     INSTRUCTIONS : typing.Final[dict[str, InstructionMatch]] = {
         'BRA 0x240' : InstructionMatch(opcode = 'BRA', modifiers = (), operands = ('0x240',)),

--- a/tests/python/test/sass/test_composite.py
+++ b/tests/python/test/sass/test_composite.py
@@ -1,10 +1,10 @@
-from reprospect.test.matchers      import any_of, Fluentizer, instructions_are, instructions_contain, instruction_is, unordered_instructions_are
-from reprospect.test.matchers_impl import AnyOfMatcher, InSequenceMatcher, InSequenceAtMatcher, OneOrMoreInSequenceMatcher, OrderedInSequenceMatcher, UnorderedInSequenceMatcher, ZeroOrMoreInSequenceMatcher
-from reprospect.test.sass          import FloatAddMatcher, InstructionMatch, OpcodeModsMatcher
+from reprospect.test.sass.composite      import any_of, Fluentizer, instructions_are, instructions_contain, instruction_is, unordered_instructions_are
+from reprospect.test.sass.composite_impl import AnyOfMatcher, InSequenceMatcher, InSequenceAtMatcher, OneOrMoreInSequenceMatcher, OrderedInSequenceMatcher, UnorderedInSequenceMatcher, ZeroOrMoreInSequenceMatcher
+from reprospect.test.sass.instruction    import FloatAddMatcher, InstructionMatch, OpcodeModsMatcher
 
 class TestInstructionIs:
     """
-    Tests for :py:func:`reprospect.test.matchers.instruction_is`.
+    Tests for :py:func:`reprospect.test.sass.composite.instruction_is`.
     """
     def test(self) -> None:
         matcher = instruction_is(FloatAddMatcher())
@@ -32,7 +32,7 @@ class TestInstructionIs:
 
 class TestInstructionsAre:
     """
-    Tests for :py:func:`reprospect.test.matchers.instructions_are`.
+    Tests for :py:func:`reprospect.test.sass.composite.instructions_are`.
     """
     def test(self) -> None:
         matcher = instructions_are(FloatAddMatcher(), FloatAddMatcher())
@@ -50,7 +50,7 @@ class TestInstructionsAre:
 
 class TestUnorderedInstructionsAre:
     """
-    Tests for :py:func:`reprospect.test.matchers.unordered_instructions_are`.
+    Tests for :py:func:`reprospect.test.sass.composite.unordered_instructions_are`.
     """
     def test(self) -> None:
         matcher = unordered_instructions_are(FloatAddMatcher(), FloatAddMatcher())
@@ -59,7 +59,7 @@ class TestUnorderedInstructionsAre:
 
 class TestInstructionsContain:
     """
-    Tests for :py:func:`reprospect.test.matchers.instructions_contain`.
+    Tests for :py:func:`reprospect.test.sass.composite.instructions_contain`.
     """
     def test(self) -> None:
         matcher = instructions_contain(FloatAddMatcher())
@@ -67,7 +67,7 @@ class TestInstructionsContain:
 
 class TestAnyOf:
     """
-    Tests for :py:func:`reprospect.test.matchers.any_of`.
+    Tests for :py:func:`reprospect.test.sass.composite.any_of`.
     """
     def test(self) -> None:
         matcher = any_of(FloatAddMatcher(), FloatAddMatcher())

--- a/tests/python/test/sass/test_composite_impl.py
+++ b/tests/python/test/sass/test_composite_impl.py
@@ -3,15 +3,15 @@ import typing
 
 import pytest
 
-from reprospect.test               import sass
-from reprospect.test.matchers_impl import AnyOfMatcher, \
-                                          InSequenceAtMatcher, \
-                                          InSequenceMatcher, \
-                                          OneOrMoreInSequenceMatcher, \
-                                          OrderedInSequenceMatcher, \
-                                          UnorderedInSequenceMatcher, \
-                                          ZeroOrMoreInSequenceMatcher
-from reprospect.tools.sass         import ControlCode, Instruction
+from reprospect.test.sass                import instruction
+from reprospect.test.sass.composite_impl import AnyOfMatcher, \
+                                                InSequenceAtMatcher, \
+                                                InSequenceMatcher, \
+                                                OneOrMoreInSequenceMatcher, \
+                                                OrderedInSequenceMatcher, \
+                                                UnorderedInSequenceMatcher, \
+                                                ZeroOrMoreInSequenceMatcher
+from reprospect.tools.sass               import ControlCode, Instruction
 
 CONTROL_CODE = ControlCode.decode(code = '0x000e220000000800')
 
@@ -28,13 +28,13 @@ DADD_NOP_DMUL = (DADD, NOP, NOP, NOP, DMUL)
 NOP_DMUL_NOP_DADD = (NOP, DMUL, NOP, NOP, DADD)
 """NOP instructions with one DADD and one DMUL."""
 
-MATCHER_DADD = sass.OpcodeModsWithOperandsMatcher(opcode = 'DADD', operands = ('R4', 'R4', sass.PatternBuilder.CONSTANT))
-MATCHER_DMUL = sass.OpcodeModsWithOperandsMatcher(opcode = 'DMUL', operands = ('R6', 'R6', sass.PatternBuilder.CONSTANT))
-MATCHER_NOP  = sass.OpcodeModsMatcher(opcode = 'NOP', operands = False)
+MATCHER_DADD = instruction.OpcodeModsWithOperandsMatcher(opcode = 'DADD', operands = ('R4', 'R4', instruction.PatternBuilder.CONSTANT))
+MATCHER_DMUL = instruction.OpcodeModsWithOperandsMatcher(opcode = 'DMUL', operands = ('R6', 'R6', instruction.PatternBuilder.CONSTANT))
+MATCHER_NOP  = instruction.OpcodeModsMatcher(opcode = 'NOP', operands = False)
 
 class TestInSequenceAtMatcher:
     """
-    Tests for :py:class:`reprospect.test.matchers_impl.InSequenceAtMatcher`.
+    Tests for :py:class:`reprospect.test.sass.composite_impl.InSequenceAtMatcher`.
     """
     def test_match_first_element(self):
         """
@@ -64,7 +64,7 @@ class TestInSequenceAtMatcher:
 
 class TestZeroOrMoreInSequenceMatcher:
     """
-    Tests for :py:class:`reprospect.test.matchers_impl.ZeroOrMoreInSequenceMatcher`.
+    Tests for :py:class:`reprospect.test.sass.composite_impl.ZeroOrMoreInSequenceMatcher`.
     """
     def test_matches_zero(self):
         """
@@ -96,7 +96,7 @@ class TestZeroOrMoreInSequenceMatcher:
 
 class TestOneOrMoreInSequenceMatcher:
     """
-    Tests for :py:class:`reprospect.test.matchers_impl.OneOrMoreInSequenceMatcher`.
+    Tests for :py:class:`reprospect.test.sass.composite_impl.OneOrMoreInSequenceMatcher`.
     """
     def test_matches_zero(self):
         """
@@ -132,7 +132,7 @@ class TestOneOrMoreInSequenceMatcher:
 
 class TestOrderedInSequenceMatcher:
     """
-    Tests for :py:class:`reprospect.test.matchers_impl.OrderedInSequenceMatcher`.
+    Tests for :py:class:`reprospect.test.sass.composite_impl.OrderedInSequenceMatcher`.
     """
     MATCHER : typing.Final[OrderedInSequenceMatcher] = OrderedInSequenceMatcher(matchers = (
         MATCHER_DADD,
@@ -173,7 +173,7 @@ class TestOrderedInSequenceMatcher:
 
 class TestUnorderedInSequenceMatcher:
     """
-    Tests for :py:class:`reprospect.test.matchers_impl.UnorderedInSequenceMatcher`.
+    Tests for :py:class:`reprospect.test.sass.composite_impl.UnorderedInSequenceMatcher`.
     """
     def test_match_with_nop(self):
         """
@@ -244,7 +244,7 @@ class TestUnorderedInSequenceMatcher:
 
 class TestInSequenceMatcher:
     """
-    Tests for :py:class:`reprospect.test.matchers_impl.InSequenceMatcher`.
+    Tests for :py:class:`reprospect.test.sass.composite_impl.InSequenceMatcher`.
     """
     def test_matches(self) -> None:
         matcher = InSequenceMatcher(matcher = MATCHER_DADD)
@@ -265,7 +265,7 @@ class TestInSequenceMatcher:
 
 class TestAnyOfMatcher:
     """
-    Tests for :py:class:`reprospect.test.matchers_impl.AnyOfMatcher`.
+    Tests for :py:class:`reprospect.test.sass.composite_impl.AnyOfMatcher`.
     """
     def test_matches(self) -> None:
         matcher = AnyOfMatcher(

--- a/tests/python/test/sass/test_load.py
+++ b/tests/python/test/sass/test_load.py
@@ -5,15 +5,15 @@ import typing
 
 import pytest
 
-from reprospect.test.sass import InstructionMatch, LoadConstantMatcher, PatternBuilder
-from reprospect.utils     import cmake
+from reprospect.test.sass.instruction import InstructionMatch, LoadConstantMatcher, PatternBuilder
+from reprospect.utils                 import cmake
 
-from tests.python.parameters import Parameters, PARAMETERS
-from tests.python.test.sass.test_sass import get_decoder
+from tests.python.parameters                 import Parameters, PARAMETERS
+from tests.python.test.sass.test_instruction import get_decoder
 
 class TestLoadConstantMatcher:
     """
-    Tests for :py:class:`reprospect.test.sass.LoadConstantMatcher`.
+    Tests for :py:class:`reprospect.test.sass.instruction.LoadConstantMatcher`.
     """
     INSTRUCTIONS : typing.Final[dict[str, tuple[LoadConstantMatcher, InstructionMatch]]] = {
         'LDC R1, c[0x0][0x37c]' : (

--- a/tests/python/test_extensibility.py
+++ b/tests/python/test_extensibility.py
@@ -3,7 +3,7 @@ Ensure that the distributed package supports user extensions.
 
 ``mypyc`` compilation can inadvertently seal classes, preventing inheritance.
 This module verifies that :py:mod:`reprospect` extension points (*e.g.*,
-:py:class:`reprospect.test.sass.InstructionMatcher`) remain
+:py:class:`reprospect.test.sass.instruction.InstructionMatcher`) remain
 subclassable after compilation, allowing users to extend :py:mod:`reprospect` capabilities.
 """
 
@@ -15,9 +15,9 @@ import typing
 import pytest
 import regex
 
-from reprospect.tools.sass    import Instruction, ControlCode
-from reprospect.test.sass     import InstructionMatch, InstructionMatcher, PatternMatcher, FloatAddMatcher
-from reprospect.test.matchers import instruction_is
+from reprospect.tools.sass            import Instruction, ControlCode
+from reprospect.test.sass.instruction import InstructionMatch, InstructionMatcher, PatternMatcher, FloatAddMatcher
+from reprospect.test.sass.composite   import instruction_is
 
 if sys.version_info >= (3, 12):
     from typing import override
@@ -43,7 +43,7 @@ class NewPatternMatcher(PatternMatcher):
 
 class CannotBeExtended(FloatAddMatcher):
     """
-    :py:class:`reprospect.test.sass.FloatAddMatcher` was not marked as extensible.
+    :py:class:`reprospect.test.sass.instruction.FloatAddMatcher` was not marked as extensible.
     """
 
 class TestInspect:

--- a/tests/python/tools/sass/test_controlflow.py
+++ b/tests/python/tools/sass/test_controlflow.py
@@ -10,7 +10,7 @@ from reprospect.utils                  import cmake
 
 from tests.python.parameters  import Parameters, PARAMETERS
 
-from tests.python.test.sass.test_sass import get_decoder
+from tests.python.test.sass.test_instruction import get_decoder
 
 class TestGraph:
     """


### PR DESCRIPTION
1. Reorganize `reprospect.test.sass` with folder structure. More matchers and files to come in the future.
2. Introduce a generic "add int128 matcher" in our matcher collection.

Extracted from #128.