### PR TITLE
docker(rust): install rust in images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,6 +232,7 @@ jobs:
                       GOOGLEBENCHMARK_VERSION=1.9.4
                       NVTX3_VERSION=3.4.0
                       PYTHON_VERSION=${{ matrix.ubuntu_version == '24.04' && '3.12' || '3.10' }}
+                      RUST_VERSION=1.92.0
                   labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 
             - uses: docker/build-push-action@v6.18.0

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -104,8 +104,19 @@ RUN --mount=target=/requirements/requirements.txt,type=bind,source=requirements/
     python3 -m pip install pytest build
 EOF
 
+# Rust requirements.
+FROM python-requirements AS rust-requirements
+
+ARG RUST_VERSION=0.0.0
+
+ADD https://sh.rustup.rs rustup.sh
+
+RUN sh rustup.sh -y --profile minimal --default-toolchain ${RUST_VERSION}
+
+ENV PATH=/root/.cargo/bin:${PATH}
+
 # Install Nsight Systems.
-FROM python-requirements AS nsight-systems
+FROM rust-requirements AS nsight-systems
 
 RUN --mount=target=/reprospect/installers/nsight_systems.py,type=bind,source=reprospect/installers/nsight_systems.py \
     --mount=target=/reprospect/utils/nvcc.py,type=bind,source=reprospect/utils/nvcc.py <<EOF


### PR DESCRIPTION
We'll use `rust` soon to speedup many hot parsing paths (*e.g.* in `decode.py`). 