### PR TITLE
refactor: rename `matches` to `match`

### DIFF
--- a/examples/kokkos/atomic/example_add_int128.py
+++ b/examples/kokkos/atomic/example_add_int128.py
@@ -29,8 +29,8 @@ class RegisterMatchValidator(SequenceMatcher):
         """The register that must be used by :py:attr:`matcher`."""
 
     @override
-    def matches(self, instructions : typing.Sequence[Instruction | str]) -> list[InstructionMatch] | None:
-        if (matched := self.matcher.matches(instructions)) is not None:
+    def match(self, instructions : typing.Sequence[Instruction | str]) -> list[InstructionMatch] | None:
+        if (matched := self.matcher.match(instructions)) is not None:
             start_register = RegisterMatch.parse(matched[0].additional['start'][0])
             if self.load_register.rtype == start_register.rtype and self.load_register.index == start_register.index:
                 return matched
@@ -67,8 +67,8 @@ class TestAtomicAddInt128(add.TestCase):
         matcher_atom = AtomicMatcher   (operation = 'ADD', dtype = ('S', 128), scope = 'DEVICE', consistency = 'STRONG', arch = self.arch)
         matcher_red  = ReductionMatcher(operation = 'ADD', dtype = ('S', 128), scope = 'DEVICE', consistency = 'STRONG', arch = self.arch)
 
-        assert not any(matcher_atom.matches(inst) for inst in decoder.instructions)
-        assert not any(matcher_red .matches(inst) for inst in decoder.instructions)
+        assert not any(matcher_atom.match(inst) for inst in decoder.instructions)
+        assert not any(matcher_red .match(inst) for inst in decoder.instructions)
 
     def test_lock_based_atomic(self, decoder : Decoder) -> None:
         """

--- a/reprospect/test/sass/composite.py
+++ b/reprospect/test/sass/composite.py
@@ -54,8 +54,8 @@ class Fluentizer(instruction.InstructionMatcher):
 
     @override
     @typing.final
-    def matches(self, inst : Instruction | str) -> typing.Optional[instruction.InstructionMatch]:
-        return self.matcher.matches(inst = inst)
+    def match(self, inst : Instruction | str) -> typing.Optional[instruction.InstructionMatch]:
+        return self.matcher.match(inst = inst)
 
 def instruction_is(matcher : instruction.InstructionMatcher) -> Fluentizer:
     """
@@ -63,9 +63,9 @@ def instruction_is(matcher : instruction.InstructionMatcher) -> Fluentizer:
 
     >>> from reprospect.test.sass.composite   import instruction_is
     >>> from reprospect.test.sass.instruction import Fp32AddMatcher
-    >>> instruction_is(Fp32AddMatcher()).matches(inst = 'FADD R2, R2, R3')
+    >>> instruction_is(Fp32AddMatcher()).match(inst = 'FADD R2, R2, R3')
     InstructionMatch(opcode='FADD', modifiers=(), operands=('R2', 'R2', 'R3'), predicate=None, additional={'dst': ['R2']})
-    >>> instruction_is(Fp32AddMatcher()).one_or_more_times().matches(instructions = ('FADD R2, R2, R3', 'FADD R4, R4, R5'))
+    >>> instruction_is(Fp32AddMatcher()).one_or_more_times().match(instructions = ('FADD R2, R2, R3', 'FADD R4, R4, R5'))
     [InstructionMatch(opcode='FADD', modifiers=(), operands=('R2', 'R2', 'R3'), predicate=None, additional={'dst': ['R2']}), InstructionMatch(opcode='FADD', modifiers=(), operands=('R4', 'R4', 'R5'), predicate=None, additional={'dst': ['R4']})]
     """
     return Fluentizer(matcher)
@@ -79,7 +79,7 @@ def instructions_are(*matchers : instruction.InstructionMatcher | composite_impl
     >>> instructions_are(
     ...     OpcodeModsMatcher(opcode = 'YIELD', operands = False),
     ...     instruction_is(OpcodeModsMatcher(opcode = 'NOP', operands = False)).zero_or_more_times(),
-    ... ).matches(instructions = ('YIELD', 'NOP', 'NOP'))
+    ... ).match(instructions = ('YIELD', 'NOP', 'NOP'))
     [InstructionMatch(opcode='YIELD', modifiers=(), operands=(), predicate=None, additional=None), InstructionMatch(opcode='NOP', modifiers=(), operands=(), predicate=None, additional=None), InstructionMatch(opcode='NOP', modifiers=(), operands=(), predicate=None, additional=None)]
     """
     return composite_impl.OrderedInSequenceMatcher(matchers = matchers)
