### PR TITLE
tests: match all operands of all instructions of `cuBLAS`

### DIFF
--- a/reprospect/test/sass/instruction/address.py
+++ b/reprospect/test/sass/instruction/address.py
@@ -149,9 +149,9 @@ class AddressMatcher:
         match arch.compute_capability.as_int:
             case 70:
                 inner = r'-?' + PatternBuilder.HEXADECIMAL
-            case 75 | 80 | 86 | 89:
+            case 80 | 89:
                 inner = PatternBuilder.any(r'-?' + PatternBuilder.HEXADECIMAL, Register.UREG)
-            case 90 | 100 | 103 | 120 | 121:
+            case 75 | 86 | 90 | 100 | 103 | 120 | 121:
                 inner = PatternBuilder.any(r'-?' + PatternBuilder.HEXADECIMAL, Register.UREG, rf'{Register.UREG}\+-?{PatternBuilder.HEXADECIMAL}')
             case _:
                 raise ValueError(f'unsupported architecture {arch}')
@@ -203,7 +203,12 @@ class AddressMatcher:
                     cls.build_reg_address(arch=arch, reg=reg, offset=offset, captured=captured),
                     cls.build_reg64_address(arch=arch, reg=reg, offset=offset, captured=captured),
                 )
-            case 80 | 86 | 89:
+            case 80:
+                return PatternBuilder.any(
+                    cls.build_reg64_address(arch=arch, reg=reg, offset=offset, captured=captured),
+                    cls.build_desc_reg64_address(arch=arch, reg=reg, desc_ureg=desc_ureg, offset=offset, captured=captured),
+                )
+            case 86 | 89:
                 return cls.build_reg64_address(arch=arch, reg=reg, offset=offset, captured=captured)
             case 90 | 100 | 103 | 120 | 121:
                 return cls.build_desc_reg64_address(arch=arch, reg=reg, desc_ureg=desc_ureg, offset=offset, captured=captured)
@@ -276,6 +281,7 @@ class AddressMatcher:
             [R1.64]
             [R2.64+0x10]
             [R14.64+UR6]
+            [R14.64+UR8+0x80]
         """
         pattern_reg = cls.build_pattern_reg(arch=arch, reg=reg, captured=captured)
         pattern_offset = cls.build_pattern_offset(arch=arch, offset=offset, captured=captured)

--- a/reprospect/test/sass/instruction/immediate.py
+++ b/reprospect/test/sass/instruction/immediate.py
@@ -6,16 +6,10 @@ from reprospect.test.sass.instruction.pattern import PatternBuilder
 class Immediate:
     """
     Immediate patterns.
