### PR TITLE
cicd: add `mypy` dependency to `build-package` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -303,7 +303,7 @@ jobs:
                   if-no-files-found: error
 
     build-package:
-        needs: [setup-job-matrix, build-images]
+        needs: [setup-job-matrix, build-images, mypy]
         runs-on: ${{ matrix.runs-on }}
         strategy:
             fail-fast: false


### PR DESCRIPTION
If `mypy` fails, then `mypyc` will likely fail too.