@@ -93,7 +93,7 @@ def unordered_instructions_are(*matchers : instruction.InstructionMatcher | comp
     >>> unordered_instructions_are(
     ...     OpcodeModsMatcher(opcode = 'YIELD', operands = False),
     ...     OpcodeModsMatcher(opcode = 'NOP', operands = False),
-    ... ).matches(instructions = ('NOP', 'YIELD'))
+    ... ).match(instructions = ('NOP', 'YIELD'))
     [InstructionMatch(opcode='NOP', modifiers=(), operands=(), predicate=None, additional=None), InstructionMatch(opcode='YIELD', modifiers=(), operands=(), predicate=None, additional=None)]
     """
     return composite_impl.UnorderedInSequenceMatcher(matchers = matchers)
@@ -112,7 +112,7 @@ def instructions_contain(matcher : instruction.InstructionMatcher | composite_im
     ...     OpcodeModsMatcher(opcode = 'YIELD', operands = False),
     ...     OpcodeModsMatcher(opcode = 'FADD', operands = True),
     ... ))
-    >>> matcher.matches(instructions = ('NOP', 'NOP', 'YIELD', 'FADD R1, R1, R2'))
+    >>> matcher.match(instructions = ('NOP', 'NOP', 'YIELD', 'FADD R1, R1, R2'))
     [InstructionMatch(opcode='YIELD', modifiers=(), operands=(), predicate=None, additional=None), InstructionMatch(opcode='FADD', modifiers=(), operands=('R1', 'R1', 'R2'), predicate=None, additional=None)]
     >>> matcher.index
     2
@@ -133,7 +133,7 @@ def any_of(*matchers : instruction.InstructionMatcher | composite_impl.SequenceM
     ...     OpcodeModsMatcher(opcode = 'YIELD', operands = False),
     ...     OpcodeModsMatcher(opcode = 'NOP', operands = False),
     ... )
-    >>> matcher.matches(instructions = ('FADD R1, R1, R2',)) is None
+    >>> matcher.match(instructions = ('FADD R1, R1, R2',)) is None
     True
     >>> matcher.index is None
     True

--- a/reprospect/test/sass/matchers/add_int128.py
+++ b/reprospect/test/sass/matchers/add_int128.py
@@ -52,7 +52,7 @@ class AddInt128(SequenceMatcher):
                 PatternBuilder.anygpreg(reuse = None),
             ),
         )
-        if (matched_iadd_step_0 := matcher_iadd_step_0.matches(instructions[0])) is None:
+        if (matched_iadd_step_0 := matcher_iadd_step_0.match(instructions[0])) is None:
             return None
 
         matched.append(matched_iadd_step_0)
@@ -68,7 +68,7 @@ class AddInt128(SequenceMatcher):
                 f'{iadd_step_0_reg_1.rtype}{iadd_step_0_reg_1.index}',
             )
         )
-        if (matched_iadd_step_1 := matcher_iadd_step_1.matches(instructions[1])) is None:
+        if (matched_iadd_step_1 := matcher_iadd_step_1.match(instructions[1])) is None:
             return None
 
         matched.append(matched_iadd_step_1)
@@ -85,7 +85,7 @@ class AddInt128(SequenceMatcher):
                 matched_iadd_step_0.operands[1],
             )
         )
-        if (matched_iadd_step_2 := matcher_iadd_step_2.matches(instructions[2])) is None:
+        if (matched_iadd_step_2 := matcher_iadd_step_2.match(instructions[2])) is None:
             return None
 
         matched.append(matched_iadd_step_2)
@@ -123,7 +123,7 @@ class AddInt128(SequenceMatcher):
                 'RZ',
             ),
         )
-        if (matched_iadd3_step_0 := matcher_iadd3_step_0.matches(instructions[0])) is None:
+        if (matched_iadd3_step_0 := matcher_iadd3_step_0.match(instructions[0])) is None:
             return None
 
         if matched_iadd3_step_0.operands.count(matched_iadd3_step_0.operands[0]) != 2:
@@ -147,7 +147,7 @@ class AddInt128(SequenceMatcher):
                 '!PT',
             )
         )
-        if (matched_iadd3_step_1 := matcher_iadd3_step_1.matches(instructions[1])) is None:
+        if (matched_iadd3_step_1 := matcher_iadd3_step_1.match(instructions[1])) is None:
             return None
 
         matched.append(matched_iadd3_step_1)
@@ -167,7 +167,7 @@ class AddInt128(SequenceMatcher):
                 '!PT',
             )
         )
-        if (matched_iadd3_step_2 := matcher_iadd3_step_2.matches(instructions[2])) is None:
+        if (matched_iadd3_step_2 := matcher_iadd3_step_2.match(instructions[2])) is None:
             return None
 
         matched.append(matched_iadd3_step_2)
@@ -187,7 +187,7 @@ class AddInt128(SequenceMatcher):
                 '!PT',
             )
         )
-        if (matched_iadd3_step_3 := matcher_iadd3_step_3.matches(instructions[3])) is None:
+        if (matched_iadd3_step_3 := matcher_iadd3_step_3.match(instructions[3])) is None:
             return None
 
         matched.append(matched_iadd3_step_3)
@@ -195,7 +195,7 @@ class AddInt128(SequenceMatcher):
         return matched
 
     @override
-    def matches(self, instructions : typing.Sequence[Instruction | str]) -> list[InstructionMatch] | None:
+    def match(self, instructions : typing.Sequence[Instruction | str]) -> list[InstructionMatch] | None:
         instruction = instructions[0].instruction if isinstance(instructions[0], Instruction) else instructions[0]
         if instruction.startswith('IADD.64'):
             return self.pattern_3IADD(instructions = instructions)

--- a/tests/python/test/sass/instruction/test_fp32add.py
+++ b/tests/python/test/sass/instruction/test_fp32add.py
@@ -13,25 +13,25 @@ class TestFp32AddMatcher:
     Tests for :py:class:`reprospect.test.sass.instruction.Fp32AddMatcher`.
     """
     def test(self) -> None:
