### PR TITLE
test(sass): allow `with_operand` without index

### DIFF
--- a/reprospect/test/sass/composite.py
+++ b/reprospect/test/sass/composite.py
@@ -54,7 +54,7 @@ class Fluentizer(instruction.InstructionMatcher):
         """
         return composite_impl.ZeroOrMoreInSequenceMatcher(matcher = self.matcher)
 
-    def with_operand(self, index : int, operand : OperandMatcher) -> Fluentizer:
+    def with_operand(self, operand : OperandMatcher, index : int | None = None) -> Fluentizer:
         """
         >>> from reprospect.test.sass.composite   import instruction_is
         >>> from reprospect.test.sass.instruction import Fp32AddMatcher, RegisterMatcher

--- a/tests/python/test/sass/test_composite.py
+++ b/tests/python/test/sass/test_composite.py
@@ -68,6 +68,12 @@ class TestInstructionIs:
         )
         assert matcher.match(inst = 'UIADD3 UR5, UPT, UPT, -UR4, UR9, URZ') is not None
 
+        matcher = instruction_is(AnyMatcher()).with_operand(operand = 'UPT')
+        assert matcher.match(inst = 'UIADD3 UR5, UPT, UPT, -UR4, UR9, URZ') is not None
+
+        matcher = instruction_is(AnyMatcher()).with_operand(operand = 'R42')
+        assert matcher.match(inst = 'UIADD3 UR5, UPT, UPT, -UR4, UR9, URZ') is None
+
     def test_with_operand_composed(self) -> None:
         """
         Similar to :py:meth:`test_with_operands` but calls


### PR DESCRIPTION
Allowing the operand to be anywhere in the matched instruction operands. It is "less strict".