### PR TITLE
test(SASS): add `build_pattern` helper function to `PatternMatcher`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -116,6 +116,7 @@ nitpick_ignore_regex = [
     ('py:class', r'numpy.int64'),
     ('py:class', r'_regex.Match'),
     ('py:class', r'_regex.Pattern'),
+    ('py:class', r'regex.Pattern'),
     ('py:class', r'elftools.*'),
 ]
 

--- a/reprospect/test/sass/instruction/__init__.py
+++ b/reprospect/test/sass/instruction/__init__.py
@@ -59,6 +59,7 @@ from .instruction import (
     ReductionMatcher,
     StoreGlobalMatcher,
     StoreMatcher,
+    ZeroOrOne,
 )
 from .memory import MemorySpace
 from .pattern import PatternBuilder
@@ -93,4 +94,5 @@ __all__ = (
     'SharedAddressMatch',
     'StoreGlobalMatcher',
     'StoreMatcher',
+    'ZeroOrOne',
 )

--- a/reprospect/test/sass/matchers/add_int128.py
+++ b/reprospect/test/sass/matchers/add_int128.py
@@ -10,6 +10,7 @@ from reprospect.test.sass.instruction import (
     RegisterMatcher,
 )
 from reprospect.test.sass.instruction.constant import Constant
+from reprospect.test.sass.instruction.instruction import ZeroOrOne
 from reprospect.test.sass.instruction.register import Register
 from reprospect.tools.sass.decode import Instruction
 
@@ -142,7 +143,7 @@ class AddInt128Matcher(SequenceMatcher):
             operands=(
                 Register.REG,
                 Register.PRED,
-                PatternBuilder.zero_or_one(Register.PREDT),
+                ZeroOrOne(Register.PREDT),
                 self.start,
                 PatternBuilder.any(Register.REG, Register.UREG, Constant.ADDRESS),
                 'RZ',
@@ -165,7 +166,7 @@ class AddInt128Matcher(SequenceMatcher):
             operands=(
                 iadd3_step_1_dst,
                 Register.PRED,
-                PatternBuilder.zero_or_one(Register.PREDT),
+                ZeroOrOne(Register.PREDT),
                 iadd3_step_1_src,
                 PatternBuilder.any(Register.REG, Register.UREG, Constant.ADDRESS),
                 'RZ',
@@ -186,7 +187,7 @@ class AddInt128Matcher(SequenceMatcher):
             operands=(
                 iadd3_step_2_dst,
                 Register.PRED,
-                PatternBuilder.zero_or_one(Register.PREDT),
+                ZeroOrOne(Register.PREDT),
                 iadd3_step_2_src,
                 PatternBuilder.any(Register.REG, Register.UREG, Constant.ADDRESS),
                 'RZ',
@@ -206,8 +207,8 @@ class AddInt128Matcher(SequenceMatcher):
             opcode='IADD3', modifiers=('X',),
             operands=(
                 iadd3_step_3_dst,
-                PatternBuilder.zero_or_one(Register.PREDT),
-                PatternBuilder.zero_or_one(Register.PREDT),
+                ZeroOrOne(Register.PREDT),
+                ZeroOrOne(Register.PREDT),
                 iadd3_step_3_src,
                 PatternBuilder.any(Register.REG, Register.UREG, Constant.ADDRESS),
                 'RZ',

--- a/tests/test/sass/test_any.py
+++ b/tests/test/sass/test_any.py
@@ -54,11 +54,12 @@ class TestAnyMatcher:
 
     def test_pattern(self) -> None:
         assert self.MATCHER.pattern.pattern == (
-            r'(?:(?P<predicate>@!?U?P(?:T|[0-9]+))\s*)?'
+            r'(?:(?P<predicate>@!?U?P(?:T|[0-9]+)))?'
+            r'\s*'
             r'(?P<opcode>[A-Z0-9]+)'
-            r'(?:\.(?P<modifiers>[A-Z0-9_]+))*\s*'
-            r'(?:(?P<operands>[^,\s]+)(?:\s*,\s*|\s+))*'
-            r'(?:(?P<operands>[^,\s]+))?'
+            r'(?:\.(?P<modifiers>[A-Z0-9_]+))*'
+            r'\s*'
+            r'(?:(?P<operands>[\w!\.\[\]\+\-\|~]+)(?:,?\s*(?P<operands>[\w!\.\[\]\+\-\|~]+))*)?'
         )
 
     @pytest.mark.parametrize(('instruction', 'expected'), INSTRUCTIONS.items())

--- a/tests/test/sass/test_branch.py
+++ b/tests/test/sass/test_branch.py
@@ -23,8 +23,10 @@ class TestBranchMatcher:
 
     def test_pattern(self) -> None:
         assert self.MATCHER.pattern.pattern == (
-            r'(?:(?P<predicate>@!?U?P(?:T|[0-9]+)))?\s*'
-            r'(?P<opcode>BRA)\s*'
+            r'(?:(?P<predicate>@!?U?P(?:T|[0-9]+)))?'
+            r'\s*'
+            r'(?P<opcode>BRA)'
+            r'\s*'
             r'(?P<operands>0x[0-9A-Fa-f]+)'
         )
 

--- a/tests/test/sass/test_instruction.py
+++ b/tests/test/sass/test_instruction.py
@@ -343,12 +343,13 @@ class TestOpcodeModsWithOperandsMatcher:
         ))
 
         assert matcher.pattern.pattern == (
-            r'(?P<opcode>ISETP)\.(?P<modifiers>NE)\.(?P<modifiers>AND)\s*'
-            r'(?P<operands>P[0-9]+),\s+'
-            r'(?P<operands>P(?:T|\d+)),\s+'
-            r'(?P<operands>R4),\s+'
-            r'(?P<operands>R(?:Z|\d+)),\s+'
-            r'(?P<operands>P(?:T|\d+))'
+            r'(?P<opcode>ISETP)\.(?P<modifiers>NE)\.(?P<modifiers>AND)'
+            r'\s*'
+            r'(?P<operands>P[0-9]+)'
+            r',?\s*(?P<operands>P(?:T|\d+))'
+            r',?\s*(?P<operands>R4)'
+            r',?\s*(?P<operands>R(?:Z|\d+))'
+            r',?\s*(?P<operands>P(?:T|\d+))'
         )
 
         matched = matcher.match(instruction)


### PR DESCRIPTION
This function is built from what we did in `OpcodeModsMatcher`, `OpcodeModsWithOperandsMatcher`, `AnyMatcher`.

It is used to construct `BranchMatcher`, `LEAMatcher`, `Fp32AddMatcher` and `Fp64AddMatcher`, i.e. where we're closest to making a matcher for a specific opcode.