### PR TITLE
test(SASS): move constant related stuff from pattern to constant

### DIFF
--- a/examples/kokkos/atomic/example_add_complex128.py
+++ b/examples/kokkos/atomic/example_add_complex128.py
@@ -10,6 +10,7 @@ from reprospect.test.sass.instruction import (
     PatternBuilder,
     RegisterMatcher,
 )
+from reprospect.test.sass.instruction.constant import Constant
 from reprospect.tools.sass import ControlFlow, Decoder
 
 from examples.kokkos.atomic import add, cas, desul
@@ -42,13 +43,13 @@ class AddComplex128:
         matcher_dadd_real = OpcodeModsWithOperandsMatcher(opcode='DADD',
             operands=(
                 PatternBuilder.REG, dadd_real_reg,
-                PatternBuilder.any(PatternBuilder.UREG, PatternBuilder.CONSTANT),
+                PatternBuilder.any(PatternBuilder.UREG, Constant.ADDRESS),
             ),
         )
         matcher_dadd_imag = OpcodeModsWithOperandsMatcher(opcode='DADD',
             operands=(
                 PatternBuilder.REG, dadd_imag_reg,
-                PatternBuilder.any(PatternBuilder.UREG, PatternBuilder.CONSTANT),
+                PatternBuilder.any(PatternBuilder.UREG, Constant.ADDRESS),
             ),
         )
 

--- a/examples/kokkos/atomic/example_add_double256.py
+++ b/examples/kokkos/atomic/example_add_double256.py
@@ -21,6 +21,7 @@ from reprospect.test.sass.instruction import (
     RegisterMatcher,
     StoreGlobalMatcher,
 )
+from reprospect.test.sass.instruction.constant import Constant
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.tools.sass import Decoder
 
@@ -92,14 +93,14 @@ class AddDouble4:
             matchers.append(OpcodeModsWithOperandsMatcher(opcode='DADD',
                 operands=(
                     register, register,
-                    PatternBuilder.any(PatternBuilder.UREG, PatternBuilder.CONSTANT),
+                    PatternBuilder.any(PatternBuilder.UREG, Constant.ADDRESS),
                 ),
             ))
             matchers.append(OpcodeModsWithOperandsMatcher(opcode='DADD',
                 operands=(
                     f'{matched.rtype}{matched.index + 2}',
                     f'{matched.rtype}{matched.index + 2}',
-                    PatternBuilder.any(PatternBuilder.UREG, PatternBuilder.CONSTANT),
+                    PatternBuilder.any(PatternBuilder.UREG, Constant.ADDRESS),
                 ),
             ))
 

--- a/reprospect/test/sass/instruction/constant.py
+++ b/reprospect/test/sass/instruction/constant.py
@@ -13,6 +13,25 @@ from reprospect.test.sass.instruction.operand import (
 from reprospect.test.sass.instruction.pattern import PatternBuilder
 
 
+class Constant:
+    """
+    Constant memory patterns.
+    """
+    BANK: typing.Final[str] = r'0x[0-9]+'
+    """Constant memory bank."""
+
+    OFFSET: typing.Final[str] = PatternBuilder.any(PatternBuilder.HEX, PatternBuilder.REG, PatternBuilder.UREG)
+    """Constant memory offset."""
+
+    ADDRESS: typing.Final[str] = r'c\[' + BANK + r'\]\[' + OFFSET + r'\]'
+    """
+    Constant memory location.
+    """
+
+    @classmethod
+    def address(cls) -> str:
+        return PatternBuilder.group(cls.ADDRESS, group='operands')
+
 @dataclasses.dataclass(frozen=True, slots=True)
 class ConstantMatch:
     """
@@ -75,8 +94,8 @@ class ConstantMatcher:
         else:
             pattern_modifier_math = PatternBuilder.group(math.value, group='modifier_math') if capture_modifier_math else math.value
 
-        pattern_bank   = bank   or PatternBuilder.CONSTANT_BANK
-        pattern_offset = offset or PatternBuilder.CONSTANT_OFFSET
+        pattern_bank   = bank   or Constant.BANK
+        pattern_offset = offset or Constant.OFFSET
 
         pattern = TEMPLATE_CONSTANT.format(
             modifier_math=pattern_modifier_math,

--- a/reprospect/test/sass/instruction/instruction.py
+++ b/reprospect/test/sass/instruction/instruction.py
@@ -12,7 +12,7 @@ import regex
 import semantic_version
 
 from reprospect.test.sass.instruction.address import AddressMatcher
-from reprospect.test.sass.instruction.constant import ConstantMatcher
+from reprospect.test.sass.instruction.constant import Constant, ConstantMatcher
 from reprospect.test.sass.instruction.memory import MemorySpace
 from reprospect.test.sass.instruction.pattern import PatternBuilder
 from reprospect.tools.architecture import NVIDIAArch
@@ -111,7 +111,7 @@ def floating_point_add_pattern(*, ftype: typing.Literal['F', 'D']) -> regex.Patt
         PatternBuilder.mathmodregz() + r'\s*,\s*' +
         PatternBuilder.any(
             PatternBuilder.mathmodregz(), PatternBuilder.ureg(),
-            ConstantMatcher.build_pattern(),
+            Constant.address(),
             PatternBuilder.immediate(),
         ),
     )

--- a/reprospect/test/sass/instruction/pattern.py
+++ b/reprospect/test/sass/instruction/pattern.py
@@ -29,23 +29,6 @@ class PatternBuilder:
 
     OPERAND: typing.Final[str] = r'[\w@!\.\[\]\+\-\s]+'
 
-    CONSTANT_BANK: typing.Final[str] = r'0x[0-9]+'
-    """
-    Constant memory bank.
-    """
-
-    CONSTANT_OFFSET: typing.Final[str] = r'(?:0x[0-9a-f]+|' + REG + '|' + UREG + ')'
-    """
-    Constant memory offset.
-    """
-
-    CONSTANT: typing.Final[str] = r'c\[' + CONSTANT_BANK + r'\]\[' + CONSTANT_OFFSET + r'\]'
-    """
-    Constant memory location.
-    The bank looks like ``0x3`` while the address is either compile-time (*e.g.*
-    ``0x899``) or depends on a register.
-    """
-
     IMMEDIATE: typing.Final[str] = r'(-?\d+)(\.\d*)?((e|E)[-+]?\d+)?'
     """
     References:

--- a/reprospect/test/sass/matchers/add_int128.py
+++ b/reprospect/test/sass/matchers/add_int128.py
@@ -9,6 +9,7 @@ from reprospect.test.sass.instruction import (
     PatternBuilder,
     RegisterMatcher,
 )
+from reprospect.test.sass.instruction.constant import Constant
 from reprospect.tools.sass.decode import Instruction
 
 if sys.version_info >= (3, 12):
@@ -143,7 +144,7 @@ class AddInt128(SequenceMatcher):
                 PatternBuilder.PRED,
                 PatternBuilder.zero_or_one(PatternBuilder.PREDT),
                 PatternBuilder.REG,
-                PatternBuilder.any(PatternBuilder.REG, PatternBuilder.CONSTANT),
+                PatternBuilder.any(PatternBuilder.REG, Constant.ADDRESS),
                 'RZ',
             ),
         )
