### PR TITLE
paper: add code snippet for math fp16/fp32

### DIFF
--- a/papers/joss/paper.md
+++ b/papers/joss/paper.md
@@ -82,7 +82,21 @@ Notably, the machine code already contains information about the available code 
 
 # Key features
 
-Key features.
++------------------------------------+---------------------------------+
+| 16-bit path `__hmax`               | 32-bit path `fmax`              |
++====================================+=================================+
+| ```bash                            | ```bash                         |
+| LDG.E.U16 R2, desc[UR6][R2.64]     | LDG.E.U16 R2, desc[UR6][R2.64]  |
+| LDG.E.U16 R5, desc[UR6][R4.64]     | LDG.E.U16 R4, desc[UR6][R4.64]  |
+| ...                                | ...                             |
+| HMNMX2 R5, R2.H0_H0, R5.H0_H0, !PT | HADD2.F32 R6, -RZ, R2.H0_H0     |
+| ...                                | HADD2.F32 R7, -RZ, R4.H0_H0     |
+|                                    | FMNMX R6, R6, R7, !PT           |
+|                                    | F2FP.F16.F32.PACK_AB R3, RZ, R6 |
+|                                    | ...                             |
+| STG.E.U16 desc[UR6][R6.64], R5     | STG.E.U16 desc[UR6][R6.64], R3  |
+| ```                                | ```                             |
++------------------------------------+---------------------------------+
 
 # Case studies
 


### PR DESCRIPTION
Added detailed key features section with 16-bit and 32-bit path examples.

Copied from #390.