### PR TITLE
Add readme field to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ description = "A framework for reproducible prospecting of CUDA applications."
 version = "0.0.8"
 license = "MIT"
 license-files = ["LICENSE"]
+readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">= 3.10"
 dynamic = [
     "dependencies",


### PR DESCRIPTION
This will make the `PyPi` page better. For now, it's looking like
<img width="2540" height="1401" alt="image" src="https://github.com/user-attachments/assets/8da6eb38-8595-445b-9db3-4c7bf9a363d5" />
