### PR TITLE
cicd(examples): add CC 90

### DIFF
--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -197,7 +197,6 @@ def main(*, args: argparse.Namespace) -> None:
         'compilers': {'CXX': Compiler(ID='gnu', version='14'), 'CUDA': Compiler(ID='nvidia')},
         'nvidia_compute_capability': 90,
         'platforms': ('linux/amd64',),
-        'tests': False,
     }, args=args))
 
     matrix.extend(complete_job({


### PR DESCRIPTION
This PR adds CUDA CC 90 (Hopper) to the CI/CD matrix strategy to address blind spots in test coverage.