-        matched = Fp32AddMatcher().matches(inst = 'FADD R6, R4, R2')
+        matched = Fp32AddMatcher().match(inst = 'FADD R6, R4, R2')
         assert matched is not None
         assert matched.additional is not None
         assert matched.additional['dst'][0] == 'R6'
         assert matched.operands[-1] == 'R2'
 
-        matched = Fp32AddMatcher().matches(inst = 'FADD R6, R4, c[0x0][0x178]')
+        matched = Fp32AddMatcher().match(inst = 'FADD R6, R4, c[0x0][0x178]')
         assert matched is not None
         assert matched.additional is not None
         assert matched.additional['dst'][0] == 'R6'
         assert matched.operands[-1] == 'c[0x0][0x178]'
 
-        matched = Fp32AddMatcher().matches(inst = 'FADD R25, R4, UR12')
+        matched = Fp32AddMatcher().match(inst = 'FADD R25, R4, UR12')
         assert matched is not None
         assert matched.additional is not None
         assert matched.additional['dst'][0] == 'R25'
         assert matched.operands[-1] == 'UR12'
 
-        matched = Fp32AddMatcher().matches(inst = 'FADD.FTZ R9, -R7, 1.5707963705062866211')
+        matched = Fp32AddMatcher().match(inst = 'FADD.FTZ R9, -R7, 1.5707963705062866211')
         assert matched is not None
         assert matched.additional is not None
         assert matched.additional['dst'][0] == 'R9'
