### PR TITLE
test(sass): `RegisterMatch` now sets its `index` to `-1` if it is a special register

### DIFF
--- a/examples/kokkos/atomic/example_add_complex128.py
+++ b/examples/kokkos/atomic/example_add_complex128.py
@@ -33,9 +33,7 @@ class AddComplex128:
             raise RuntimeError(self)
         load_register = loads[0].operands[0]
 
-        parsed = RegisterMatcher(special=False).match(load_register)
-        assert parsed is not None
-        assert parsed.index is not None
+        assert (parsed := RegisterMatcher(special=False).match(load_register)) is not None
 
         dadd_real_reg = load_register
         dadd_imag_reg = f'{parsed.rtype}{parsed.index + 2}'

--- a/examples/kokkos/atomic/example_add_complex64.py
+++ b/examples/kokkos/atomic/example_add_complex64.py
@@ -29,7 +29,6 @@ class AddComplex64:
         assert len(loads) == 1
 
         assert (load_reg := RegisterMatcher(special=False).match(reg=loads[0].operands[0])) is not None
-        assert load_reg.index is not None
 
         reg_real = f'{load_reg.rtype}{load_reg.index}'
         reg_imag = f'{load_reg.rtype}{load_reg.index + 1}'

--- a/examples/kokkos/atomic/example_add_double256.py
+++ b/examples/kokkos/atomic/example_add_double256.py
@@ -85,8 +85,7 @@ class AddDouble4:
         matchers: list[OpcodeModsWithOperandsMatcher] = []
 
         for register in registers:
-            matched = RegisterMatcher(special=False).match(register)
-            assert matched is not None and matched.index is not None
+            assert (matched := RegisterMatcher(special=False).match(register)) is not None
 
             logging.info(f'Load register {matched}.')
 

--- a/reprospect/test/sass/instruction/register.py
+++ b/reprospect/test/sass/instruction/register.py
@@ -18,11 +18,11 @@ MODIFIER_REUSE: typing.Final[str] = 'reuse'
 @dataclasses.dataclass(frozen=True, slots=True)
 class RegisterMatch:
     """
-    If :py:attr:`index` is :py:obj:`None`, it is a special register (*e.g.*
+    If :py:attr:`index` is set to a negative value, it is a special register (*e.g.*
     ``RZ`` if :py:attr:`rtype` is :py:const:`reprospect.tools.sass.decode.RegisterType.GPR`).
     """
     rtype: RegisterType
-    index: int | None = None
+    index: int = -1
     reuse: bool = False
     math: MathModifier | None = None
 
@@ -33,7 +33,7 @@ class RegisterMatch:
         if len(rtype := captured['rtype']) != 1:
             raise ValueError(bits)
 
-        index: int | None = None
+        index: int = -1
         if (value := captured.get('index')) is not None:
             if len(value) == 1:
                 index = int(value[0])

--- a/reprospect/test/sass/matchers/add_int128.py
+++ b/reprospect/test/sass/matchers/add_int128.py
@@ -79,10 +79,8 @@ class AddInt128Matcher(SequenceMatcher):
         offset += 1
         matched.append(matched_iadd_step_0)
 
