### PR TITLE
test(sass): `with_operand[s]`

### DIFF
--- a/reprospect/test/sass/composite.py
+++ b/reprospect/test/sass/composite.py
@@ -61,9 +61,27 @@ class Fluentizer(instruction.InstructionMatcher):
         >>> matcher.match(inst = 'FADD R5, R8, R9')
         InstructionMatch(opcode='FADD', modifiers=(), operands=('R5', 'R8', 'R9'), predicate=None, additional={'dst': ['R5']})
         """
-        return Fluentizer(composite_impl.OperandValidator(
+        return Fluentizer(matcher = composite_impl.OperandValidator(
             matcher = self.matcher,
             index = index, operand = operand,
+        ))
+
+    def with_operands(self, operands : typing.Collection[tuple[int, str]]) -> instruction.InstructionMatcher:
+        """
+        Similar to :py:meth:`with_operand` for many operands.
+
+        >>> from reprospect.test.sass.composite   import instruction_is
+        >>> from reprospect.test.sass.instruction import Fp32AddMatcher
+        >>> matcher = instruction_is(Fp32AddMatcher()).with_operands(
+        ...     operands = ((1, 'R8'), (2, 'R9')),
+        ... )
+        >>> matcher.match(inst = 'FADD R5, R9, R10')
+        >>> matcher.match(inst = 'FADD R5, R8, R9')
+        InstructionMatch(opcode='FADD', modifiers=(), operands=('R5', 'R8', 'R9'), predicate=None, additional={'dst': ['R5']})
+        """
+        return Fluentizer(matcher = composite_impl.OperandsValidator(
+            matcher = self,
+            operands = operands
         ))
 
     @override

--- a/reprospect/test/sass/composite_impl.py
+++ b/reprospect/test/sass/composite_impl.py
@@ -251,3 +251,31 @@ class OperandValidator(InstructionMatcher):
             if operand == self.operand:
                 return matched
         return None
+
+class OperandsValidator(InstructionMatcher):
+    """
+    Validate that the :py:attr:`operands` match the instruction matched
+    with :py:attr:`matcher`.
+
+    .. note::
+
+        It is not decorated with :py:func:`dataclasses.dataclass` because of https://github.com/mypyc/mypyc/issues/1061.
+    """
+    __slots__ = ('matcher', 'operands')
+
+    def __init__(self, matcher : InstructionMatcher, operands : typing.Collection[tuple[int, str]]) -> None:
+        self.matcher : typing.Final[InstructionMatcher] = matcher
+        self.operands : typing.Final[tuple[tuple[int, str], ...]] = tuple(operands)
+
+    @override
+    def match(self, inst : Instruction | str) -> InstructionMatch | None:
+        if (matched := self.matcher.match(inst)) is not None:
+            for mindex, moperand in self.operands:
+                try:
+                    operand = matched.operands[mindex]
+                except IndexError:
+                    return None
+                if operand != moperand:
+                    return None
+            return matched
+        return None

--- a/tests/python/test/sass/test_composite.py
+++ b/tests/python/test/sass/test_composite.py
@@ -1,6 +1,6 @@
 from reprospect.test.sass.composite      import any_of, Fluentizer, instructions_are, instructions_contain, instruction_is, unordered_instructions_are
 from reprospect.test.sass.composite_impl import AnyOfMatcher, InSequenceMatcher, InSequenceAtMatcher, OneOrMoreInSequenceMatcher, OrderedInSequenceMatcher, UnorderedInSequenceMatcher, ZeroOrMoreInSequenceMatcher
-from reprospect.test.sass.instruction    import Fp32AddMatcher, InstructionMatch, OpcodeModsMatcher
+from reprospect.test.sass.instruction    import AnyMatcher, Fp32AddMatcher, InstructionMatch, OpcodeModsMatcher
 
 class TestInstructionIs:
     """
@@ -41,6 +41,33 @@ class TestInstructionIs:
         assert isinstance(matcher, Fluentizer)
         assert matcher.match(inst = 'FADD R2, R2, R3') is not None
         assert matcher.match(inst = 'FADD R4, R4, RZ') is None
+
+    def test_with_operand_composed(self) -> None:
+        """
+        Similar to :py:meth:`test_with_operands` but calls
+        :py:meth:`reprospect.test.sass.composite.Fluentizer.with_operand`
+        many times.
+        """
+        matcher = instruction_is(Fp32AddMatcher()).with_operand(
+            index = 2, operand = 'R3',
+        ).with_operand(
+            index = 1, operand = 'R2',
+        )
+        assert isinstance(matcher, Fluentizer)
+        assert matcher.match(inst = 'FADD R2, R2, R3') is not None
+        assert matcher.match(inst = 'FADD R3, R2, R3') is not None
+        assert matcher.match(inst = 'FADD R2, R2, RZ') is None
+
+    def test_with_operands(self) -> None:
+        """
+        Test :py:meth:`reprospect.test.sass.composite.Fluentizer.with_operands`.
+        """
+        matcher = instruction_is(AnyMatcher()).with_operands(operands = (
+            (-1, 'URZ'),
+            ( 1, 'UPT'),
+        ))
+        assert isinstance(matcher, Fluentizer)
+        assert matcher.match(inst = 'UIADD3 UR5, UPT, UPT, -UR4, UR9, URZ') is not None
 
 class TestInstructionsAre:
     """


### PR DESCRIPTION
When multiple operands need to be matched, let's build a single "wrapping" matcher (`OperandsValidator`).

It has better semantics and probably less overhead.