-
-    ..note::
-
-         Limits may print in dumped SASS followed by a space as in::
-
-            FSETP.GEU.AND P1, PT, |R151|, +INF , PT
     """
-    INF: typing.Final[str] = r'[+-]?INF\s?'
+    INF: typing.Final[str] = r'[+-]?INF'
 
-    QNAN: typing.Final[str] = PatternBuilder.any(r'[+-]?QNAN\s?', '0x7fffffff')
+    QNAN: typing.Final[str] = PatternBuilder.any(r'[+-]?QNAN', '0x7fffffff')
     """Quiet NaN. Note that in SASS, :code:`CUDART_NAN_F` from ``math_constants.h`` is represented as ``0x7fffffff``."""
 
     FLOATING: typing.Final[str] = r'(?:-?\d+)(?:\.\d*)?(?:[eE][-+]?\d+)?'

--- a/tests/cublas.py
+++ b/tests/cublas.py
@@ -39,3 +39,12 @@ class CuBLAS:
             cwd / file
             for file in CuObjDump.extract_elf(file=self.libcublas, arch=arch, name=name, cwd=cwd)
         )
+
+    def cubin(self, *, arch: NVIDIAArch, cwd: pathlib.Path, randomly: bool = True, **kwargs) -> CuObjDump:
+        """
+        Pick a cubin file from :py:attr:`libcublas` and read it with :py:class:`reprospect.tools.binaries.CuObjDump`.
+        """
+        [cubin] = self.extract(arch=arch, cwd=cwd, randomly=randomly)
+        assert cubin.is_file()
+
+        return CuObjDump(file=cubin, arch=arch, **kwargs)

--- a/tests/test/sass/instruction/CMakeLists.txt
+++ b/tests/test/sass/instruction/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_pytest(address)
 add_pytest(constant)
+add_pytest(cublas)
 add_pytest(fp32add)
 add_pytest(fp64add)
 add_pytest(half)

--- a/tests/test/sass/instruction/test_address.py
+++ b/tests/test/sass/instruction/test_address.py
@@ -59,6 +59,15 @@ class TestAddressMatcher:
         assert AddressMatcher(arch=ARCH, reg='R42', offset='UR2' ).match(ADDRESS_WITH_OFFSET_AS_UREG) is None
         assert AddressMatcher(arch=ARCH, reg='R42', offset='0x20').match(ADDRESS_WITH_OFFSET_AS_UREG) is None
 
+        ADDRESS_WITH_OFFSET_AS_UREG_AND_HEX: typing.Final[str] = '[R14.64+UR8+0x80]'
+
+        assert AddressMatcher(arch=ARCH                                ).match(ADDRESS_WITH_OFFSET_AS_UREG_AND_HEX) == GenericOrGlobalAddressMatch(reg='R14', offset='UR8+0x80')
+        assert AddressMatcher(arch=ARCH, reg='R14'                     ).match(ADDRESS_WITH_OFFSET_AS_UREG_AND_HEX) == GenericOrGlobalAddressMatch(reg='R14', offset='UR8+0x80')
+        assert AddressMatcher(arch=ARCH, reg='R14', offset=r'UR8\+0x80').match(ADDRESS_WITH_OFFSET_AS_UREG_AND_HEX) == GenericOrGlobalAddressMatch(reg='R14', offset='UR8+0x80')
+        assert AddressMatcher(arch=ARCH, reg='R27'                     ).match(ADDRESS_WITH_OFFSET_AS_UREG_AND_HEX) is None
+        assert AddressMatcher(arch=ARCH, reg='R42', offset='UR2'       ).match(ADDRESS_WITH_OFFSET_AS_UREG_AND_HEX) is None
+        assert AddressMatcher(arch=ARCH, reg='R42', offset='0x20'      ).match(ADDRESS_WITH_OFFSET_AS_UREG_AND_HEX) is None
+
     def test_reg64_address(self) -> None:
         ARCH: typing.Final[NVIDIAArch] = NVIDIAArch.from_str('AMPERE86')
 
@@ -108,7 +117,7 @@ class TestAddressMatcher:
         assert AddressMatcher(arch=ARCH, memory=MemorySpace.SHARED, reg='R25', offset='0x800', stride=StrideModifier.X8).match(ADDRESS) == SharedAddressMatch(reg='R25', offset='0x800', stride=StrideModifier.X8)
         assert AddressMatcher(arch=ARCH, memory=MemorySpace.SHARED, reg='R25', offset='0x800', stride=StrideModifier.X4).match(ADDRESS) is None
 
-    def test_shared_offset_address(self) -> None:
+    def test_shared_offset_address_volta70(self) -> None:
         ARCH: typing.Final[NVIDIAArch] = NVIDIAArch.from_str('VOLTA70')
 
         ADDRESS: typing.Final[str] = '[0x10]'
@@ -119,6 +128,18 @@ class TestAddressMatcher:
         assert OpcodeModsWithOperandsMatcher(opcode='LDS', modifiers=('U', '128'), operands=(
             Register.REG, AddressMatcher.build_pattern(arch=ARCH, memory=MemorySpace.SHARED),
         )).match(inst=f'LDS.U.128 R20, {ADDRESS}') is not None
+
+    def test_shared_offset_address_ampere86(self) -> None:
+        ARCH: typing.Final[NVIDIAArch] = NVIDIAArch.from_str('AMPERE86')
+
+        ADDRESS: typing.Final[str] = '[R33+UR6+-0x4]'
+
+        assert AddressMatcher(arch=ARCH, memory=MemorySpace.SHARED           ).match(ADDRESS) == SharedAddressMatch(reg='R33', offset='UR6+-0x4')
+        assert AddressMatcher(arch=ARCH, memory=MemorySpace.SHARED, reg='R32').match(ADDRESS) is None
+
+        assert OpcodeModsWithOperandsMatcher(opcode='LDS', operands=(
+            Register.REG, AddressMatcher.build_pattern(arch=ARCH, memory=MemorySpace.SHARED),
+        )).match(inst=f'LDS R32, {ADDRESS}') is not None
 
     def test_shared_rz_address(self) -> None:
         ARCH: typing.Final[NVIDIAArch] = NVIDIAArch.from_str('VOLTA70')

--- a/tests/test/sass/instruction/test_cublas.py
+++ b/tests/test/sass/instruction/test_cublas.py
@@ -1,0 +1,99 @@
+import logging
+import pathlib
+import random
+import typing
+
+import pytest
+import regex
+
+from reprospect.test.sass.instruction.address import AddressMatcher, MemorySpace
+from reprospect.test.sass.instruction.constant import ConstantMatcher
+from reprospect.test.sass.instruction.immediate import Immediate
+from reprospect.test.sass.instruction.instruction import AnyMatcher
+from reprospect.test.sass.instruction.register import RegisterMatcher
+from reprospect.tools.sass.decode import Decoder
+
+from tests.cublas import CuBLAS
+from tests.parameters import PARAMETERS, Parameters
+
+
+class TestCuBLAS:
+    @pytest.mark.parametrize('parameters', PARAMETERS, ids=str)
+    def test_operands(self, workdir: pathlib.Path, parameters: Parameters, cmake_file_api) -> None:
+        """
+        For each supported architecture, pick one cubin from cuBLAS.
+        From this cubin, pick a few functions.
+        Loop over all instructions of each function, and match each operand.
+        """
+        cublas = CuBLAS(cmake_file_api=cmake_file_api)
+        try:
+            cuobjdump = cublas.cubin(arch=parameters.arch, cwd=workdir, sass=True)
+        except IndexError:
+            pytest.skip(f'The library {cublas.libcublas} does not contain any CUDA binary file for {parameters.arch}.')
+
+        if len(cuobjdump.functions) == 0:
+            pytest.skip(f'{cuobjdump.file} does not contain any function for {parameters.arch}.')
+
+        # Match any instruction.
+        matcher = AnyMatcher()
+
+        matchers_op: list = []
+
+        # Matchers for operands that are well covered.
+        matchers_op.extend((
+            regex.compile(AddressMatcher.build_pattern(arch=parameters.arch, memory=MemorySpace.GENERIC, captured=False)),
+            regex.compile(AddressMatcher.build_pattern(arch=parameters.arch, memory=MemorySpace.GLOBAL, captured=False)),
+            regex.compile(AddressMatcher.build_pattern(arch=parameters.arch, memory=MemorySpace.LOCAL, captured=False)),
+            regex.compile(AddressMatcher.build_pattern(arch=parameters.arch, memory=MemorySpace.SHARED, captured=False)),
+            regex.compile(ConstantMatcher.build_pattern(captured=False)),
+            regex.compile(Immediate.FLOATING_OR_LIMIT),
+            regex.compile(RegisterMatcher.build_pattern(captured=False)),
+        ))
+
+        # Matchers for other operands.
+        matchers_op.extend((
+            regex.compile(r'B[0-9]+'),
+            regex.compile(r'PR'),
+            regex.compile(r'(SR_TID|SR_CTAID).(X|Y|Z)'),
+            regex.compile(r'SR(X|Y|Z)'),
+            regex.compile(r'SR_CgaCtaId|SR_LANEID|SR_LTMASK|SR_SWINHI'),
+        ))
+
+        # Pick 3 functions randomly.
+        MAX_NUM_FUNCS: typing.Final[int] = len(cuobjdump.functions)
+        for function in random.sample(tuple(cuobjdump.functions.keys()), k=min(len(cuobjdump.functions), MAX_NUM_FUNCS)):
+            logging.info(f'Picked function {function} from {cuobjdump.file} for {parameters.arch}.')
+
+            decoder = Decoder(code=cuobjdump.functions[function].code)
+
+            for instruction in decoder.instructions:
+                assert (matched := matcher.match(instruction)) is not None
+                for operand in matched.operands:
+                    if not any(mop.match(operand) is not None for mop in matchers_op):
+                        logging.info(f'Instruction {instruction.instruction} has unmatched operand {operand}.')
+                        pytest.fail()
+
+# libcublas.2.sm_75.cubin for TURING75.
+# HADD2 R21, -RZ.H0_H0, c[0x2] [0x0].F32
+
+# libcublas.27.sm_80.cubin for AMPERE80
+# HADD2.F32 R10, -RZ, c[0x0] [0x160].H0_H0
+# /*0010*/                   HADD2.F32 R10, -RZ, c[0x0] [0x160].H0_H0 ;            /* 0x20005800ff0a7630 */
+#                                                                                  /* 0x000fca0000004100 */
+# nvidisasm also shows the space, except if using emit-json.
+# So it probably does not mean anything.
+
+# libcublas.22.sm_86.cubin for AMPERE86
+# HADD2.F32 R9, -RZ, c[0x0] [0x160].H0_H0
+
+# libcublas.15.sm_80.cubin
+# LDG.E R12, desc[UR4][R8.64]
+
+# libcublas.99.sm_86.cubin
+# LDS R32, [R33+UR6+-0x4]
+
+# libcublas.13.sm_80.cubin
+# LDG.E.64 R12, desc[UR4][R12.64]
+
+# libcublas.42.sm_75.cubin
+# LDG.E.SYS R40, [R14.64+UR8+0x80]

--- a/tests/tools/sass/test_decode.py
+++ b/tests/tools/sass/test_decode.py
@@ -142,6 +142,18 @@ class TestDecoder:
             ),
         ], decoder.instructions
 
+    def test_fixit(self) -> None:
+        """
+        Check that :py:meth:`reprospect.tools.sass.decode.Decoder.fixit` works as expected.
+        """
+        SAMPLES: typing.Final[dict[str, str]] = {
+            'HADD2.F32 R10, -RZ, c[0x0] [0x160].H0_H0': 'HADD2.F32 R10, -RZ, c[0x0][0x160].H0_H0',
+            'FSETP.GEU.AND P1, PT, |R151|, +INF , PT': 'FSETP.GEU.AND P1, PT, |R151|, +INF, PT',
+        }
+
+        for sample, expected in SAMPLES.items():
+            assert sass.Decoder.fixit(instruction=sample) == expected
+
     def test_from_source(self) -> None:
         """
         Read SASS from a source.
@@ -275,13 +287,9 @@ class TestDecoder:
         cublas = CuBLAS(cmake_file_api=cmake_file_api)
 
         try:
-            [cubin] = cublas.extract(arch=parameters.arch, cwd=workdir, randomly=True)
+            cuobjdump = cublas.cubin(arch=parameters.arch, cwd=workdir, sass=True)
         except IndexError:
             pytest.skip(f'The library {cublas.libcublas} does not contain any CUDA binary file for {parameters.arch}.')
-
-        assert cubin.is_file()
-
-        cuobjdump = binaries.CuObjDump(file=cubin, arch=parameters.arch, sass=True)
 
         for name, function in cuobjdump.functions.items():
             decoder = sass.Decoder(code=function.code)


### PR DESCRIPTION
According to the official documentation, `desc` only appears as of `HOPPER`. But we found evidence in `libcublas.so` that it's sometimes (not to say rarely) used for earlier architectures. Other mentions of this:
* https://forums.developer.nvidia.com/t/what-does-desc-mean-in-sass/258352/5
* https://forums.developer.nvidia.com/t/what-does-desc-mean-in-sass/258352/6