### PR TITLE
test(matchers): `RegisterMatcher` and `with_operand`

### DIFF
--- a/docs/source/tests/python/test/sass/instruction.rst
+++ b/docs/source/tests/python/test/sass/instruction.rst
@@ -3,3 +3,4 @@ Instruction
 
 .. automodule:: tests.python.test.sass.instruction.test_fp32add
 .. automodule:: tests.python.test.sass.instruction.test_fp64add
+.. automodule:: tests.python.test.sass.instruction.test_register

--- a/examples/kokkos/atomic/example_add_complex128.py
+++ b/examples/kokkos/atomic/example_add_complex128.py
@@ -8,7 +8,7 @@ from reprospect.test.sass.instruction    import InstructionMatch, \
                                                 OpcodeModsMatcher, \
                                                 OpcodeModsWithOperandsMatcher, \
                                                 PatternBuilder, \
-                                                RegisterMatch
+                                                RegisterMatcher
 from reprospect.tools.sass               import Decoder
 
 from examples.kokkos.atomic import add, desul
@@ -29,7 +29,9 @@ class AddKokkosComplexDouble:
     def build(self, load : InstructionMatch) -> UnorderedInSequenceMatcher:
         load_register = load.operands[0]
 
-        parsed = RegisterMatch.parse(load_register)
+        parsed = RegisterMatcher(special = False).match(load_register)
+        assert parsed is not None
+        assert parsed.index is not None
 
         dadd_real_reg = load_register
         dadd_imag_reg = f'{parsed.rtype}{parsed.index + 2}'

