### PR TITLE
test(sass): `MOV` matcher

### DIFF
--- a/docs/source/tests/test/sass/matchers.rst
+++ b/docs/source/tests/test/sass/matchers.rst
@@ -4,3 +4,4 @@ Matchers
 .. automodule:: tests.test.sass.matchers.test_add_int128
 .. automodule:: tests.test.sass.matchers.test_add_int32
 .. automodule:: tests.test.sass.matchers.test_convert_fp32_to_fp16
+.. automodule:: tests.test.sass.matchers.test_move32

--- a/examples/kokkos/atomic/desul.py
+++ b/examples/kokkos/atomic/desul.py
@@ -40,7 +40,6 @@ import sys
 import typing
 
 from reprospect.test.sass.composite import (
-    any_of,
     instruction_is,
     instructions_are,
     instructions_contain,
@@ -61,6 +60,7 @@ from reprospect.test.sass.instruction import (
     PatternBuilder,
     StoreGlobalMatcher,
 )
+from reprospect.test.sass.matchers.move32 import Move32Matcher
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.tools.sass import Instruction
 
@@ -94,16 +94,7 @@ class AtomicAcquireMatcher:
     def build(cls, arch: NVIDIAArch, compiler_id: str) -> OrderedInSequenceMatcher:
         return instructions_are(
             # Storing 1 in a register can be done in different ways.
-            any_of(
-                OpcodeModsWithOperandsMatcher(
-                    opcode='MOV',
-                    operands=(PatternBuilder.REG, '0x1'),
-                ),
-                OpcodeModsWithOperandsMatcher(
-                    opcode='IMAD', modifiers=('MOV', 'U32'),
-                    operands=(PatternBuilder.REG, PatternBuilder.REGZ, PatternBuilder.REGZ, '0x1'),
-                ),
-            ),
+            Move32Matcher(src='0x1'),
             AtomicMatcher(
                 memory=get_atomic_memory_suffix(compiler_id=compiler_id),
                 arch=arch,

--- a/reprospect/test/sass/matchers/move32.py
+++ b/reprospect/test/sass/matchers/move32.py
@@ -1,0 +1,58 @@
+import sys
+import typing
+
+from reprospect.test.sass.instruction import (
+    InstructionMatch,
+    InstructionMatcher,
+    OpcodeModsWithOperandsMatcher,
+    PatternBuilder,
+)
+from reprospect.tools.sass.decode import Instruction
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+
+class Move32Matcher(InstructionMatcher):
+    """
+    Match the *move* of a 32-bit source to a 32-bit destination.
+
+    It can be achieved using one of the following instructions::
+
+        MOV <dst>, <src>
+        IMAD.MOV.U32 <dst>, RZ, RZ, <src>
+
+    .. note::
+
+        It is not decorated with :py:func:`dataclasses.dataclass` because of https://github.com/mypyc/mypyc/issues/1061.
+    """
+    __slots__ = ('imad', 'mov')
+
+    def __init__(self, *,
+        src: str | None = None,
+        dst: str | None = None,
+    ) -> None:
+        self.mov: typing.Final[OpcodeModsWithOperandsMatcher] = OpcodeModsWithOperandsMatcher(
+            opcode='MOV', operands=(
+                dst or PatternBuilder.REG,
+                src or PatternBuilder.OPERAND,
+            ),
+        )
+
+        self.imad: typing.Final[OpcodeModsWithOperandsMatcher] = OpcodeModsWithOperandsMatcher(
+            opcode='IMAD', modifiers=('MOV', 'U32'), operands=(
+                dst or PatternBuilder.REG,
+                'RZ', 'RZ',
+                src or PatternBuilder.OPERAND,
+            ),
+        )
+
+    @override
+    def match(self, inst: Instruction | str) -> InstructionMatch | None:
+        if (matched := self.mov.match(inst=inst)) is not None:
+            return matched
+        if (matched := self.imad.match(inst=inst)) is not None:
+            return matched
+        return None

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ def enable_mypyc(dist: Distribution) -> None:
             'reprospect/test/sass/matchers/add_int128.py',
             'reprospect/test/sass/matchers/add_int32.py',
             'reprospect/test/sass/matchers/convert_fp32_to_fp16.py',
+            'reprospect/test/sass/matchers/move32.py',
             'reprospect/tools/architecture.py',
             'reprospect/tools/binaries/cuobjdump.py',
             'reprospect/tools/binaries/demangle.py',

--- a/tests/test/sass/matchers/CMakeLists.txt
+++ b/tests/test/sass/matchers/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_pytest(add_int128)
 add_pytest(add_int32)
 add_pytest(convert_fp32_to_fp16)
+add_pytest(move32)

--- a/tests/test/sass/matchers/test_move32.py
+++ b/tests/test/sass/matchers/test_move32.py
@@ -1,0 +1,18 @@
+from reprospect.test.sass.matchers.move32 import Move32Matcher
+
+
+class TestMove32Matcher:
+    """
+    Tests for :py:class:`reprospect.test.sass.matchers.move32.Move32Matcher`.
+    """
+    def test_mov(self) -> None:
+        assert Move32Matcher().match(inst='MOV R11, 0x4') is not None
+        assert Move32Matcher().match(inst='MOV R7, 0x3d53f941') is not None
+        assert Move32Matcher().match(inst='MOV R5, c[0x0][0x0]') is not None
+
+        assert Move32Matcher(dst='R42').match(inst='MOV R42, 0x1') is not None
+        assert Move32Matcher(src='0x1').match(inst='MOV R42, 0x1') is not None
+
+    def test_imad(self) -> None:
+        assert (matched := Move32Matcher(src='R17').match(inst='IMAD.MOV.U32 R6, RZ, RZ, R17')) is not None
+        assert matched.opcode == 'IMAD'


### PR DESCRIPTION
Working towards a general *move* matcher. This one is a first, easy step.