### PR TITLE
test(sass): fix addresses seen in cublas

### DIFF
--- a/reprospect/test/sass/instruction/__init__.py
+++ b/reprospect/test/sass/instruction/__init__.py
@@ -34,7 +34,6 @@ References:
 """
 
 from .address import (
-    AddressMatch,
     AddressMatcher,
     GenericOrGlobalAddressMatch,
     LocalAddressMatch,
@@ -66,7 +65,6 @@ from .pattern import PatternBuilder
 from .register import RegisterMatch, RegisterMatcher
 
 __all__ = (
-    'AddressMatch',
     'AddressMatcher',
     'AnyMatcher',
     'ArchitectureAndVersionAwarePatternMatcher',

--- a/reprospect/test/sass/instruction/instruction.py
+++ b/reprospect/test/sass/instruction/instruction.py
@@ -561,7 +561,7 @@ class AtomicMatcher(ArchitectureAndVersionAwarePatternMatcher):
 
         match self.arch.compute_capability.as_int:
             case 80 | 86 | 89 | 90 | 100 | 103 | 120:
-                address = PatternBuilder.any(AddressMatcher.build_address(arch=self.arch), address)
+                address = PatternBuilder.any(AddressMatcher.build_reg_address(arch=self.arch), address)
             case _:
                 pass
 

--- a/tests/test/sass/instruction/test_address.py
+++ b/tests/test/sass/instruction/test_address.py
@@ -21,7 +21,7 @@ class TestAddressMatcher:
     """
     Tests for :py:class:`reprospect.test.sass.instruction.address.AddressMatcher`.
     """
-    def test_address(self) -> None:
+    def test_reg_address(self) -> None:
         ARCH: typing.Final[NVIDIAArch] = NVIDIAArch.from_str('TURING75')
 
         ADDRESS: typing.Final[str] = '[R42]'
@@ -97,7 +97,7 @@ class TestAddressMatcher:
         assert AddressMatcher(arch=ARCH, reg='R42', offset='0x10', desc_ureg='UR6').match(ADDRESS_WITH_OFFSET) is None
         assert AddressMatcher(arch=ARCH, reg='R42', offset='0x20', desc_ureg='UR4').match(ADDRESS_WITH_OFFSET) is None
 
-    def test_stride_address(self) -> None:
+    def test_reg_stride_address(self) -> None:
         ARCH: typing.Final[NVIDIAArch] = NVIDIAArch.from_str('VOLTA70')
 
         ADDRESS: typing.Final[str] = '[R25.X8+0x800]'
@@ -108,12 +108,17 @@ class TestAddressMatcher:
         assert AddressMatcher(arch=ARCH, memory=MemorySpace.SHARED, reg='R25', offset='0x800', stride=StrideModifier.X8).match(ADDRESS) == SharedAddressMatch(reg='R25', offset='0x800', stride=StrideModifier.X8)
         assert AddressMatcher(arch=ARCH, memory=MemorySpace.SHARED, reg='R25', offset='0x800', stride=StrideModifier.X4).match(ADDRESS) is None
 
-    def test_shared_hex_only_address_volta70(self) -> None:
+    def test_shared_offset_address(self) -> None:
         ARCH: typing.Final[NVIDIAArch] = NVIDIAArch.from_str('VOLTA70')
+
+        ADDRESS: typing.Final[str] = '[0x10]'
+
+        assert AddressMatcher(arch=ARCH, memory=MemorySpace.SHARED           ).match(ADDRESS) == SharedAddressMatch(offset='0x10')
+        assert AddressMatcher(arch=ARCH, memory=MemorySpace.SHARED, reg='R25').match(ADDRESS) is None
 
         assert OpcodeModsWithOperandsMatcher(opcode='LDS', modifiers=('U', '128'), operands=(
             Register.REG, AddressMatcher.build_pattern(arch=ARCH, memory=MemorySpace.SHARED),
-        )).match(inst='LDS.U.128 R20, [0x10]') is not None
+        )).match(inst=f'LDS.U.128 R20, {ADDRESS}') is not None
 
     def test_global_reg64_address_turing75(self) -> None:
         ARCH: typing.Final[NVIDIAArch] = NVIDIAArch.from_str('TURING75')


### PR DESCRIPTION
This PR fixes the address patterns for `VOLTA70` and `TURING75` to allow for some addresses seen in `libcublas.so`.