### PR TITLE
tests(sass): make add int128 more flexible

### DIFF
--- a/reprospect/test/sass/instruction/register.py
+++ b/reprospect/test/sass/instruction/register.py
@@ -64,7 +64,7 @@ class RegisterMatcher:
     special: bool | None = None
     index: int | None = None
     reuse: bool | None = None
-    math: MathModifier | None = None
+    math: MathModifier | bool | None = None
 
     pattern: regex.Pattern[str] = attrs.field(init=False)
 
@@ -90,7 +90,7 @@ class RegisterMatcher:
         special: bool | None = None,
         index: int | None = None,
         reuse: bool | None = None,
-        math: MathModifier | None = None,
+        math: MathModifier | bool | None = None,
         captured: bool = True,
         capture_math: bool = False,
         capture_reg: bool = False,
@@ -104,11 +104,13 @@ class RegisterMatcher:
         return PatternBuilder.group(pattern, group='operands') if captured else pattern
 
     @classmethod
-    def build_pattern_modifier_math(cls, *, math: MathModifier | None = None, captured: bool = True) -> str | None:
-        if math is not None:
+    def build_pattern_modifier_math(cls, *, math: MathModifier | bool | None = None, captured: bool = True) -> str | None:
+        if isinstance(math, MathModifier):
             return PatternBuilder.group(math.value, group='modifier_math') if captured else math.value
-        inner = PatternBuilder.group(MODIFIER_MATH, group='modifier_math') if captured else MODIFIER_MATH
-        return PatternBuilder.zero_or_one(inner)
+        if math is None or math is True:
+            inner = PatternBuilder.group(MODIFIER_MATH, group='modifier_math') if captured else MODIFIER_MATH
+            return PatternBuilder.zero_or_one(inner) if math is None else inner
+        return None
 
     @classmethod
     def build_pattern_reg(cls, *, rtype: RegisterType | None = None, special: bool | None = None, index: int | None = None, captured: bool = True) -> str:

--- a/tests/test/sass/instruction/test_register.py
+++ b/tests/test/sass/instruction/test_register.py
@@ -33,10 +33,17 @@ class TestRegisterMatcher:
     MATCHER: typing.Final[RegisterMatcher] = RegisterMatcher()
 
     def test_reg(self) -> None:
-        REG: typing.Final[str] = 'R42'
+        REG: typing.Final[str] = '!R42'
 
         matcher = RegisterMatcher(rtype=RegisterType.GPR, special=False, reuse=None)
         assert matcher.pattern.pattern == r'(?:(?P<modifier_math>[\-!\|~]))?(?P<rtype>R)(?P<index>\d+)(?:\.(?P<reuse>reuse))?'
+        assert matcher.match(REG) == self.REGISTERS[REG]
+
+    def test_reg_no_math(self) -> None:
+        REG: typing.Final[str] = 'R42'
+
+        matcher = RegisterMatcher(rtype=RegisterType.GPR, special=False, reuse=None, math=False)
+        assert matcher.pattern.pattern == r'(?P<rtype>R)(?P<index>\d+)(?:\.(?P<reuse>reuse))?'
         assert matcher.match(REG) == self.REGISTERS[REG]
 
     def test_regz(self) -> None:


### PR DESCRIPTION
This PR makes the `AddInt128Matcher` more flexible by allowing callers to specify the starting register pattern, removing the requirement that destination and source registers must be the same. This enables matching of 128-bit integer addition patterns where operands and results use different register ranges.