### PR TITLE
Minor: use lowercase letters for one-word profiling range name

### DIFF
--- a/examples/kokkos/complex/example_alignment.cpp
+++ b/examples/kokkos/complex/example_alignment.cpp
@@ -93,7 +93,7 @@ int main(int argc, char* argv[])
     {
         using namespace reprospect::examples::kokkos::complex;
 
-        Kokkos::Profiling::ProfilingSection profiling_section {"Alignment"};
+        Kokkos::Profiling::ProfilingSection profiling_section {"alignment"};
         profiling_section.start();
 
         using complex_double_specified_alignment_t = Kokkos::complex<double>;

--- a/examples/kokkos/complex/example_alignment.py
+++ b/examples/kokkos/complex/example_alignment.py
@@ -180,7 +180,7 @@ class TestNCU(TestAlignment):
         MetricCounter(name='lts__t_sectors_srcunit_tex_op_read_lookup_miss', subs=(MetricCounterRollUp.SUM,)),
     )
 
-    NVTX_INCLUDES: typing.Final[tuple[str, ...]] = ('Alignment',)
+    NVTX_INCLUDES: typing.Final[tuple[str, ...]] = ('alignment',)
 
     @pytest.fixture(scope='class')
     def report(self) -> Report:


### PR DESCRIPTION
Extracted from:
- #412 