### PR TITLE
test(SASS): introduce `OpCode` in instruction

### DIFF
--- a/reprospect/test/sass/instruction/half.py
+++ b/reprospect/test/sass/instruction/half.py
@@ -3,7 +3,11 @@ import typing
 import regex
 
 from reprospect.test.sass.instruction.immediate import Immediate
-from reprospect.test.sass.instruction.instruction import PatternMatcher
+from reprospect.test.sass.instruction.instruction import (
+    OpCode,
+    PatternMatcher,
+    ZeroOrOne,
+)
 from reprospect.test.sass.instruction.operand import Operand
 from reprospect.test.sass.instruction.pattern import PatternBuilder
 from reprospect.test.sass.instruction.register import Register
@@ -104,7 +108,7 @@ class Fp16FusedMulAddMatcher(PatternMatcher):
 
         This likely means "multiply both lanes of ``R0`` by 1 and add ``R5``".
     """
-    TEMPLATE: typing.Final[str] = f"{PatternBuilder.opcode_mods('HFMA2', modifiers = ('?MMA',))} {Register.dst()}, {{op1}}, {{op2}}, {{op3}}(?:, {{op4}})?"
+    TEMPLATE: typing.Final[str] = f"{OpCode.mod('HFMA2', modifiers=(ZeroOrOne('MMA'),))} {Register.dst()}, {{op1}}, {{op2}}, {{op3}}(?:, {{op4}})?"
 
     PATTERN_ANY: typing.Final[regex.Pattern[str]] = regex.compile(TEMPLATE.format(
         op1=Fp16.build_pattern_operand(),
@@ -152,7 +156,7 @@ class Fp16MulMatcher(PatternMatcher):
 
         HMUL2 R0, R2, R3
     """
-    TEMPLATE: typing.Final[str] = f"{PatternBuilder.opcode_mods('HMUL2')} {Register.dst()}, {{op1}}, {{op2}}"
+    TEMPLATE: typing.Final[str] = f"{OpCode.mod('HMUL2', modifiers=())} {Register.dst()}, {{op1}}, {{op2}}"
 
     PATTERN_ANY: typing.Final[regex.Pattern[str]] = regex.compile(TEMPLATE.format(
         op1=Fp16.build_pattern_operand(),
@@ -198,7 +202,7 @@ class Fp16AddMatcher(PatternMatcher):
 
         HADD2 R0, R2, R3
     """
-    TEMPLATE: typing.Final[str] = f"{PatternBuilder.opcode_mods('HADD2', modifiers = ('?F32',))} {Register.dst()}, {{op1}}, {{op2}}"
+    TEMPLATE: typing.Final[str] = f"{OpCode.mod('HADD2', modifiers=(ZeroOrOne('F32'),))} {Register.dst()}, {{op1}}, {{op2}}"
 
     PATTERN_ANY: typing.Final[regex.Pattern[str]] = regex.compile(TEMPLATE.format(
         op1=Fp16.build_pattern_operand(),
@@ -228,7 +232,7 @@ class Fp16MinMaxMatcher(PatternMatcher):
     """
     Matcher for 16-bit floating-point min-max (``HMNMX2``) instruction.
     """
-    TEMPLATE: typing.Final[str] = f"{PatternBuilder.opcode_mods('HMNMX2')} {Register.dst()}, {{op1}}, {{op2}}, {{which}}"
+    TEMPLATE: typing.Final[str] = f"{OpCode.mod('HMNMX2', modifiers=())} {Register.dst()}, {{op1}}, {{op2}}, {{which}}"
 
     PATTERN_ANY: typing.Final[regex.Pattern[str]] = regex.compile(TEMPLATE.format(
         op1=Fp16.build_pattern_operand(),

--- a/reprospect/test/sass/instruction/integer.py
+++ b/reprospect/test/sass/instruction/integer.py
@@ -11,6 +11,7 @@ from reprospect.test.sass.instruction import (
     PatternBuilder,
     PatternMatcher,
 )
+from reprospect.test.sass.instruction.instruction import OpCode
 from reprospect.test.sass.instruction.register import Register
 from reprospect.tools.architecture import NVIDIAArch
 
@@ -79,7 +80,7 @@ class LEAMatcher(PatternMatcher):
 
     * https://forums.developer.nvidia.com/t/how-to-understand-the-lea-assembly-behind-the-cuda-c/257679/2
     """
-    TEMPLATE: typing.Final[str] = rf"{PatternBuilder.opcode_mods(opcode='LEA')} {{dest}}, {{index}}, {{base}}, {{shift}}"
+    TEMPLATE: typing.Final[str] = rf"{OpCode.mod(opcode='LEA', modifiers=())} {{dest}}, {{index}}, {{base}}, {{shift}}"
 
     SHIFT: typing.Final[str] = r'0x[0-9]+'
 

--- a/reprospect/test/sass/instruction/pattern.py
+++ b/reprospect/test/sass/instruction/pattern.py
@@ -50,26 +50,3 @@ class PatternBuilder:
         for g in groups:
             s = PatternBuilder.group(s, group=g)
         return str(s)
-
-    @staticmethod
-    def opcode_mods(opcode: str, modifiers: typing.Iterable[int | str | None] | None = None) -> str:
-        """
-        Append each modifier with a `.`, within a proper named capture group.
-
-        Note that the modifiers starting with a `?` are matched optionally.
-        """
-        opcode = PatternBuilder.group(opcode, group='opcode')
-        if modifiers is None:
-            return opcode
-
-        parts: list[str] = [opcode]
-
-        for modifier in modifiers:
-            if not modifier:
-                continue
-            if isinstance(modifier, str) and modifier[0] == '?':
-                parts.append(PatternBuilder.zero_or_one(r'\.' + PatternBuilder.group(modifier[1:], group='modifiers')))
-            else:
-                parts.append(r'\.' + PatternBuilder.group(modifier, group='modifiers'))
-
-        return ''.join(parts)


### PR DESCRIPTION
This PR adds an `OpCode` class with a `mod` function in `instruction.py`. With this PR, the `PatternBuilder` now essentially holds the `HEX` pattern and the helper functions for pattern logic.