@@ -50,7 +50,7 @@ class TestFp32AddMatcher:
         decoder, _ = get_decoder(cwd = workdir, arch = parameters.arch, file = FILE, cmake_file_api = cmake_file_api)
 
         matcher = Fp32AddMatcher()
-        fadd = [(inst, matched) for inst in decoder.instructions if (matched := matcher.matches(inst))]
+        fadd = [(inst, matched) for inst in decoder.instructions if (matched := matcher.match(inst))]
         assert len(fadd) == 4
 
         logging.info(matcher.pattern)

--- a/tests/python/test/sass/instruction/test_fp64add.py
+++ b/tests/python/test/sass/instruction/test_fp64add.py
@@ -21,7 +21,7 @@ __global__ void fp64_add(double* __restrict__ const dst, const double* __restric
 """
 
     def test(self) -> None:
-        matched = Fp64AddMatcher().matches(inst = 'DADD R6, R4, R2')
+        matched = Fp64AddMatcher().match(inst = 'DADD R6, R4, R2')
         assert matched is not None
         assert matched.additional is not None
         assert matched.additional['dst'][0] == 'R6'
@@ -38,7 +38,7 @@ __global__ void fp64_add(double* __restrict__ const dst, const double* __restric
         decoder, _ = get_decoder(cwd = workdir, arch = parameters.arch, file = FILE, cmake_file_api = cmake_file_api)
 
         matcher = Fp64AddMatcher()
-        [dadd] = [(inst, matched) for inst in decoder.instructions if (matched := matcher.matches(inst))]
+        [dadd] = [(inst, matched) for inst in decoder.instructions if (matched := matcher.match(inst))]
         inst, matched = dadd
 
         assert inst.instruction.startswith(matched.opcode)

--- a/tests/python/test/sass/test_any.py
+++ b/tests/python/test/sass/test_any.py
@@ -47,7 +47,7 @@ class TestAnyMatcher:
 
     @pytest.mark.parametrize('instruction,expected', INSTRUCTIONS.items())
     def test(self, instruction : str, expected : InstructionMatch) -> None:
-        matched = self.MATCHER.matches(inst = instruction)
+        matched = self.MATCHER.match(inst = instruction)
 
         logging.info(f'{self.MATCHER} matched {instruction} as {matched}.')
 
@@ -55,4 +55,4 @@ class TestAnyMatcher:
         assert matched == expected
 
     def test_no_match(self) -> None:
-        assert self.MATCHER.matches(inst = 'this-is-really-not-a-good-looking-instruction') is None
+        assert self.MATCHER.match(inst = 'this-is-really-not-a-good-looking-instruction') is None

--- a/tests/python/test/sass/test_atomic.py
+++ b/tests/python/test/sass/test_atomic.py
@@ -130,7 +130,7 @@ __global__ void atomic_exch_kernel() {
         Match exactly one instruction.
         """
         matcher = AtomicMatcher(**kwargs)
-        red = [(inst, matched) for inst in decoder.instructions if (matched := matcher.matches(inst))]
+        red = [(inst, matched) for inst in decoder.instructions if (matched := matcher.match(inst))]
         assert len(red) == 1, matcher
 
         inst, matched = red[0]

--- a/tests/python/test/sass/test_branch.py
+++ b/tests/python/test/sass/test_branch.py
@@ -22,7 +22,7 @@ class TestBranchMatcher:
     def test(self, instruction : str, expected : InstructionMatch) -> None:
         matcher = BranchMatcher()
 
-        matched = matcher.matches(inst = instruction)
+        matched = matcher.match(inst = instruction)
 
         assert matched is not None
         assert matched == expected
@@ -34,9 +34,9 @@ class TestBranchMatcher:
         """
         matcher = BranchMatcher(predicate = '@!UP0')
 
-        assert matcher.matches('@!UP0 BRA 0xc') == self.INSTRUCTIONS['@!UP0 BRA 0xc']
-        assert matcher.matches('@!UP2 BRA 0xc') is None
-        assert matcher.matches(      'BRA 0xc') is None
+        assert matcher.match('@!UP0 BRA 0xc') == self.INSTRUCTIONS['@!UP0 BRA 0xc']
+        assert matcher.match('@!UP2 BRA 0xc') is None
+        assert matcher.match(      'BRA 0xc') is None
 
     def test_no_match(self) -> None:
-        assert BranchMatcher().matches(inst = 'STG.E [R2], R4') is None
+        assert BranchMatcher().match(inst = 'STG.E [R2], R4') is None

--- a/tests/python/test/sass/test_composite.py
+++ b/tests/python/test/sass/test_composite.py
@@ -10,7 +10,7 @@ class TestInstructionIs:
         matcher = instruction_is(Fp32AddMatcher())
         assert isinstance(matcher, Fluentizer)
 
-        assert (matched := matcher.matches(inst = 'FADD R2, R2, R3')) is not None
+        assert (matched := matcher.match(inst = 'FADD R2, R2, R3')) is not None
         assert isinstance(matched, InstructionMatch)
 
     def test_times_1(self) -> None:

--- a/tests/python/test/sass/test_composite_impl.py
+++ b/tests/python/test/sass/test_composite_impl.py
@@ -40,7 +40,7 @@ class TestInSequenceAtMatcher:
         """
         Matches the first element.
         """
-        [matched] = InSequenceAtMatcher(matcher = MATCHER_DADD).matches(instructions = DADD_NOP_DMUL[0:1])
+        [matched] = InSequenceAtMatcher(matcher = MATCHER_DADD).match(instructions = DADD_NOP_DMUL[0:1])
 
         assert matched.opcode == 'DADD'
 
@@ -48,7 +48,7 @@ class TestInSequenceAtMatcher:
         """
         Matches the element pointed to by `start`.
         """
-        [matched] = InSequenceAtMatcher(matcher = MATCHER_DADD).matches(instructions = NOP_DMUL_NOP_DADD[4::])
+        [matched] = InSequenceAtMatcher(matcher = MATCHER_DADD).match(instructions = NOP_DMUL_NOP_DADD[4::])
 
         assert matched.opcode == 'DADD'
 
@@ -70,7 +70,7 @@ class TestZeroOrMoreInSequenceMatcher:
         """
         Matches zero time with sequence :py:const:`DADD_NOP_DMUL`.
         """
-        matched = ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP).matches(instructions = DADD_NOP_DMUL)
+        matched = ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP).match(instructions = DADD_NOP_DMUL)
 
         assert not matched
 
@@ -86,7 +86,7 @@ class TestZeroOrMoreInSequenceMatcher:
         """
         Matches many times, with a `start` and sequence :py:const:`DADD_NOP_DMUL`.
         """
-        matched = ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP).matches(instructions = DADD_NOP_DMUL[1::])
+        matched = ZeroOrMoreInSequenceMatcher(matcher = MATCHER_NOP).match(instructions = DADD_NOP_DMUL[1::])
 
         assert len(matched) == 3 and all(x.opcode == 'NOP' for x in matched)
 
@@ -104,7 +104,7 @@ class TestOneOrMoreInSequenceMatcher:
         """
         matcher = OneOrMoreInSequenceMatcher(matcher = MATCHER_NOP)
 
-        assert not matcher.matches(instructions = DADD_NOP_DMUL)
+        assert not matcher.match(instructions = DADD_NOP_DMUL)
 
         with pytest.raises(RuntimeError, match = 'did not match'):
             matcher.assert_matches(instructions = DADD_NOP_DMUL)
@@ -115,7 +115,7 @@ class TestOneOrMoreInSequenceMatcher:
         """
         matcher = OneOrMoreInSequenceMatcher(matcher = MATCHER_DADD)
 
-        assert len(matcher.matches(instructions = DADD_NOP_DMUL)) == 1
+        assert len(matcher.match(instructions = DADD_NOP_DMUL)) == 1
         assert len(matcher.assert_matches(instructions = DADD_NOP_DMUL)) == 1
 
     def test_matches_more(self):
@@ -124,7 +124,7 @@ class TestOneOrMoreInSequenceMatcher:
         """
         matcher = OneOrMoreInSequenceMatcher(matcher = MATCHER_NOP)
 
-        assert len(matcher.matches(instructions = DADD_NOP_DMUL[1::])) == 3
+        assert len(matcher.match(instructions = DADD_NOP_DMUL[1::])) == 3
         assert len(matcher.assert_matches(instructions = DADD_NOP_DMUL[1::])) == 3
 
     def test_explain(self) -> None:
@@ -144,7 +144,7 @@ class TestOrderedInSequenceMatcher:
         """
         Matches the sequence :py:const:`DADD_NOP_DMUL`.
         """
-        matched = self.MATCHER.matches(instructions = DADD_NOP_DMUL)
+        matched = self.MATCHER.match(instructions = DADD_NOP_DMUL)
 
         assert len(matched) == 5
         assert matched[0].opcode == 'DADD'
@@ -155,7 +155,7 @@ class TestOrderedInSequenceMatcher:
         """
         Matches the sequence :py:const:`DADD_DMUL`.
         """
-        matched = self.MATCHER.matches(instructions = DADD_DMUL)
+        matched = self.MATCHER.match(instructions = DADD_DMUL)
 
         assert len(matched) == 2
         assert matched[0].opcode == 'DADD'
@@ -187,7 +187,7 @@ class TestUnorderedInSequenceMatcher:
 
         random.shuffle(inners)
 
-        matched = UnorderedInSequenceMatcher(matchers = inners).matches(instructions = DADD_NOP_DMUL)
+        matched = UnorderedInSequenceMatcher(matchers = inners).match(instructions = DADD_NOP_DMUL)
 
         assert len(matched) == 5
 
@@ -203,7 +203,7 @@ class TestUnorderedInSequenceMatcher:
 
         random.shuffle(inners)
 
-        matched = UnorderedInSequenceMatcher(matchers = inners).matches(instructions = DADD_DMUL)
+        matched = UnorderedInSequenceMatcher(matchers = inners).match(instructions = DADD_DMUL)
 
         assert len(matched) == 2
 
@@ -220,7 +220,7 @@ class TestUnorderedInSequenceMatcher:
 
         random.shuffle(inners)
 
-        matched = UnorderedInSequenceMatcher(matchers = inners).matches(instructions = NOP_DMUL_NOP_DADD)
+        matched = UnorderedInSequenceMatcher(matchers = inners).match(instructions = NOP_DMUL_NOP_DADD)
 
         assert len(matched) == 5
 
@@ -249,14 +249,14 @@ class TestInSequenceMatcher:
     def test_matches(self) -> None:
         matcher = InSequenceMatcher(matcher = MATCHER_DADD)
 
-        assert matcher.matches(instructions = NOP_DMUL_NOP_DADD) is not None
+        assert matcher.match(instructions = NOP_DMUL_NOP_DADD) is not None
 
         assert matcher.index == 4
 
     def test_no_match(self) -> None:
         matcher = InSequenceMatcher(matcher = MATCHER_NOP)
 
-        assert matcher.matches(instructions = DADD_DMUL) is None
+        assert matcher.match(instructions = DADD_DMUL) is None
 
         assert matcher.index is None
 
@@ -273,11 +273,11 @@ class TestAnyOfMatcher:
             MATCHER_DADD,
         )
 
