### PR TITLE
mypyc: freeze to 1.18.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools",
-    "mypy[mypyc]",
+    "mypy[mypyc]==1.18.2",
 
     # mypyc requires that runtime dependencies are also installed
     # during the build, since it parses the code base.

--- a/requirements/requirements.python.txt
+++ b/requirements/requirements.python.txt
@@ -1,5 +1,5 @@
 matplotlib
-mypy>=1.18.2
+mypy==1.18.2
 myst-nb>=1.3.0
 nvtx>=0.2.13
 pylint>=4.0.1


### PR DESCRIPTION
They just released 1.19.0, but it fails our pipeline.

I will first make the pipeline green again, and then update to 1.19.0.