### PR TITLE
test(sass): constant offset may be `RZ`

### DIFF
--- a/reprospect/test/sass/instruction/constant.py
+++ b/reprospect/test/sass/instruction/constant.py
@@ -21,7 +21,7 @@ class Constant:
     BANK: typing.Final[str] = r'0x[0-9]+'
     """Constant memory bank."""
 
-    OFFSET: typing.Final[str] = PatternBuilder.any(PatternBuilder.HEX, Register.REG, Register.UREG)
+    OFFSET: typing.Final[str] = PatternBuilder.any(PatternBuilder.HEX, Register.REGZ, Register.UREG)
     """Constant memory offset."""
 
     ADDRESS: typing.Final[str] = r'c\[' + BANK + r'\]\[' + OFFSET + r'\]'

--- a/tests/test/sass/instruction/test_constant.py
+++ b/tests/test/sass/instruction/test_constant.py
@@ -18,6 +18,7 @@ class TestConstantMatcher:
         'c[0x0][R9]':     ConstantMatch(bank='0x0', offset='R9'),
         '-c[0x0][0x18c]': ConstantMatch(bank='0x0', offset='0x18c', math=MathModifier.NEG),
         'c[0x0][UR456]':  ConstantMatch(bank='0x0', offset='UR456'),
+        'c[0x0][RZ]':     ConstantMatch(bank='0x0', offset='RZ'),
     }
 
     MATCHER: typing.Final[ConstantMatcher] = ConstantMatcher()
@@ -36,6 +37,13 @@ class TestConstantMatcher:
         assert ConstantMatcher(bank='0x0', offset='R9').match(CONSTANT) == self.CONSTANTS[CONSTANT]
         assert ConstantMatcher(bank='0x2'             ).match(CONSTANT) is None
 
+    def test_constant_with_rz(self) -> None:
+        CONSTANT: typing.Final[str] = 'c[0x0][RZ]'
+
+        assert ConstantMatcher(bank='0x0'             ).match(CONSTANT) == self.CONSTANTS[CONSTANT]
+        assert ConstantMatcher(bank='0x0', offset='RZ').match(CONSTANT) == self.CONSTANTS[CONSTANT]
+        assert ConstantMatcher(bank='0x2'             ).match(CONSTANT) is None
+
     def test_constant_with_ureg(self) -> None:
         CONSTANT: typing.Final[str] = 'c[0x0][UR456]'
 
@@ -52,7 +60,7 @@ class TestConstantMatcher:
 
     def test_build_pattern(self) -> None:
         pattern = ConstantMatcher.build_pattern(bank='0x0', capture_bank=True, capture_modifier_math=True, captured=False)
-        assert pattern == r'(?:(?P<modifier_math>(?:!|\-\||\-|\~|\|)))?c\[(?P<bank>0x0)\]\[(?:0x[0-9A-Fa-f]+|R[0-9]+|UR[0-9]+)\]'
+        assert pattern == r'(?:(?P<modifier_math>(?:!|\-\||\-|\~|\|)))?c\[(?P<bank>0x0)\]\[(?:0x[0-9A-Fa-f]+|R(?:Z|\d+)|UR[0-9]+)\]'
 
     @pytest.mark.parametrize(('constant', 'expected'), CONSTANTS.items())
     def test_any(self, constant: str, expected: ConstantMatch) -> None:


### PR DESCRIPTION
This PR adds support for the special register `RZ` as a valid constant memory offset in SASS instruction patterns.