@@ -165,7 +166,7 @@ class AddInt128(SequenceMatcher):
                 PatternBuilder.PRED,
                 PatternBuilder.zero_or_one(PatternBuilder.PREDT),
                 iadd3_step_1_reg,
-                PatternBuilder.any(PatternBuilder.REG, PatternBuilder.CONSTANT),
+                PatternBuilder.any(PatternBuilder.REG, Constant.ADDRESS),
                 'RZ',
                 PatternBuilder.PRED,
                 '!PT',
@@ -185,7 +186,7 @@ class AddInt128(SequenceMatcher):
                 PatternBuilder.PRED,
                 PatternBuilder.zero_or_one(PatternBuilder.PREDT),
                 iadd3_step_2_reg,
-                PatternBuilder.any(PatternBuilder.REG, PatternBuilder.CONSTANT),
+                PatternBuilder.any(PatternBuilder.REG, Constant.ADDRESS),
                 'RZ',
                 PatternBuilder.PRED,
                 '!PT',
@@ -205,7 +206,7 @@ class AddInt128(SequenceMatcher):
                 PatternBuilder.zero_or_one(PatternBuilder.PREDT),
                 PatternBuilder.zero_or_one(PatternBuilder.PREDT),
                 iadd3_step_3_reg,
-                PatternBuilder.any(PatternBuilder.REG, PatternBuilder.CONSTANT),
+                PatternBuilder.any(PatternBuilder.REG, Constant.ADDRESS),
                 'RZ',
                 PatternBuilder.PRED,
                 '!PT',

--- a/tests/test/sass/instruction/test_constant.py
+++ b/tests/test/sass/instruction/test_constant.py
@@ -52,7 +52,7 @@ class TestConstantMatcher:
 
     def test_build_pattern(self) -> None:
         pattern = ConstantMatcher.build_pattern(bank='0x0', capture_bank=True, capture_modifier_math=True, captured=False)
-        assert pattern == r'(?:(?P<modifier_math>[\-!\|~]))?c\[(?P<bank>0x0)\]\[(?:0x[0-9a-f]+|R[0-9]+|UR[0-9]+)\]'
+        assert pattern == r'(?:(?P<modifier_math>[\-!\|~]))?c\[(?P<bank>0x0)\]\[(?:0x[0-9A-Fa-f]+|R[0-9]+|UR[0-9]+)\]'
 
     @pytest.mark.parametrize(('constant', 'expected'), CONSTANTS.items())
     def test_any(self, constant: str, expected: ConstantMatch) -> None:

--- a/tests/test/sass/test_load.py
+++ b/tests/test/sass/test_load.py
@@ -13,6 +13,7 @@ from reprospect.test.sass.composite import (
     instructions_contain,
 )
 from reprospect.test.sass.instruction import (
+    ConstantMatcher,
     InstructionMatch,
     LoadConstantMatcher,
     LoadGlobalMatcher,
@@ -97,7 +98,7 @@ __global__ __launch_bounds__(128, 1) void ldc({type}* __restrict__ const out)
         logging.info(f'{matcher} matched instruction {inst.instruction} as {matched}.')
 
         assert len(matched.operands) == 2
-        assert re.match(PatternBuilder.CONSTANT, matched.operands[1]) is not None
+        assert ConstantMatcher().match(matched.operands[1]) is not None
 
         assert matched.additional is not None
         assert 'bank' in matched.additional


### PR DESCRIPTION
This is a WIP to see what it would look like to move class variables and functions from pattern builder to address/constant/register. 

This is a try just for constant. So we can see if it works with mypyc. And so we can also think about whether we like it, and then possibly do the same for the register stuff. 