-        assert matcher.matches(instructions = NOP_DMUL_NOP_DADD) is not None
+        assert matcher.match(instructions = NOP_DMUL_NOP_DADD) is not None
 
         assert matcher.index == 0
 
-        assert matcher.matches(instructions = (DADD,)) is not None
+        assert matcher.match(instructions = (DADD,)) is not None
 
         assert matcher.index == 1
 
@@ -287,7 +287,7 @@ class TestAnyOfMatcher:
             MATCHER_DMUL,
         )
 
-        assert matcher.matches(instructions = (NOP, DADD, DMUL)) is None
+        assert matcher.match(instructions = (NOP, DADD, DMUL)) is None
 
         assert matcher.index is None
 

--- a/tests/python/test/sass/test_load.py
+++ b/tests/python/test/sass/test_load.py
@@ -52,7 +52,7 @@ __global__ __launch_bounds__(128, 1) void ldc({type}* __restrict__ const out)
 
     @pytest.mark.parametrize('instruction,matcher,expected', ((instr, *vals) for instr, vals in INSTRUCTIONS.items()))
     def test(self, instruction : str, matcher : LoadConstantMatcher, expected : InstructionMatch) -> None:
-        assert (matched := matcher.matches(inst = instruction)) is not None
+        assert (matched := matcher.match(inst = instruction)) is not None
         assert matched == expected
 
     @pytest.mark.parametrize('parameters', PARAMETERS, ids = str)