--- a/reprospect/test/sass/composite.py
+++ b/reprospect/test/sass/composite.py
@@ -5,8 +5,9 @@ Thin user-facing factories for the matchers in :py:mod:`reprospect.test.sass.com
 import sys
 import typing
 
-from reprospect.test.sass  import composite_impl, instruction
-from reprospect.tools.sass import Instruction
+from reprospect.test.sass                import composite_impl, instruction
+from reprospect.test.sass.composite_impl import OperandMatcher
+from reprospect.tools.sass               import Instruction
 
 if sys.version_info >= (3, 12):
     from typing import override
@@ -52,11 +53,12 @@ class Fluentizer(instruction.InstructionMatcher):
         """
         return composite_impl.ZeroOrMoreInSequenceMatcher(matcher = self.matcher)
 
-    def with_operand(self, index : int, operand : str) -> 'Fluentizer':
+    def with_operand(self, index : int, operand : OperandMatcher) -> 'Fluentizer':
         """
         >>> from reprospect.test.sass.composite   import instruction_is
-        >>> from reprospect.test.sass.instruction import Fp32AddMatcher
-        >>> matcher = instruction_is(Fp32AddMatcher()).with_operand(index = 1, operand = 'R8')
+        >>> from reprospect.test.sass.instruction import Fp32AddMatcher, RegisterMatcher
+        >>> from reprospect.tools.sass.decode     import RegisterType
+        >>> matcher = instruction_is(Fp32AddMatcher()).with_operand(index = 1, operand = RegisterMatcher(rtype = RegisterType.GPR, index = 8))
         >>> matcher.match(inst = 'FADD R5, R9, R10')
         >>> matcher.match(inst = 'FADD R5, R8, R9')
         InstructionMatch(opcode='FADD', modifiers=(), operands=('R5', 'R8', 'R9'), predicate=None, additional={'dst': ['R5']})
@@ -66,7 +68,7 @@ class Fluentizer(instruction.InstructionMatcher):
             index = index, operand = operand,
         ))
 
-    def with_operands(self, operands : typing.Collection[tuple[int, str]]) -> instruction.InstructionMatcher:
+    def with_operands(self, operands : typing.Collection[tuple[int, OperandMatcher]]) -> instruction.InstructionMatcher:
         """
         Similar to :py:meth:`with_operand` for many operands.
 

--- a/reprospect/test/sass/instruction/__init__.py
+++ b/reprospect/test/sass/instruction/__init__.py
@@ -18,7 +18,7 @@ from .pattern import AnyMatcher, \
                      StoreMatcher, \
                      StoreGlobalMatcher
 
-from .register import RegisterMatch
+from .register import RegisterMatch, RegisterMatcher
 
 __all__ = (
     'AnyMatcher',
@@ -39,6 +39,7 @@ __all__ = (
     'PatternMatcher',
     'ReductionMatcher',
     'RegisterMatch',
+    'RegisterMatcher',
     'StoreMatcher',
     'StoreGlobalMatcher',
 )

--- a/reprospect/test/sass/instruction/register.py
+++ b/reprospect/test/sass/instruction/register.py
@@ -1,36 +1,101 @@
 import dataclasses
-import typing
 
+import attrs
 import regex
 
 from reprospect.tools.sass.decode import RegisterType
 
-REGISTER_MATCH : typing.Final[regex.Pattern[str]] = regex.compile(
-    r'^(?P<rtype>(R|UR|P|UP))'
-    r'((?P<special>(T|Z))|(?P<index>\d+))?'
-    r'(?P<reuse>\.reuse)?$'
-)
-
 @dataclasses.dataclass(frozen = True, slots = True)
 class RegisterMatch:
+    """
+    If :py:attr:`index` is :py:obj:`None`, it is a special register (*e.g.*
+    ``RZ`` if :py:attr:`rtype` is :py:const:`reprospect.tools.sass.decode.RegisterType.GPR`).
+    """
     rtype : RegisterType
-    index : int
+    index : int | None = None
     reuse : bool = False
 
     @classmethod
-    def parse(cls, value : str) -> 'RegisterMatch':
-        """
-        Parse an operand, assuming it is a register.
+    def parse(cls, bits : regex.Match[str]) -> 'RegisterMatch':
+        captured = bits.capturesdict()
 
-        >>> from reprospect.test.sass.instruction import RegisterMatch
-        >>> RegisterMatch.parse('UR12')
-        RegisterMatch(rtype=<RegisterType.UGPR: 'UR'>, index=12, reuse=False)
-        """
-        if (matched := REGISTER_MATCH.match(value)) is not None:
-            if matched['index'] or matched['special']:
-                return cls(
-                    rtype = RegisterType(matched['rtype']),
-                    index = int(matched['index']) if matched['index'] else -1,
-                    reuse = bool(matched.group('reuse')),
-                )
-        raise ValueError(f'Invalid register format {value!r}.')
+        if len(rtype := captured['rtype']) != 1:
+            raise ValueError(bits)
+
+        index : int | None = None
+        if (value := captured.get('index')) is not None:
+            if len(value) == 1:
+                index = int(value[0])
+
+        return cls(
+            rtype = RegisterType(rtype[0]),
+            index = index,
+            reuse = bool(captured.get('reuse')),
+        )
+
+@attrs.define(frozen = True, slots = True, kw_only = True)
+class RegisterMatcher:
+    """
+    Matcher for a register.
+    """
+    rtype : RegisterType | None = None
+    special : bool | None = None
+    index : int | None = None
+    reuse : bool | None = None
+
+    pattern : regex.Pattern[str] = attrs.field(init = False)
+
+    def __attrs_post_init__(self) -> None:
+        if self.special is not None and self.index is not None:
+            raise RuntimeError(self)
+
+        object.__setattr__(self, 'pattern', regex.compile(''.join(filter(None, (
+            rf'(?P<rtype>({self.rtype.value if self.rtype else "R|UR|P|UP"}))',
+            self._build_special(),
+            self._build_index(),
+            self._build_reuse(),
+        )))))
+
+    def match(self, reg : str) -> RegisterMatch | None:
+        if (matched := self.pattern.match(reg)) is not None:
+            return RegisterMatch.parse(bits = matched)
+        return None
+
+    def __call__(self, reg : str) -> RegisterMatch | None:
+        return self.match(reg = reg)
+
+    def _build_special(self) -> str | None:
+        if self.index is not None:
+            return None
+        if self.special is False:
+            return None
+
+        idx = self.rtype.special if self.rtype is not None else r'Z|T'
+
+        special = rf'(?P<special>({idx}))'
+
+        if self.special is None:
+            return special + '?'
+        return special
+
+    def _build_index(self) -> str | None:
+        if self.special is True:
+            return None
+        if self.index is not None:
+            return rf'(?P<index>({self.index}))'
+        index = r'(?P<index>(\d+))'
+        if self.special is None:
+            return index + '?'
+        return index
+
+    def _build_reuse(self) -> str | None:
+        if self.reuse is False:
+            return None
+        if self.special is True:
+            return None
+        if self.rtype is not None and self.rtype.is_predicate:
+            return None
+        reuse = r'(?P<reuse>\.reuse)'
+        if self.reuse is None:
+            return reuse + '?'
+        return reuse

--- a/reprospect/test/sass/matchers/add_int128.py
+++ b/reprospect/test/sass/matchers/add_int128.py
@@ -2,7 +2,7 @@ import sys
 import typing
 
 from reprospect.test.sass.composite_impl import SequenceMatcher
-from reprospect.test.sass.instruction    import InstructionMatch, OpcodeModsWithOperandsMatcher, PatternBuilder, RegisterMatch
+from reprospect.test.sass.instruction    import InstructionMatch, OpcodeModsWithOperandsMatcher, PatternBuilder, RegisterMatcher
 from reprospect.tools.sass.decode        import Instruction
 
 if sys.version_info >= (3, 12):
@@ -57,8 +57,10 @@ class AddInt128(SequenceMatcher):
 
         matched.append(matched_iadd_step_0)
 
-        iadd_step_0_reg_0 = RegisterMatch.parse(matched_iadd_step_0.operands[-2])
-        iadd_step_0_reg_1 = RegisterMatch.parse(matched_iadd_step_0.operands[-1])
+        iadd_step_0_reg_0 = RegisterMatcher(special = False).match(matched_iadd_step_0.operands[-2])
+        assert iadd_step_0_reg_0 is not None and iadd_step_0_reg_0.index is not None
+        iadd_step_0_reg_1 = RegisterMatcher(special = False).match(matched_iadd_step_0.operands[-1])
+        assert iadd_step_0_reg_1 is not None and iadd_step_0_reg_1.index is not None
 
         matcher_iadd_step_1 = OpcodeModsWithOperandsMatcher(
             opcode = 'IADD', modifiers = ('64',),
@@ -131,7 +133,8 @@ class AddInt128(SequenceMatcher):
 
         matched.append(matched_iadd3_step_0)
 
-        iadd3_step_0_reg = RegisterMatch.parse(matched_iadd3_step_0.operands[0])
+        iadd3_step_0_reg = RegisterMatcher(special = False).match(matched_iadd3_step_0.operands[0])
+        assert iadd3_step_0_reg is not None and iadd3_step_0_reg.index is not None
         iadd3_step_1_reg = f'{iadd3_step_0_reg.rtype}{iadd3_step_0_reg.index + 1}'
 
         matcher_iadd3_step_1 = OpcodeModsWithOperandsMatcher(

--- a/reprospect/tools/sass/decode.py
+++ b/reprospect/tools/sass/decode.py
@@ -168,6 +168,20 @@ class RegisterType(StrEnum):
     UGPR = 'UR'
     UPRED = 'UP'
 
+    @property
+    def is_predicate(self) -> bool:
+        return self in (RegisterType.PRED, RegisterType.UPRED)
+
+    @property
+    def special(self) -> str:
+        match self:
+            case RegisterType.GPR | RegisterType.UGPR:
+                return 'Z'
+            case RegisterType.PRED | RegisterType.UPRED:
+                return 'T'
+            case _:
+                raise ValueError(self)
+
 @mypy_extensions.mypyc_attr(native_class = True)
 @dataclasses.dataclass(frozen = True, slots = True)
 class Instruction:

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ def enable_mypyc(dist : Distribution) -> None:
             'reprospect/test/sass/composite.py',
             'reprospect/test/sass/composite_impl.py',
             'reprospect/test/sass/instruction/pattern.py',
+            'reprospect/test/sass/instruction/register.py',
             'reprospect/test/sass/matchers/add_int128.py',
             'reprospect/tools/architecture.py',
             'reprospect/tools/binaries/cuobjdump.py',

--- a/tests/python/test/sass/instruction/test_register.py
+++ b/tests/python/test/sass/instruction/test_register.py
@@ -1,36 +1,62 @@
-import pytest
+import typing
 
-from reprospect.test.sass.instruction import RegisterMatch
-from reprospect.tools.sass.decode     import RegisterType
+from reprospect.test.sass.instruction.register import RegisterMatch, RegisterType, RegisterMatcher
 
-class TestRegisterMatch:
+class TestRegisterMatcher:
     """
-    Tests for :py:class:`reprospect.test.sass.instruction.register.RegisterMatch`.
+    Tests for :py:class:`reprospect.test.sass.instruction.register.RegisterMatcher`.
     """
     def test_reg(self) -> None:
-        assert RegisterMatch.parse('R42') == RegisterMatch(rtype = RegisterType.GPR, index = 42, reuse = False)
+        REG : typing.Final[str] = 'R42'
+        RES : typing.Final[RegisterMatch] = RegisterMatch(rtype = RegisterType.GPR, index = 42, reuse = False)
+
+        assert RegisterMatcher().match(REG) == RES
+
+        matcher = RegisterMatcher(rtype = RegisterType.GPR, special = False, reuse = False)
+        assert matcher.pattern.pattern == r'(?P<rtype>(R))(?P<index>(\d+))'
+        assert matcher.match(REG) == RES
 
     def test_regz(self) -> None:
-        assert RegisterMatch.parse('RZ') == RegisterMatch(rtype = RegisterType.GPR, index = -1, reuse = False)
+        REG : typing.Final[str] = 'RZ'
+        RES : typing.Final[RegisterMatch] = RegisterMatch(rtype = RegisterType.GPR, index = None, reuse = False)
+
+        assert RegisterMatcher().match(REG) == RES
+
+        matcher = RegisterMatcher(rtype = RegisterType.GPR, special = True)
+        assert matcher.pattern.pattern == r'(?P<rtype>(R))(?P<special>(Z))'
+        assert matcher.match(REG) == RES
 
     def test_ureg(self) -> None:
-        assert RegisterMatch.parse('UR42') == RegisterMatch(rtype = RegisterType.UGPR, index = 42, reuse = False)
+        REG : typing.Final[str] = 'UR42'
+        RES : typing.Final[RegisterMatch] = RegisterMatch(rtype = RegisterType.UGPR, index = 42, reuse = False)
+
+        assert RegisterMatcher().match(REG) == RES
+
+        matcher = RegisterMatcher(rtype = RegisterType.UGPR, special = False)
+        assert matcher.pattern.pattern == r'(?P<rtype>(UR))(?P<index>(\d+))(?P<reuse>\.reuse)?'
+        assert matcher.match(REG) == RES
 
     def test_reg_reuse(self) -> None:
-        assert RegisterMatch.parse('R42.reuse') == RegisterMatch(rtype = RegisterType.GPR, index = 42, reuse = True)
+        assert RegisterMatcher().match('R42.reuse') == RegisterMatch(rtype = RegisterType.GPR, index = 42, reuse = True)
 
     def test_pred(self) -> None:
-        assert RegisterMatch.parse('P3') == RegisterMatch(rtype = RegisterType.PRED, index = 3, reuse = False)
+        assert RegisterMatcher().match('P3') == RegisterMatch(rtype = RegisterType.PRED, index = 3, reuse = False)
 
     def test_predt(self) -> None:
-        assert RegisterMatch.parse('PT') == RegisterMatch(rtype = RegisterType.PRED, index = -1, reuse = False)
+        REG : typing.Final[str] = 'PT'
+        RES : typing.Final[RegisterMatch] = RegisterMatch(rtype = RegisterType.PRED, index = None, reuse = False)
+
+        assert RegisterMatcher().match(REG) == RES
+
+        matcher = RegisterMatcher(rtype = RegisterType.PRED)
+        assert matcher.pattern.pattern == r'(?P<rtype>(P))(?P<special>(T))?(?P<index>(\d+))?'
+        assert matcher.match(REG) == RES
 
     def test_upred(self) -> None:
-        assert RegisterMatch.parse('UP3') == RegisterMatch(rtype = RegisterType.UPRED, index = 3, reuse = False)
+        assert RegisterMatcher().match('UP3') == RegisterMatch(rtype = RegisterType.UPRED, index = 3, reuse = False)
 
     def test_upredt(self) -> None:
-        assert RegisterMatch.parse('UPT') == RegisterMatch(rtype = RegisterType.UPRED, index = -1, reuse = False)
+        assert RegisterMatcher().match('UPT') == RegisterMatch(rtype = RegisterType.UPRED, index = None, reuse = False)
 
     def test_not_a_reg(self) -> None:
-        with pytest.raises(ValueError, match = "Invalid register format 'YOLO666'."):
-            RegisterMatch.parse('YOLO666')
+        assert RegisterMatcher().match('YOLO666') is None

--- a/tests/python/test/sass/matchers/test_add_int128.py
+++ b/tests/python/test/sass/matchers/test_add_int128.py
@@ -7,7 +7,7 @@ import typing
 import pytest
 
 from reprospect.test.sass.composite   import instructions_contain, instruction_is
-from reprospect.test.sass.instruction import LoadGlobalMatcher, RegisterMatch
+from reprospect.test.sass.instruction import LoadGlobalMatcher, RegisterMatcher
 from reprospect.test.sass.matchers    import add_int128
 from reprospect.utils                 import cmake
 
@@ -66,8 +66,10 @@ st\.global\.v2\.(u|b)64 \[%rd\d+\], {%rd\d+, %rd\d+};
         assert matched[0].additional is not None
         assert 'start' in matched[0].additional
 
-        reg_load  = RegisterMatch.parse(matched_load_src.operands[0])
-        reg_start = RegisterMatch.parse(matched[0].additional['start'][0])
+        reg_load  = RegisterMatcher(special = False).match(matched_load_src.operands[0])
+        assert reg_load is not None
+        reg_start = RegisterMatcher(special = False).match(matched[0].additional['start'][0])
+        assert reg_start is not None
 
         assert reg_load.rtype == reg_start.rtype
         assert reg_load.index == reg_start.index


### PR DESCRIPTION
We need to match operands, usually to ensure that 2 matched instructions are linked together (*e.g.* they use the same register).