### PR TITLE
Housekeeping: split out `add_one_example` from `add_one_kokkos_example`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,14 @@ cmake_file_api(QUERY API_VERSION 1
   CODEMODEL 2
 )
 
+if(ReProspect_ENABLE_TESTS OR ReProspect_ENABLE_EXAMPLES)
+    find_package(
+        CUDAToolkit REQUIRED
+        COMPONENTS cuda_driver cudart
+    )
+    find_package(nvtx3 REQUIRED)
+endif()
+
 if(ReProspect_ENABLE_TESTS)
     enable_testing()
     add_subdirectory(tests)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,1 +1,52 @@
+function(add_one_example FILE)
+
+    cmake_parse_arguments(
+        aoe_args
+        ""
+        ""
+        "EXTRA_PRIVATE_LINK_LIBS;EXTRA_TEST_ENV"
+        ${ARGN}
+    )
+
+    set(FILE_NAME example_${FILE}.cpp)
+    set(FILE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${FILE_NAME})
+
+    get_parent_relpath_repr(DIRECTORY ${CMAKE_SOURCE_DIR} FILENAME ${FILE_PATH})
+
+    set(EXECUTABLE ${gprr_PARENT_RELPATH_REPR}_${FILE})
+
+    add_executable(${EXECUTABLE})
+
+    target_sources(${EXECUTABLE} PRIVATE ${FILE_PATH})
+
+    set_source_files_properties(${FILE_PATH} PROPERTIES LANGUAGE CUDA)
+
+    target_include_directories(${EXECUTABLE} PRIVATE ${CMAKE_SOURCE_DIR})
+
+    if(aoe_args_EXTRA_PRIVATE_LINK_LIBS)
+        target_link_libraries(${EXECUTABLE} PRIVATE ${aoe_args_EXTRA_PRIVATE_LINK_LIBS})
+    endif()
+
+    add_test(
+        NAME ${EXECUTABLE}
+        COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/example_${FILE}.py
+                    --config-file=${CMAKE_SOURCE_DIR}/tests/.pytest.ini
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
+    pytest_skip_mark(${EXECUTABLE})
+
+    test_environment(${EXECUTABLE} PYTHONPATH path_list_prepend ${CMAKE_SOURCE_DIR})
+    test_environment(${EXECUTABLE} CMAKE_BINARY_DIR set ${CMAKE_BINARY_DIR})
+    test_environment(${EXECUTABLE} CMAKE_CURRENT_BINARY_DIR set ${CMAKE_CURRENT_BINARY_DIR})
+
+    if(aoe_args_EXTRA_TEST_ENV)
+        list(GET aoe_args_EXTRA_TEST_ENV 0 ENV_NAME)
+        list(GET aoe_args_EXTRA_TEST_ENV 1 ENV_OP)
+        list(GET aoe_args_EXTRA_TEST_ENV 2 ENV_VALUE)
+        test_environment(${EXECUTABLE} ${ENV_NAME} ${ENV_OP} ${ENV_VALUE})
+    endif()
+
+endfunction()
+
 add_subdirectory(kokkos)

--- a/examples/kokkos/CMakeLists.txt
+++ b/examples/kokkos/CMakeLists.txt
@@ -1,32 +1,8 @@
-function(add_one_example FILE)
-
-    set(FILENAME ${CMAKE_CURRENT_SOURCE_DIR}/example_${FILE}.cpp)
-
-    get_parent_relpath_repr(DIRECTORY ${CMAKE_SOURCE_DIR} FILENAME ${FILENAME})
-
-    set(EXECUTABLE ${gprr_PARENT_RELPATH_REPR}_${FILE})
-
-    add_executable(${EXECUTABLE})
-
-    target_sources(${EXECUTABLE} PRIVATE ${FILENAME})
-
-    set_source_files_properties(${FILENAME} PROPERTIES LANGUAGE CUDA)
-
-    target_link_libraries(${EXECUTABLE} PRIVATE Kokkos::kokkoscore)
-
-    add_test(
-        NAME ${EXECUTABLE}
-        COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/example_${FILE}.py
-                    --config-file=${CMAKE_SOURCE_DIR}/tests/.pytest.ini
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+function(add_one_kokkos_example FILE)
+    add_one_example(${FILE}
+        EXTRA_PRIVATE_LINK_LIBS Kokkos::kokkoscore
+        EXTRA_TEST_ENV KOKKOS_TOOLS_NVTX_CONNECTOR_LIB set $<TARGET_FILE:KokkosTools::kp_nvtx_connector>
     )
-
-    pytest_skip_mark(${EXECUTABLE})
-
-    test_environment(${EXECUTABLE} PYTHONPATH path_list_prepend ${CMAKE_SOURCE_DIR})
-    test_environment(${EXECUTABLE} CMAKE_BINARY_DIR set ${CMAKE_BINARY_DIR})
-    test_environment(${EXECUTABLE} CMAKE_CURRENT_BINARY_DIR set ${CMAKE_CURRENT_BINARY_DIR})
-    test_environment(${EXECUTABLE} KOKKOS_TOOLS_NVTX_CONNECTOR_LIB set $<TARGET_FILE:KokkosTools::kp_nvtx_connector>)
 
 endfunction()
 

--- a/examples/kokkos/atomic/CMakeLists.txt
+++ b/examples/kokkos/atomic/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_one_example(add_complex64)
-add_one_example(add_complex128)
-add_one_example(add_double256)
-add_one_example(add_int128)
+add_one_kokkos_example(add_complex64)
+add_one_kokkos_example(add_complex128)
+add_one_kokkos_example(add_double256)
+add_one_kokkos_example(add_int128)

--- a/examples/kokkos/complex/CMakeLists.txt
+++ b/examples/kokkos/complex/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_one_example(alignment)
+add_one_kokkos_example(alignment)

--- a/examples/kokkos/graph/CMakeLists.txt
+++ b/examples/kokkos/graph/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_one_example(dispatch)
-add_one_example(then)
+add_one_kokkos_example(dispatch)
+add_one_kokkos_example(then)

--- a/examples/kokkos/half/CMakeLists.txt
+++ b/examples/kokkos/half/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_one_example(math)
+add_one_kokkos_example(math)

--- a/examples/kokkos/view/CMakeLists.txt
+++ b/examples/kokkos/view/CMakeLists.txt
@@ -1,8 +1,8 @@
-add_one_example(allocation_tracing)
+add_one_kokkos_example(allocation_tracing)
 
 find_package(benchmark REQUIRED COMPONENTS benchmark)
 
-add_one_example(allocation_benchmarking)
+add_one_kokkos_example(allocation_benchmarking)
 target_link_libraries(examples_kokkos_view_allocation_benchmarking PRIVATE benchmark::benchmark)
 target_sources(examples_kokkos_view_allocation_benchmarking PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/example_allocation_benchmarking.main.cpp)
 

--- a/tests/assets/CMakeLists.txt
+++ b/tests/assets/CMakeLists.txt
@@ -16,12 +16,6 @@ function(add_one_executable FILE)
 
 endfunction()
 
-find_package(
-    CUDAToolkit REQUIRED
-    COMPONENTS cuda_driver cudart
-)
-find_package(nvtx3 REQUIRED)
-
 add_one_executable(graph)
 add_one_executable(half)
 add_one_executable(saxpy)


### PR DESCRIPTION
Extracted from:
- #242 

🚗 Move find `CUDAToolkit` to main `CMakeLists.txt` file.