### PR TITLE
cuda(nvtx3): prefer to include nvtx3 from nvtx3 directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,6 +230,7 @@ jobs:
                       CXX_COMPILER=${{ matrix.compilers.CXX.path }}
                       DOXYGEN_VERSION=1_14_0
                       GOOGLEBENCHMARK_VERSION=1.9.4
+                      NVTX3_VERSION=3.4.0
                       PYTHON_VERSION=${{ matrix.ubuntu_version == '24.04' && '3.12' || '3.10' }}
                   labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -166,14 +166,48 @@ RUN <<EOF
     cmake --build build -j4 --target install
 EOF
 
+FROM requirements-compiler-${CXX_COMPILER_ID} AS nvtx3
+
+ARG NVTX3_VERSION
+
+ADD --unpack=true https://github.com/NVIDIA/NVTX/archive/refs/tags/v${NVTX3_VERSION}.tar.gz /opt/NVIDIA/
+
+# See https://github.com/NVIDIA/NVTX/issues/140.
+COPY <<EOF /opt/NVIDIA/NVTX-${NVTX3_VERSION}/nvtx-install.patch
+--- c/CMakeLists.txt.old 2025-12-17 10:06:32.849766429 +0000
++++ c/CMakeLists.txt 2025-12-17 10:06:37.800063794 +0000
+@@ -85,7 +85,7 @@
+     )
+
+     # Install the targets
+-    install(TARGETS nvtx3-c nvtx3-cpp EXPORT nvtx3-targets)
++    install(TARGETS nvtx3-c nvtx3-cpp EXPORT nvtx3-targets INCLUDES DESTINATION $\{CMAKE_INSTALL_INCLUDEDIR\})
+     install(EXPORT nvtx3-targets
+         FILE nvtx3-targets.cmake
+         NAMESPACE nvtx3::
+EOF
+
+RUN <<EOF
+    set -ex
+    cd /opt/NVIDIA/NVTX-${NVTX3_VERSION}
+    patch -p0 < nvtx-install.patch
+    cd c/
+    cmake -S . -B build -DNVTX3_INSTALL=ON -DCMAKE_INSTALL_PREFIX=/opt/nvtx3-${NVTX3_VERSION}
+    cmake --build build --target install
+EOF
+
 FROM nsight-systems
 
 ARG DOXYGEN_VERSION
 ARG GOOGLEBENCHMARK_VERSION
+ARG NVTX3_VERSION
 
 COPY --from=doxygen /opt/doxygen-${DOXYGEN_VERSION} /opt/doxygen-${DOXYGEN_VERSION}
 
 COPY --from=google-benchmark /opt/google-benchmark-${GOOGLEBENCHMARK_VERSION} /opt/google-benchmark-${GOOGLEBENCHMARK_VERSION}
 
+COPY --from=nvtx3 /opt/nvtx3-${NVTX3_VERSION} /opt/nvtx3-${NVTX3_VERSION}
+
 ENV benchmark_ROOT=/opt/google-benchmark-${GOOGLEBENCHMARK_VERSION}
 ENV Doxygen_ROOT=/opt/doxygen-${DOXYGEN_VERSION}
+ENV nvtx3_ROOT=/opt/nvtx3-${NVTX3_VERSION}

--- a/tests/assets/CMakeLists.txt
+++ b/tests/assets/CMakeLists.txt
@@ -10,7 +10,7 @@ function(add_one_executable FILE)
 
     target_sources(${EXECUTABLE} PRIVATE ${FILENAME})
 
-    target_link_libraries(${EXECUTABLE} PRIVATE CUDA::cudart CUDA::nvtx3)
+    target_link_libraries(${EXECUTABLE} PRIVATE CUDA::cudart nvtx3::nvtx3-cpp)
 
     set_source_files_properties(${FILENAME} PROPERTIES LANGUAGE CUDA)
 
@@ -18,8 +18,9 @@ endfunction()
 
 find_package(
     CUDAToolkit REQUIRED
-    COMPONENTS cuda_driver cudart nvtx3
+    COMPONENTS cuda_driver cudart
 )
+find_package(nvtx3 REQUIRED)
 
 add_one_executable(graph)
 add_one_executable(half)

--- a/tests/assets/test_graph.cpp
+++ b/tests/assets/test_graph.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 #include "common/cuda_runtime.hpp"
-#include "cub/detail/nvtx3.hpp"
+#include "nvtx3/nvtx3.hpp"
 
 /**
  * @file

--- a/tests/assets/test_half.cpp
+++ b/tests/assets/test_half.cpp
@@ -1,7 +1,7 @@
 #include <array>
 
 #include "common/cuda_runtime.hpp"
-#include "cub/detail/nvtx3.hpp"
+#include "nvtx3/nvtx3.hpp"
 
 #include "test_half.cu"
 

--- a/tests/assets/test_saxpy.cpp
+++ b/tests/assets/test_saxpy.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 
 #include "common/cuda_runtime.hpp"
-#include "cub/detail/nvtx3.hpp"
+#include "nvtx3/nvtx3.hpp"
 
 /**
  * @file


### PR DESCRIPTION
The nvidia docker images <13 do not include the nvtx3 cpp header at the expected location.

We relied on a workaround to include it from `cub/detail`.

This PR installs the `NVTX` library in the images.

* https://github.com/NVIDIA/NVTX/issues/140