### PR TITLE
test(SASS): move register patterns to separate file

### DIFF
--- a/examples/kokkos/atomic/desul.py
+++ b/examples/kokkos/atomic/desul.py
@@ -57,9 +57,9 @@ from reprospect.test.sass.instruction import (
     LoadGlobalMatcher,
     OpcodeModsMatcher,
     OpcodeModsWithOperandsMatcher,
-    PatternBuilder,
     StoreGlobalMatcher,
 )
+from reprospect.test.sass.instruction.register import Register
 from reprospect.test.sass.matchers.move32 import Move32Matcher
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.tools.sass import Instruction
@@ -225,11 +225,11 @@ class LockBasedAtomicMatcher(SequenceMatcher):
         matcher_isetp_enter = OpcodeModsWithOperandsMatcher(
             opcode='ISETP', modifiers=modifiers,
             operands=(
-                PatternBuilder.PRED,
-                PatternBuilder.PREDT,
+                Register.PRED,
+                Register.PREDT,
                 matched_atomic_acquire[-1].operands[1],
-                PatternBuilder.REGZ,
-                PatternBuilder.PREDT,
+                Register.REGZ,
+                Register.PREDT,
             ),
         )
 

--- a/examples/kokkos/atomic/example_add_complex128.py
+++ b/examples/kokkos/atomic/example_add_complex128.py
@@ -11,6 +11,7 @@ from reprospect.test.sass.instruction import (
     RegisterMatcher,
 )
 from reprospect.test.sass.instruction.constant import Constant
+from reprospect.test.sass.instruction.register import Register
 from reprospect.test.sass.matchers.cas import AtomicCASMatcher
 from reprospect.tools.sass import ControlFlow, Decoder
 
@@ -40,18 +41,16 @@ class AddComplex128:
             dadd_real_reg = load_register
             dadd_imag_reg = f'{parsed.rtype}{parsed.index + 2}'
         else:
-            dadd_real_reg = dadd_imag_reg = PatternBuilder.REG
+            dadd_real_reg = dadd_imag_reg = Register.REG
 
         matcher_dadd_real = OpcodeModsWithOperandsMatcher(opcode='DADD',
             operands=(
-                PatternBuilder.REG, dadd_real_reg,
-                PatternBuilder.any(PatternBuilder.UREG, Constant.ADDRESS),
+                Register.REG, dadd_real_reg, PatternBuilder.any(Register.UREG, Constant.ADDRESS),
             ),
         )
         matcher_dadd_imag = OpcodeModsWithOperandsMatcher(opcode='DADD',
             operands=(
-                PatternBuilder.REG, dadd_imag_reg,
-                PatternBuilder.any(PatternBuilder.UREG, Constant.ADDRESS),
+                Register.REG, dadd_imag_reg, PatternBuilder.any(Register.UREG, Constant.ADDRESS),
             ),
         )
 

--- a/examples/kokkos/atomic/example_add_double256.py
+++ b/examples/kokkos/atomic/example_add_double256.py
@@ -22,6 +22,7 @@ from reprospect.test.sass.instruction import (
     StoreGlobalMatcher,
 )
 from reprospect.test.sass.instruction.constant import Constant
+from reprospect.test.sass.instruction.register import Register
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.tools.sass import Decoder
 
@@ -93,14 +94,14 @@ class AddDouble4:
             matchers.append(OpcodeModsWithOperandsMatcher(opcode='DADD',
                 operands=(
                     register, register,
-                    PatternBuilder.any(PatternBuilder.UREG, Constant.ADDRESS),
+                    PatternBuilder.any(Register.UREG, Constant.ADDRESS),
                 ),
             ))
             matchers.append(OpcodeModsWithOperandsMatcher(opcode='DADD',
                 operands=(
                     f'{matched.rtype}{matched.index + 2}',
                     f'{matched.rtype}{matched.index + 2}',
-                    PatternBuilder.any(PatternBuilder.UREG, Constant.ADDRESS),
+                    PatternBuilder.any(Register.UREG, Constant.ADDRESS),
                 ),
             ))
 

--- a/examples/kokkos/half/example_math.py
+++ b/examples/kokkos/half/example_math.py
@@ -48,10 +48,10 @@ from reprospect.test.sass.instruction import (
     InstructionMatch,
     LoadGlobalMatcher,
     OpcodeModsWithOperandsMatcher,
-    PatternBuilder,
     StoreGlobalMatcher,
 )
 from reprospect.test.sass.instruction.half import Fp16AddMatcher, Fp16MinMaxMatcher
+from reprospect.test.sass.instruction.register import Register
 from reprospect.test.sass.matchers.convert_fp32_to_fp16 import ConvertFp32ToFp16
 from reprospect.tools.binaries import CuObjDump
 from reprospect.tools.sass import ControlFlow, Decoder, Instruction
@@ -240,9 +240,8 @@ class TestMax(CMakeAwareTestCase):
         offset += advanced
 
         # Take the max.