@@ -67,7 +67,7 @@ __global__ __launch_bounds__(128, 1) void ldc({type}* __restrict__ const out)
 
         # Find the constant load.
         matcher = LoadConstantMatcher(size = 64, uniform = False)
-        load_cst = tuple((inst, matched) for inst in decoder.instructions if (matched := matcher.matches(inst)))
+        load_cst = tuple((inst, matched) for inst in decoder.instructions if (matched := matcher.match(inst)))
         assert len(load_cst) == 1, matcher
 
         inst, matched = load_cst[0]

--- a/tests/python/test_extensibility.py
+++ b/tests/python/test_extensibility.py
@@ -29,7 +29,7 @@ class NewInstructionMatcher(InstructionMatcher):
     Faking a matcher for some unforeseen use case.
     """
     @override
-    def matches(self, inst : str | Instruction) -> InstructionMatch | None:
+    def match(self, inst : str | Instruction) -> InstructionMatch | None:
         if (matched := regex.match(r'(?P<opcode>[A-Z]+).*', inst.instruction if isinstance(inst, Instruction) else inst)) is not None:
             return InstructionMatch.parse(bits = matched)
         return None
@@ -72,14 +72,14 @@ class TestInstructionMatching:
     NOP  : typing.Final[Instruction] = Instruction(offset = 0, instruction = 'NOP',                        hex = '0x2', control = CONTROLCODE)
 
     def test_NewInstructionMatcher(self) -> None:
-        result = instruction_is(matcher = NewInstructionMatcher()).times(3).matches(instructions = (self.DADD, self.DMUL, self.NOP))
+        result = instruction_is(matcher = NewInstructionMatcher()).times(3).match(instructions = (self.DADD, self.DMUL, self.NOP))
 
         assert result is not None
 
         assert len(result) == 3
 
     def test_NewPatternMatcher(self) -> None:
-        result = instruction_is(matcher = NewPatternMatcher()).times(3).matches(instructions = (self.DADD, self.DMUL, self.NOP))
+        result = instruction_is(matcher = NewPatternMatcher()).times(3).match(instructions = (self.DADD, self.DMUL, self.NOP))
 
         assert result is not None
 


### PR DESCRIPTION
So we better align with *e.g.* `regex.match`.