### PR TITLE
tools(controlflow): disabling auto `repr` for `BasicBlock`

### DIFF
--- a/reprospect/tools/sass/controlflow.py
+++ b/reprospect/tools/sass/controlflow.py
@@ -5,7 +5,7 @@ import typing
 from reprospect.tools.sass.decode import Decoder, Instruction
 
 
-@dataclasses.dataclass(frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True, slots=True, repr=False)
 class BasicBlock:
     """
     Basic block in the control flow graph.


### PR DESCRIPTION
Otherwise, when printing a `Graph` with many blocks, each with many instructions, it creates a ton of output that really isn't helpful at all.