-        matcher_fmnmx = instructions_contain(OpcodeModsWithOperandsMatcher(opcode='FMNMX', operands=(
-            PatternBuilder.REG,
-            matched_hadd2_a.operands[0], matched_hadd2_b.operands[0], '!PT',
+        matcher_fmnmx = instructions_contain(OpcodeModsWithOperandsMatcher(opcode='FMNMX',
+            operands=(Register.REG, matched_hadd2_a.operands[0], matched_hadd2_b.operands[0], '!PT',
         )))
         [matched_fmnmx] = matcher_fmnmx.assert_matches(instructions=block.instructions[offset:])
         logging.info(matched_fmnmx)

--- a/reprospect/test/sass/instruction/address.py
+++ b/reprospect/test/sass/instruction/address.py
@@ -9,6 +9,7 @@ import regex
 
 from reprospect.test.sass.instruction.memory import MemorySpace
 from reprospect.test.sass.instruction.pattern import PatternBuilder
+from reprospect.test.sass.instruction.register import Register
 from reprospect.tools.architecture import NVIDIAArch
 
 if sys.version_info >= (3, 11):
@@ -136,19 +137,19 @@ class AddressMatcher:
 
     @classmethod
     def build_pattern_reg(cls, *, arch: NVIDIAArch, reg: str | None = None, captured: bool = True) -> str:
-        pattern_reg = reg or (rf'(?:{PatternBuilder.REG}|{PatternBuilder.UREG})' if arch.compute_capability.as_int >= 75 else PatternBuilder.REG)
+        pattern_reg = reg or (rf'(?:{Register.REG}|{Register.UREG})' if arch.compute_capability.as_int >= 75 else Register.REG)
         return PatternBuilder.group(pattern_reg, 'reg') if captured else pattern_reg
 
     @classmethod
     def build_pattern_offset(cls, *, arch: NVIDIAArch, offset: str | None = None, captured: bool = True) -> str:
         if offset is not None:
             return rf'\+{PatternBuilder.group(offset, "offset") if captured else offset}'
-        inner = rf'(?:-?{PatternBuilder.HEX}|{PatternBuilder.UREG})' if arch.compute_capability.as_int >= 75 else rf'-?{PatternBuilder.HEX}'
+        inner = rf'(?:-?{PatternBuilder.HEX}|{Register.UREG})' if arch.compute_capability.as_int >= 75 else rf'-?{PatternBuilder.HEX}'
         return PatternBuilder.zero_or_one(r'\+' + (PatternBuilder.group(inner, 'offset') if captured else inner))
 
     @classmethod
     def build_pattern_desc_ureg(cls, *, desc_ureg: str | None = None, captured: bool = True) -> str:
-        pattern_desc_ureg = desc_ureg or PatternBuilder.UREG
+        pattern_desc_ureg = desc_ureg or Register.UREG
         return PatternBuilder.group(pattern_desc_ureg, 'desc_ureg') if captured else pattern_desc_ureg
 
     @classmethod

--- a/reprospect/test/sass/instruction/constant.py
+++ b/reprospect/test/sass/instruction/constant.py
@@ -11,6 +11,7 @@ from reprospect.test.sass.instruction.operand import (
     MathModifier,
 )
 from reprospect.test.sass.instruction.pattern import PatternBuilder
+from reprospect.test.sass.instruction.register import Register
 
 
 class Constant:
@@ -20,7 +21,7 @@ class Constant:
     BANK: typing.Final[str] = r'0x[0-9]+'
     """Constant memory bank."""
 
-    OFFSET: typing.Final[str] = PatternBuilder.any(PatternBuilder.HEX, PatternBuilder.REG, PatternBuilder.UREG)
+    OFFSET: typing.Final[str] = PatternBuilder.any(PatternBuilder.HEX, Register.REG, Register.UREG)
     """Constant memory offset."""
 
     ADDRESS: typing.Final[str] = r'c\[' + BANK + r'\]\[' + OFFSET + r'\]'

--- a/reprospect/test/sass/instruction/immediate.py
+++ b/reprospect/test/sass/instruction/immediate.py
@@ -6,10 +6,16 @@ from reprospect.test.sass.instruction.pattern import PatternBuilder
 class Immediate:
     """
     Immediate patterns.
-    """
-    INF: typing.Final[str] = r'[+-]?INF'
 
-    QNAN: typing.Final[str] = PatternBuilder.any(r'[+-]?QNAN', '0x7fffffff')
+    ..note::
+
+         Limits may print in dumped SASS followed by a space as in::
+
+            FSETP.GEU.AND P1, PT, |R151|, +INF , PT
+    """
+    INF: typing.Final[str] = r'[+-]?INF\s?'
+
+    QNAN: typing.Final[str] = PatternBuilder.any(r'[+-]?QNAN\s?', '0x7fffffff')
     """Quiet NaN. Note that in SASS, :code:`CUDART_NAN_F` from ``math_constants.h`` is represented as ``0x7fffffff``."""
 
     FLOATING: typing.Final[str] = r'(?:-?\d+)(?:\.\d*)?(?:[eE][-+]?\d+)?'

--- a/reprospect/test/sass/instruction/integer.py
+++ b/reprospect/test/sass/instruction/integer.py
@@ -11,6 +11,7 @@ from reprospect.test.sass.instruction import (
     PatternBuilder,
     PatternMatcher,
 )
+from reprospect.test.sass.instruction.register import Register
 from reprospect.tools.architecture import NVIDIAArch
 
 
@@ -21,9 +22,9 @@ class IntAddMatcher(OpcodeModsWithOperandsMatcher):
         IADD R14, R8, R11
     """
     def __init__(self, *,
-        src_a: str = PatternBuilder.REG,
-        src_b: str = PatternBuilder.REG,
-        dst: str = PatternBuilder.REG,
+        src_a: str = Register.REG,
+        src_b: str = Register.REG,
+        dst: str = Register.REG,
     ) -> None:
         super().__init__(
             opcode='IADD',
@@ -45,10 +46,10 @@ class IntAdd3Matcher(OpcodeModsWithOperandsMatcher):
     """
     def __init__(self, *,
         arch: NVIDIAArch,
-        src_a: str = PatternBuilder.REG,
-        src_b: str = PatternBuilder.REG,
-        src_c: str = PatternBuilder.REGZ,
-        dst: str = PatternBuilder.REG,
+        src_a: str = Register.REG,
+        src_b: str = Register.REG,
+        src_c: str = Register.REGZ,
+        dst: str = Register.REG,
     ) -> None:
         super().__init__(
             opcode='IADD3',
@@ -83,9 +84,9 @@ class LEAMatcher(PatternMatcher):
     SHIFT: typing.Final[str] = r'0x[0-9]+'
 
     PATTERN: typing.Final[regex.Pattern[str]] = regex.compile(TEMPLATE.format(
-        dest=PatternBuilder.reg(),
-        index=PatternBuilder.reg(),
-        base=PatternBuilder.reg(),
+        dest=Register.reg(),
+        index=Register.reg(),
+        base=Register.reg(),
         shift=PatternBuilder.groups(SHIFT, groups=('operands', 'shift')),
     ))
 
@@ -99,8 +100,8 @@ class LEAMatcher(PatternMatcher):
             pattern=self.PATTERN
             if not (dest or index or base or shift)
             else self.TEMPLATE.format(
-                dest=PatternBuilder.group(dest or PatternBuilder.REG, group='operands'),
-                index=PatternBuilder.group(index or PatternBuilder.REG, group='operands'),
-                base=PatternBuilder.group(base or PatternBuilder.REG, group='operands'),
+                dest=PatternBuilder.group(dest or Register.REG, group='operands'),
+                index=PatternBuilder.group(index or Register.REG, group='operands'),
+                base=PatternBuilder.group(base or Register.REG, group='operands'),
                 shift=PatternBuilder.groups(shift or self.SHIFT, groups=('operands', 'shift')),
             ))

--- a/reprospect/test/sass/instruction/pattern.py
+++ b/reprospect/test/sass/instruction/pattern.py
@@ -1,31 +1,12 @@
 import functools
 import typing
 
-from reprospect.test.sass.instruction.operand import MODIFIER_MATH
-
 
 class PatternBuilder:
     """
     Helper class to build patterns for instruction components.
     """
     HEX: typing.Final[str] = r'0x[0-9A-Fa-f]+'
-    OFFSET: typing.Final[str] = r'\+0x[0-9A-Fa-f]+'
-    PRED: typing.Final[str] = r'P[0-9]+'
-    REG: typing.Final[str] = r'R[0-9]+'
-    REG64: typing.Final[str] = r'R[0-9]+\.64'
-    UREG: typing.Final[str] = r'UR[0-9]+'
-
-    #: Match a register or ``RZ``.
-    REGZ: typing.Final[str] = r'R(?:Z|\d+)'
-
-    #: Match a predicate register or ``PT``.
-    PREDT: typing.Final[str] = r'P(?:T|\d+)'
-
-    #: Match a uniform predicate register.
-    UPRED: typing.Final[str] = r'UP[0-9]+'
-
-    #: Match a uniform predicate register or ``UPT``.
-    UPREDT: typing.Final[str] = r'UP(?:T|\d+)'
 
     OPERAND: typing.Final[str] = r'[\w@!\.\[\]\+\-\s]+'
 
@@ -77,55 +58,6 @@ class PatternBuilder:
         :py:attr:`HEX` with `operands` group.
         """
         return cls.group(cls.HEX, group='operands')
-
-    @classmethod
-    def reg(cls) -> str:
-        """
-        :py:attr:`REG` with `operands` group.
-        """
-        return cls.group(cls.REG, group='operands')
-
-    @classmethod
-    def mathmodregz(cls) -> str:
-        """
-        :py:attr:`REGZ` with `operands` group and optional math modifiers :py:const:`reprospect.test.sass.instruction.operand.MODIFIER_MATH`.
-        """
-        return cls.group(cls.zero_or_one(MODIFIER_MATH) + cls.REGZ, group='operands')
-
-    @classmethod
-    def regz(cls) -> str:
-        """
-        :py:attr:`REGZ` with `operands` group.
-        """
-        return cls.group(cls.REGZ, group='operands')
-
-    @classmethod
-    def ureg(cls) -> str:
-        """
-        :py:attr:`UREG` with `operands` group.
-        """
-        return cls.group(cls.UREG, group='operands')
-
-    @classmethod
-    def anygpreg(cls, *, reuse: bool | None = None, group: str | None = None) -> str:
-        """
-        Match any general purpose register.
-        """
-        pattern = cls.any(cls.REG, cls.UREG)
-        if reuse is None:
-            pattern += PatternBuilder.zero_or_one(r'\.reuse')
-        elif reuse is True:
-            pattern += r'\.reuse'
-        if group is not None:
-            pattern = cls.group(pattern, group=group)
-        return pattern
-
-    @classmethod
-    def predt(cls) -> str:
-        """
-        :py:attr:`PREDT` with `operands` group.
-        """
-        return cls.group(cls.PREDT, group='operands')
 
     @classmethod
     def predicate(cls) -> str:

--- a/reprospect/test/sass/instruction/register.py
+++ b/reprospect/test/sass/instruction/register.py
@@ -15,6 +15,88 @@ from reprospect.tools.sass.decode import RegisterType
 
 MODIFIER_REUSE: typing.Final[str] = 'reuse'
 
+class Register:
+    """
+    Register patterns.
+    """
+    #: Match a general purpose register.
+    REG: typing.Final[str] = r'R[0-9]+'
+
+    #: Match a general purpose register or ``RZ``.
+    REGZ: typing.Final[str] = r'R(?:Z|\d+)'
+
+    #: Match a uniform general purpose register.
+    UREG: typing.Final[str] = r'UR[0-9]+'
+
+    #: Match a uniform general purpose register or ``URZ``.
+    UREGZ: typing.Final[str] = r'UR(?:Z|\d+)'
+
+    #: Match a predicate register.
+    PRED: typing.Final[str] = r'P[0-9]+'
+
+    #: Match a predicate register or ``PT``.
+    PREDT: typing.Final[str] = r'P(?:T|\d+)'
+
+    #: Match a uniform predicate register.
+    UPRED: typing.Final[str] = r'UP[0-9]+'
+
+    #: Match a uniform predicate register or ``UPT``.
+    UPREDT: typing.Final[str] = r'UP(?:T|\d+)'
+
+    @classmethod
+    def reg(cls) -> str:
+        return PatternBuilder.group(cls.REG, group='operands')
+
+    @classmethod
+    def regz(cls) -> str:
+        return PatternBuilder.group(cls.REGZ, group='operands')
+
+    @classmethod
+    def ureg(cls) -> str:
+        return PatternBuilder.group(cls.UREG, group='operands')
+
+    @classmethod
+    def uregz(cls) -> str:
+        return PatternBuilder.group(cls.UREGZ, group='operands')
+
+    @classmethod
+    def pred(cls) -> str:
+        return PatternBuilder.group(cls.PRED, group='operands')
+
+    @classmethod
+    def predt(cls) -> str:
+        return PatternBuilder.group(cls.PREDT, group='operands')
+
+    @classmethod
+    def upred(cls) -> str:
+        return PatternBuilder.group(cls.UPRED, group='operands')
+
+    @classmethod
+    def upredt(cls) -> str:
+        return PatternBuilder.group(cls.UPREDT, group='operands')
+
+    @classmethod
+    def mathmodregz(cls) -> str:
+        """
+        :py:attr:`REGZ` with `operands` group and optional math modifiers :py:const:`reprospect.test.sass.instruction.operand.MODIFIER_MATH`.
+        """
+        return PatternBuilder.group(PatternBuilder.zero_or_one(MODIFIER_MATH) + cls.REGZ, group='operands')
+
+    @classmethod
+    def dst(cls) -> str:
+        return PatternBuilder.groups(cls.REG, groups=('dst', 'operands'))
+
+    @classmethod
+    def mod(cls, reg: str, *, reuse: bool | None = None) -> str:
+        """
+        Wrap a register pattern with a reuse modifier.
+        """
+        if reuse is None:
+            return reg + PatternBuilder.zero_or_one(rf'\.{MODIFIER_REUSE}')
+        if reuse is True:
+            return reg + rf'\.{MODIFIER_REUSE}'
+        return reg
+
 @dataclasses.dataclass(frozen=True, slots=True)
 class RegisterMatch:
     """

--- a/reprospect/test/sass/matchers/add_int128.py
+++ b/reprospect/test/sass/matchers/add_int128.py
@@ -10,6 +10,7 @@ from reprospect.test.sass.instruction import (
     RegisterMatcher,
 )
 from reprospect.test.sass.instruction.constant import Constant
+from reprospect.test.sass.instruction.register import Register
 from reprospect.tools.sass.decode import Instruction
 
 if sys.version_info >= (3, 12):
@@ -49,8 +50,7 @@ class AddInt128Matcher(SequenceMatcher):
     def __init__(self, start: str | None = None) -> None:
         self._index: int = 0
         self.start: typing.Final[str] = PatternBuilder.group(
-            start or PatternBuilder.anygpreg(reuse=None),
-            group='start',
+            start or Register.mod(PatternBuilder.any(Register.REG, Register.UREG), reuse=None), group='start',
         )
 
     def pattern_3IADD(self, instructions: typing.Sequence[Instruction | str]) -> list[InstructionMatch] | None: # pylint: disable=invalid-name
@@ -69,9 +69,9 @@ class AddInt128Matcher(SequenceMatcher):
             opcode='IADD', modifiers=('64',),
             operands=(
                 'RZ',
-                PatternBuilder.PRED,
+                Register.PRED,
                 self.start,
-                PatternBuilder.anygpreg(reuse=None),
+                Register.mod(PatternBuilder.any(Register.REG, Register.UREG), reuse=None),
             ),
         )
         if (matched_iadd_step_0 := matcher_iadd_step_0.match(instructions[offset])) is None:
@@ -85,7 +85,7 @@ class AddInt128Matcher(SequenceMatcher):
         matcher_iadd_step_1 = OpcodeModsWithOperandsMatcher(
             opcode='IADD', modifiers=('64',),
             operands=(
-                PatternBuilder.REG,
+                Register.REG,
                 f'{iadd_step_0_reg_0.rtype}{iadd_step_0_reg_0.index}',
                 f'{iadd_step_0_reg_1.rtype}{iadd_step_0_reg_1.index}',
             ),
@@ -101,7 +101,7 @@ class AddInt128Matcher(SequenceMatcher):
         matcher_iadd_step_2 = instructions_contain(OpcodeModsWithOperandsMatcher(
             opcode='IADD', modifiers=('64', 'X'),
             operands=(
-                PatternBuilder.REG,
+                Register.REG,
                 iadd_step_2_reg_0,
                 iadd_step_2_reg_1,
                 matched_iadd_step_0.operands[1],
@@ -140,11 +140,11 @@ class AddInt128Matcher(SequenceMatcher):
         matcher_iadd3_step_0 = OpcodeModsWithOperandsMatcher(
             opcode='IADD3',
             operands=(
-                PatternBuilder.REG,
-                PatternBuilder.PRED,
-                PatternBuilder.zero_or_one(PatternBuilder.PREDT),
+                Register.REG,
+                Register.PRED,
+                PatternBuilder.zero_or_one(Register.PREDT),
                 self.start,
-                PatternBuilder.any(PatternBuilder.REG, PatternBuilder.UREG, Constant.ADDRESS),
+                PatternBuilder.any(Register.REG, Register.UREG, Constant.ADDRESS),
                 'RZ',
             ),
         )
@@ -164,12 +164,12 @@ class AddInt128Matcher(SequenceMatcher):
             opcode='IADD3', modifiers=('X',),
             operands=(
                 iadd3_step_1_dst,
-                PatternBuilder.PRED,
-                PatternBuilder.zero_or_one(PatternBuilder.PREDT),
+                Register.PRED,
+                PatternBuilder.zero_or_one(Register.PREDT),
                 iadd3_step_1_src,
-                PatternBuilder.any(PatternBuilder.REG, PatternBuilder.UREG, Constant.ADDRESS),
+                PatternBuilder.any(Register.REG, Register.UREG, Constant.ADDRESS),
                 'RZ',
-                PatternBuilder.PRED,
+                Register.PRED,
                 '!PT',
             ),
         ))
@@ -185,12 +185,12 @@ class AddInt128Matcher(SequenceMatcher):
             opcode='IADD3', modifiers=('X',),
             operands=(
                 iadd3_step_2_dst,
-                PatternBuilder.PRED,
-                PatternBuilder.zero_or_one(PatternBuilder.PREDT),
+                Register.PRED,
+                PatternBuilder.zero_or_one(Register.PREDT),
                 iadd3_step_2_src,
-                PatternBuilder.any(PatternBuilder.REG, PatternBuilder.UREG, Constant.ADDRESS),
+                PatternBuilder.any(Register.REG, Register.UREG, Constant.ADDRESS),
                 'RZ',
-                PatternBuilder.PRED,
+                Register.PRED,
                 '!PT',
             ),
         ))
@@ -206,12 +206,12 @@ class AddInt128Matcher(SequenceMatcher):
             opcode='IADD3', modifiers=('X',),
             operands=(
                 iadd3_step_3_dst,
-                PatternBuilder.zero_or_one(PatternBuilder.PREDT),
-                PatternBuilder.zero_or_one(PatternBuilder.PREDT),
+                PatternBuilder.zero_or_one(Register.PREDT),
+                PatternBuilder.zero_or_one(Register.PREDT),
                 iadd3_step_3_src,
-                PatternBuilder.any(PatternBuilder.REG, PatternBuilder.UREG, Constant.ADDRESS),
+                PatternBuilder.any(Register.REG, Register.UREG, Constant.ADDRESS),
                 'RZ',
-                PatternBuilder.PRED,
+                Register.PRED,
                 '!PT',
             ),
         ))

--- a/reprospect/test/sass/matchers/add_int32.py
+++ b/reprospect/test/sass/matchers/add_int32.py
@@ -5,12 +5,12 @@ from reprospect.test.sass.instruction import (
     InstructionMatch,
     InstructionMatcher,
     OpcodeModsWithOperandsMatcher,
-    PatternBuilder,
 )
 from reprospect.test.sass.instruction.integer import (
     IntAdd3Matcher,
     IntAddMatcher,
 )
+from reprospect.test.sass.instruction.register import Register
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.tools.sass.decode import Instruction
 
@@ -38,9 +38,9 @@ class AddInt32Matcher(InstructionMatcher):
 
     def __init__(self, *,
         arch: NVIDIAArch,
-        dst: str = PatternBuilder.REG,
-        src_a: str = PatternBuilder.REG,
-        src_b: str = PatternBuilder.REG,
+        dst: str = Register.REG,
+        src_a: str = Register.REG,
+        src_b: str = Register.REG,
         swap: bool = False,
     ) -> None:
         """

--- a/reprospect/test/sass/matchers/convert_fp32_to_fp16.py
+++ b/reprospect/test/sass/matchers/convert_fp32_to_fp16.py
@@ -5,8 +5,8 @@ from reprospect.test.sass.instruction import (
     InstructionMatch,
     InstructionMatcher,
     OpcodeModsWithOperandsMatcher,
-    PatternBuilder,
 )
+from reprospect.test.sass.instruction.register import Register
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.tools.sass.decode import Instruction
 
@@ -26,8 +26,8 @@ class ConvertFp32ToFp16(InstructionMatcher):
     __slots__ = ('matcher',)
 
     def __init__(self, arch: NVIDIAArch, *,
-        dst: str = PatternBuilder.REG,
-        src: str = PatternBuilder.REG,
+        dst: str = Register.REG,
+        src: str = Register.REG,
     ) -> None:
         """
         :param src: 32-bit floating-point value.

--- a/reprospect/test/sass/matchers/move32.py
+++ b/reprospect/test/sass/matchers/move32.py
@@ -7,6 +7,7 @@ from reprospect.test.sass.instruction import (
     OpcodeModsWithOperandsMatcher,
     PatternBuilder,
 )
+from reprospect.test.sass.instruction.register import Register
 from reprospect.tools.sass.decode import Instruction
 
 if sys.version_info >= (3, 12):
@@ -36,14 +37,14 @@ class Move32Matcher(InstructionMatcher):
     ) -> None:
         self.mov: typing.Final[OpcodeModsWithOperandsMatcher] = OpcodeModsWithOperandsMatcher(
             opcode='MOV', operands=(
-                PatternBuilder.group(dst or PatternBuilder.REG, group='dst'),
+                PatternBuilder.group(dst or Register.REG, group='dst'),
                 PatternBuilder.group(src or PatternBuilder.OPERAND, group='src'),
             ),
         )
 
         self.imad: typing.Final[OpcodeModsWithOperandsMatcher] = OpcodeModsWithOperandsMatcher(
             opcode='IMAD', modifiers=('MOV', 'U32'), operands=(
-                PatternBuilder.group(dst or PatternBuilder.REG, group='dst'),
+                PatternBuilder.group(dst or Register.REG, group='dst'),
                 'RZ', 'RZ',
                 PatternBuilder.group(src or PatternBuilder.OPERAND, group='src'),
             ),

--- a/tests/test/sass/instruction/test_immediate.py
+++ b/tests/test/sass/instruction/test_immediate.py
@@ -5,7 +5,7 @@ import pytest
 
 from reprospect.test.sass.instruction import OpcodeModsWithOperandsMatcher
 from reprospect.test.sass.instruction.immediate import Immediate
-from reprospect.test.sass.instruction.pattern import PatternBuilder
+from reprospect.test.sass.instruction.register import Register
 
 
 class TestImmediate:
@@ -34,7 +34,7 @@ class TestImmediate:
         assert re.fullmatch(Immediate.INF, '100') is None
 
         assert OpcodeModsWithOperandsMatcher(
-            opcode='FADD', operands=(PatternBuilder.REG, PatternBuilder.REG, Immediate.INF),
+            opcode='FADD', operands=(Register.REG, Register.REG, Immediate.INF),
         ).match('FADD R5, R0, +INF') is not None
 
     def test_qnan(self) -> None:
@@ -43,7 +43,7 @@ class TestImmediate:
         assert re.fullmatch(Immediate.QNAN, '100') is None
 
         assert OpcodeModsWithOperandsMatcher(
-            opcode='FADD', operands=(PatternBuilder.REG, PatternBuilder.REG, Immediate.QNAN),
+            opcode='FADD', operands=(Register.REG, Register.REG, Immediate.QNAN),
         ).match('FADD R5, R0, -QNAN') is not None
 
     def test_floating(self) -> None:
@@ -51,14 +51,14 @@ class TestImmediate:
         assert re.fullmatch(Immediate.FLOATING, '+QNAN') is None
 
         assert OpcodeModsWithOperandsMatcher(
-            opcode='FADD', operands=(PatternBuilder.REG, PatternBuilder.REG, Immediate.FLOATING),
+            opcode='FADD', operands=(Register.REG, Register.REG, Immediate.FLOATING),
         ).match('FADD R5, R0, 3.1400001049041748047') is not None
 
     def test_floating_or_limit(self) -> None:
         assert re.fullmatch(Immediate.FLOATING_OR_LIMIT, '0x3') is None
 
         assert OpcodeModsWithOperandsMatcher(
-            opcode='FADD', operands=(PatternBuilder.REG, PatternBuilder.REG, Immediate.FLOATING_OR_LIMIT),
+            opcode='FADD', operands=(Register.REG, Register.REG, Immediate.FLOATING_OR_LIMIT),
         ).match('FADD R5, R0, +QNAN') is not None
 
     @pytest.mark.parametrize('immediate', IMMEDIATES)

--- a/tests/test/sass/instruction/test_register.py
+++ b/tests/test/sass/instruction/test_register.py
@@ -1,14 +1,36 @@
 import typing
 
 import pytest
+import regex
 
 from reprospect.test.sass.instruction.register import (
     MathModifier,
+    Register,
     RegisterMatch,
     RegisterMatcher,
     RegisterType,
 )
 
+
+class TestRegister:
+    """
+    Tests for :py:class:`reprospect.test.sass.instruction.register.Register`.
+    """
+    def test_reg_vs_ureg(self) -> None:
+        """
+        Ensure that :py:attr:`reprospect.test.sass.instruction.register.Register.REG` does not
+        match what :py:attr:`reprospect.test.sass.instruction.register.Register.UREG` matches
+        (and vice versa).
+        """
+        assert regex.fullmatch(Register.REG,    'R42') is not None
+        assert regex.fullmatch(Register.reg(),  'R42') is not None
+        assert regex.fullmatch(Register.UREG,   'R42') is None
+        assert regex.fullmatch(Register.ureg(), 'R42') is None
+
+        assert regex.fullmatch(Register.REG,    'UR42') is None
+        assert regex.fullmatch(Register.reg(),  'UR42') is None
+        assert regex.fullmatch(Register.UREG,   'UR42') is not None
+        assert regex.fullmatch(Register.ureg(), 'UR42') is not None
 
 class TestRegisterMatcher:
     """

--- a/tests/test/sass/test_atomic.py
+++ b/tests/test/sass/test_atomic.py
@@ -10,9 +10,9 @@ import semantic_version
 from reprospect.test.sass.instruction import (
     AtomicMatcher,
     InstructionMatch,
-    PatternBuilder,
 )
 from reprospect.test.sass.instruction.memory import MemorySpace
+from reprospect.test.sass.instruction.register import Register
 from reprospect.tools.sass import Instruction
 from reprospect.utils import cmake
 
@@ -234,7 +234,7 @@ __global__ void atomic_exch_kernel() {
             dtype=('S', 32),
         )
 
-        assert regex.match(PatternBuilder.PREDT, matched.operands[0]) is not None
+        assert regex.match(Register.PREDT, matched.operands[0]) is not None
         assert matched.operands[1] == 'RZ'
 
         # In the PTX, we can see the '.relaxed'.
@@ -264,7 +264,7 @@ __global__ void atomic_exch_kernel() {
             dtype=('U', 64),
         )
 
-        assert regex.match(PatternBuilder.PREDT, matched.operands[0]) is not None
+        assert regex.match(Register.PREDT, matched.operands[0]) is not None
         assert matched.operands[1] == 'RZ'
 
         # In the PTX, we can see the '.relaxed'.
@@ -291,7 +291,7 @@ __global__ void atomic_exch_kernel() {
             dtype=('F', 32),
         )
 
-        assert regex.match(PatternBuilder.PREDT, matched.operands[0]) is not None
+        assert regex.match(Register.PREDT, matched.operands[0]) is not None
         assert matched.operands[1] == 'RZ'
 
         # In the PTX, we can see the '.relaxed'.
@@ -318,7 +318,7 @@ __global__ void atomic_exch_kernel() {
             dtype=('F', 64),
         )
 
-        assert regex.match(PatternBuilder.PREDT, matched.operands[0]) is not None
+        assert regex.match(Register.PREDT, matched.operands[0]) is not None
         assert matched.operands[1] == 'RZ'
 
         # In the PTX, we can see the '.relaxed'.
@@ -345,7 +345,7 @@ __global__ void atomic_exch_kernel() {
             dtype=('S', 32),
         )
 
-        assert regex.match(PatternBuilder.PREDT, matched.operands[0]) is not None
+        assert regex.match(Register.PREDT, matched.operands[0]) is not None
         assert matched.operands[1] == 'RZ'
         assert {'MIN', 'S32'}.issubset(matched.modifiers)
 
@@ -373,7 +373,7 @@ __global__ void atomic_exch_kernel() {
             dtype=('S', 64),
         )
 
-        assert regex.match(PatternBuilder.PREDT, matched.operands[0]) is not None
+        assert regex.match(Register.PREDT, matched.operands[0]) is not None
         assert matched.operands[1] == 'RZ'
         assert {'MIN', 'S64'}.issubset(matched.modifiers)
 
@@ -401,7 +401,7 @@ __global__ void atomic_exch_kernel() {
             dtype=('U', 64),
         )
 
-        assert regex.match(PatternBuilder.PREDT, matched.operands[0]) is not None
+        assert regex.match(Register.PREDT, matched.operands[0]) is not None
         assert matched.operands[1] == 'RZ'
         assert {'MIN', '64'}.issubset(matched.modifiers)
 

--- a/tests/test/sass/test_composite_impl.py
+++ b/tests/test/sass/test_composite_impl.py
@@ -22,7 +22,7 @@ from reprospect.test.sass.instruction import (
     OpcodeModsWithOperandsMatcher,
 )
 from reprospect.test.sass.instruction.constant import Constant
-from reprospect.test.sass.instruction.pattern import PatternBuilder
+from reprospect.test.sass.instruction.register import Register
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.tools.sass import ControlCode, Instruction
 
@@ -351,10 +351,10 @@ class TestOrderedInterleavedInSequenceMatcher:
     )
 
     MATCHERS_DADD: typing.Final[tuple[OpcodeModsWithOperandsMatcher, ...]] = (
-        OpcodeModsWithOperandsMatcher(opcode='DADD', modifiers=(), operands=('R4',  'R4',  PatternBuilder.UREG)),
-        OpcodeModsWithOperandsMatcher(opcode='DADD', modifiers=(), operands=('R6',  'R6',  PatternBuilder.UREG)),
-        OpcodeModsWithOperandsMatcher(opcode='DADD', modifiers=(), operands=('R8',  'R8',  PatternBuilder.UREG)),
-        OpcodeModsWithOperandsMatcher(opcode='DADD', modifiers=(), operands=('R10', 'R10', PatternBuilder.UREG)),
+        OpcodeModsWithOperandsMatcher(opcode='DADD', modifiers=(), operands=('R4',  'R4',  Register.UREG)),
+        OpcodeModsWithOperandsMatcher(opcode='DADD', modifiers=(), operands=('R6',  'R6',  Register.UREG)),
+        OpcodeModsWithOperandsMatcher(opcode='DADD', modifiers=(), operands=('R8',  'R8',  Register.UREG)),
+        OpcodeModsWithOperandsMatcher(opcode='DADD', modifiers=(), operands=('R10', 'R10', Register.UREG)),
     )
 
     INSTRUCTIONS_LDG: typing.Final[tuple[str, ...]] = (

--- a/tests/test/sass/test_load.py
+++ b/tests/test/sass/test_load.py
@@ -22,6 +22,7 @@ from reprospect.test.sass.instruction import (
     PatternBuilder,
 )
 from reprospect.test.sass.instruction.memory import MemorySpace
+from reprospect.test.sass.instruction.register import Register
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.utils import cmake
 
@@ -103,7 +104,7 @@ __global__ __launch_bounds__(128, 1) void ldc({type}* __restrict__ const out)
         assert matched.additional is not None
         assert 'bank' in matched.additional
         assert 'offset' in matched.additional
-        assert re.match(PatternBuilder.REG, matched.additional['offset'][0]) is not None
+        assert re.match(Register.REG, matched.additional['offset'][0]) is not None
 
 class TestLoadMatcher:
     """
@@ -322,7 +323,7 @@ __global__ void extend({dst}* {restrict} const dst, {src}* {restrict} const src,
 
             matcher_prmt = instructions_contain(matcher=instruction_is(OpcodeModsWithOperandsMatcher(
                 opcode='PRMT',
-                operands=(PatternBuilder.REG, PatternBuilder.REG, PatternBuilder.HEX, PatternBuilder.REGZ),
+                operands=(Register.REG, Register.REG, PatternBuilder.HEX, Register.REGZ),
             )).with_operand(index=1, operand=matched_u16_ro.operands[0]))
             matcher_prmt.assert_matches(decoder_u16.instructions[matcher_u16_ro.next_index::])
         else:


### PR DESCRIPTION
This PR refactors the register pattern definitions by extracting them from the `PatternBuilder` class into a new dedicated Register class in `reprospect/test/sass/instruction/register.py`. This improves code organization by separating register-specific patterns from general pattern building utilities.

Extracted from:
- #425 