-        iadd_step_0_reg_0 = RegisterMatcher(special=False).match(matched_iadd_step_0.operands[-2])
-        assert iadd_step_0_reg_0 is not None and iadd_step_0_reg_0.index is not None
-        iadd_step_0_reg_1 = RegisterMatcher(special=False).match(matched_iadd_step_0.operands[-1])
-        assert iadd_step_0_reg_1 is not None and iadd_step_0_reg_1.index is not None
+        assert (iadd_step_0_reg_0 := RegisterMatcher(special=False).match(matched_iadd_step_0.operands[-2])) is not None
+        assert (iadd_step_0_reg_1 := RegisterMatcher(special=False).match(matched_iadd_step_0.operands[-1])) is not None
 
         matcher_iadd_step_1 = OpcodeModsWithOperandsMatcher(
             opcode='IADD', modifiers=('64',),
@@ -157,10 +155,8 @@ class AddInt128Matcher(SequenceMatcher):
 
         index_src = 2 if len(matched_iadd3_step_0.operands) == 5 else 3
 
-        iadd3_step_0_dst = RegisterMatcher(special=False).match(matched_iadd3_step_0.operands[0])
-        iadd3_step_0_src = RegisterMatcher(special=False).match(matched_iadd3_step_0.operands[index_src])
-        assert iadd3_step_0_dst is not None and iadd3_step_0_dst.index is not None
-        assert iadd3_step_0_src is not None and iadd3_step_0_src.index is not None
+        assert (iadd3_step_0_dst := RegisterMatcher(special=False).match(matched_iadd3_step_0.operands[0])) is not None
+        assert (iadd3_step_0_src := RegisterMatcher(special=False).match(matched_iadd3_step_0.operands[index_src])) is not None
         iadd3_step_1_dst = f'{iadd3_step_0_dst.rtype}{iadd3_step_0_dst.index + 1}'
         iadd3_step_1_src = f'{iadd3_step_0_src.rtype}{iadd3_step_0_src.index + 1}'
 

--- a/tests/test/sass/instruction/test_register.py
+++ b/tests/test/sass/instruction/test_register.py
@@ -15,19 +15,19 @@ class TestRegisterMatcher:
     Tests for :py:class:`reprospect.test.sass.instruction.register.RegisterMatcher`.
     """
     REGISTERS: typing.Final[dict[str, RegisterMatch]] = {
-        'R42':       RegisterMatch(rtype=RegisterType.GPR,   index=42,   reuse=False),
-        '!P0':       RegisterMatch(rtype=RegisterType.PRED,  index=0,    reuse=False, math=MathModifier.NOT),
-        '!R42':      RegisterMatch(rtype=RegisterType.GPR,   index=42,   reuse=False, math=MathModifier.NOT),
-        '~R42':      RegisterMatch(rtype=RegisterType.GPR,   index=42,   reuse=False, math=MathModifier.INV),
-        '-R42':      RegisterMatch(rtype=RegisterType.GPR,   index=42,   reuse=False, math=MathModifier.NEG),
-        '|R42|':     RegisterMatch(rtype=RegisterType.GPR,   index=42,   reuse=False, math=MathModifier.ABS),
-        'R42.reuse': RegisterMatch(rtype=RegisterType.GPR,   index=42,   reuse=True),
-        'RZ':        RegisterMatch(rtype=RegisterType.GPR,   index=None, reuse=False),
-        'UR42':      RegisterMatch(rtype=RegisterType.UGPR,  index=42,   reuse=False),
-        'P3':        RegisterMatch(rtype=RegisterType.PRED,  index=3,    reuse=False),
-        'PT':        RegisterMatch(rtype=RegisterType.PRED,  index=None, reuse=False),
-        'UP3':       RegisterMatch(rtype=RegisterType.UPRED, index=3,    reuse=False),
-        'UPT':       RegisterMatch(rtype=RegisterType.UPRED, index=None, reuse=False),
+        'R42':       RegisterMatch(rtype=RegisterType.GPR,   index=42, reuse=False),
+        '!P0':       RegisterMatch(rtype=RegisterType.PRED,  index=0,  reuse=False, math=MathModifier.NOT),
+        '!R42':      RegisterMatch(rtype=RegisterType.GPR,   index=42, reuse=False, math=MathModifier.NOT),
+        '~R42':      RegisterMatch(rtype=RegisterType.GPR,   index=42, reuse=False, math=MathModifier.INV),
+        '-R42':      RegisterMatch(rtype=RegisterType.GPR,   index=42, reuse=False, math=MathModifier.NEG),
+        '|R42|':     RegisterMatch(rtype=RegisterType.GPR,   index=42, reuse=False, math=MathModifier.ABS),
+        'R42.reuse': RegisterMatch(rtype=RegisterType.GPR,   index=42, reuse=True),
+        'RZ':        RegisterMatch(rtype=RegisterType.GPR,   index=-1, reuse=False),
+        'UR42':      RegisterMatch(rtype=RegisterType.UGPR,  index=42, reuse=False),
+        'P3':        RegisterMatch(rtype=RegisterType.PRED,  index=3,  reuse=False),
+        'PT':        RegisterMatch(rtype=RegisterType.PRED,  index=-1, reuse=False),
+        'UP3':       RegisterMatch(rtype=RegisterType.UPRED, index=3,  reuse=False),
+        'UPT':       RegisterMatch(rtype=RegisterType.UPRED, index=-1, reuse=False),
     }
 
     MATCHER: typing.Final[RegisterMatcher] = RegisterMatcher()


### PR DESCRIPTION
Otherwise one has to `assert` that *index is not None*.

If one wants a positive index (*i.e.* don't match a special register), just tell `RegisterMatcher`.