### PR TITLE
cicd: support for windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,12 +313,14 @@ jobs:
             fail-fast: false
             matrix:
                 pyver: [cp310, cp311, cp312, cp313, cp314]
-                arch : [x86_64, aarch64]
+                build: [manylinux_x86_64, manylinux_aarch64, win_amd64]
                 include:
                     - runs-on: ubuntu-24.04
-                      arch: x86_64
+                      build: manylinux_x86_64
                     - runs-on: ubuntu-24.04-arm
-                      arch: aarch64
+                      build: manylinux_aarch64
+                    - runs-on: windows-latest
+                      build: win_amd64
         if: ${{ ! failure() && ! cancelled() }}
         steps:
             - uses: actions/checkout@v6
@@ -328,11 +330,10 @@ jobs:
             - run: python -m pip install -U cibuildwheel
             - run: python -m cibuildwheel --config-file pyproject.toml --output-dir wheelhouse
               env:
-                  CIBW_ARCHS: ${{ matrix.arch }}
-                  CIBW_BUILD: "${{ matrix.pyver }}-manylinux*"
+                  CIBW_BUILD: "${{ matrix.pyver }}-${{ matrix.build }}"
             - uses: actions/upload-artifact@v6
               with:
-                  name: package-${{ matrix.pyver }}-${{ matrix.arch }}
+                  name: package-${{ matrix.pyver }}-${{ matrix.build }}
                   path: wheelhouse/
                   retention-days: 1
                   if-no-files-found: error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -233,3 +233,7 @@ build = []
 archs = []
 
 build-verbosity = 1
+
+[tool.cibuildwheel.windows]
+# Improve cl.exe error messages for debugging mypyc-generated C code.
+environment = { CL = "/diagnostics:caret" }

--- a/reprospect/test/sass/instruction/address.py
+++ b/reprospect/test/sass/instruction/address.py
@@ -148,11 +148,11 @@ class AddressMatcher:
             return rf'\+{PatternBuilder.group(offset, "offset") if captured else offset}'
         match arch.compute_capability.as_int:
             case 70:
-                inner = r'-?' + PatternBuilder.HEX
+                inner = r'-?' + PatternBuilder.HEXADECIMAL
             case 75 | 80 | 86 | 89:
-                inner = PatternBuilder.any(r'-?' + PatternBuilder.HEX, Register.UREG)
+                inner = PatternBuilder.any(r'-?' + PatternBuilder.HEXADECIMAL, Register.UREG)
             case 90 | 100 | 103 | 120:
-                inner = PatternBuilder.any(r'-?' + PatternBuilder.HEX, Register.UREG, rf'{Register.UREG}\+-?{PatternBuilder.HEX}')
+                inner = PatternBuilder.any(r'-?' + PatternBuilder.HEXADECIMAL, Register.UREG, rf'{Register.UREG}\+-?{PatternBuilder.HEXADECIMAL}')
             case _:
                 raise ValueError(f'unsupported architecture {arch}')
         return PatternBuilder.zero_or_one(r'\+' + (PatternBuilder.group(inner, 'offset') if captured else inner))
@@ -222,7 +222,7 @@ class AddressMatcher:
         patterns: list[str] = [reg_stride_address]
 
         if reg is None:
-            offset_address = offset or PatternBuilder.HEX
+            offset_address = offset or PatternBuilder.HEXADECIMAL
             offset_address = rf"\[{PatternBuilder.group(offset_address, group='offset') if captured else offset_address}\]"
             patterns.append(offset_address)
 

--- a/reprospect/test/sass/instruction/branch.py
+++ b/reprospect/test/sass/instruction/branch.py
@@ -17,7 +17,7 @@ class BranchMatcher(PatternMatcher):
     PATTERN: typing.Final[regex.Pattern[str]] = regex.compile(PatternMatcher.build_pattern(
         opcode='BRA',
         modifiers=(),
-        operands=(PatternBuilder.HEX,),
+        operands=(PatternBuilder.HEXADECIMAL,),
         predicate=None,
     ))
 
@@ -27,7 +27,7 @@ class BranchMatcher(PatternMatcher):
             else self.build_pattern(
                 opcode='BRA',
                 modifiers=(),
-                operands=(offset or PatternBuilder.HEX,),
+                operands=(offset or PatternBuilder.HEXADECIMAL,),
                 predicate=predicate,
             ),
         )

--- a/reprospect/test/sass/instruction/constant.py
+++ b/reprospect/test/sass/instruction/constant.py
@@ -21,7 +21,7 @@ class Constant:
     BANK: typing.Final[str] = r'0x[0-9]+'
     """Constant memory bank."""
 
-    OFFSET: typing.Final[str] = PatternBuilder.any(PatternBuilder.HEX, Register.REGZ, Register.UREG)
+    OFFSET: typing.Final[str] = PatternBuilder.any(PatternBuilder.HEXADECIMAL, Register.REGZ, Register.UREG)
     """Constant memory offset."""
 
     ADDRESS: typing.Final[str] = r'c\[' + BANK + r'\]\[' + OFFSET + r'\]'

--- a/reprospect/test/sass/instruction/pattern.py
+++ b/reprospect/test/sass/instruction/pattern.py
@@ -5,14 +5,7 @@ class PatternBuilder:
     """
     Helper class to build patterns for instruction components.
     """
-    HEX: typing.Final[str] = r'0x[0-9A-Fa-f]+'
-
-    @classmethod
-    def hex(cls) -> str:
-        """
-        :py:attr:`HEX` with `operands` group.
-        """
-        return cls.group(cls.HEX, group='operands')
+    HEXADECIMAL: typing.Final[str] = r'0x[0-9A-Fa-f]+'
 
     @staticmethod
     def zero_or_one(s: str) -> str:

--- a/reprospect/tools/sass/controlflow.py
+++ b/reprospect/tools/sass/controlflow.py
@@ -3,7 +3,8 @@ import re
 import typing
 
 from reprospect.test.sass.instruction.instruction import Predicate
-from reprospect.tools.sass.decode import Decoder, Instruction
+from reprospect.test.sass.instruction.pattern import PatternBuilder
+from reprospect.tools.sass.decode import Instruction
 
 
 @dataclasses.dataclass(frozen=True, slots=True, repr=False)
@@ -129,7 +130,7 @@ class ControlFlow:
         >>> ControlFlow.get_target(instruction = Instruction(offset = '0160', instruction = f'@!P0 BRA {hex(400)}', hex = '0x0000000000088947', control = ControlCode.decode(code = '0x000fea0003800000')))
         400
         """
-        if (target := re.search(rf'({Decoder.HEX})', instruction.instruction)) is not None:
+        if (target := re.search(rf'({PatternBuilder.HEXADECIMAL})', instruction.instruction)) is not None:
             return int(target.group(1), 16)
         return None
 

--- a/reprospect/tools/sass/decode.py
+++ b/reprospect/tools/sass/decode.py
@@ -206,19 +206,19 @@ class Decoder(rich_helpers.TableMixin):
 
     OFFSET: typing.Final[str] = r'[a-f0-9]+'
 
-    HEX: typing.Final[str] = r'0x[a-f0-9]+'
+    HEXADECIMAL: typing.Final[str] = r'0x[a-f0-9]+'
     """
     Matcher for an hex-like string, such as `0x00000a0000017a02`.
     """
 
-    MATCHER_CONTROL: typing.Final[re.Pattern[str]] = re.compile(rf'\/\* ({HEX}) \*\/')
+    MATCHER_CONTROL: typing.Final[re.Pattern[str]] = re.compile(rf'\/\* ({HEXADECIMAL}) \*\/')
 
     MATCHER: typing.Final[re.Pattern[str]] = re.compile(
         rf'/\*({OFFSET})\*/'
         r'\s+'
         r'(.*?)(?=\s{2,}|[;?&])'
         r'.*?'
-        rf'/\*\s*({HEX})\s*\*/',
+        rf'/\*\s*({HEXADECIMAL})\s*\*/',
     )
     """
     Matcher for the full SASS line. It focuses on the offset, instruction and trailing hex encoding.

--- a/tests/test/sass/test_load.py
+++ b/tests/test/sass/test_load.py
@@ -323,7 +323,7 @@ __global__ void extend({dst}* {restrict} const dst, {src}* {restrict} const src,
 
             matcher_prmt = instructions_contain(matcher=instruction_is(OpcodeModsWithOperandsMatcher(
                 opcode='PRMT',
-                operands=(Register.REG, Register.REG, PatternBuilder.HEX, Register.REGZ),
+                operands=(Register.REG, Register.REG, PatternBuilder.HEXADECIMAL, Register.REGZ),
             )).with_operand(index=1, operand=matched_u16_ro.operands[0]))
             matcher_prmt.assert_matches(decoder_u16.instructions[matcher_u16_ro.next_index::])
         else:

--- a/tests/tools/sass/test_decode.py
+++ b/tests/tools/sass/test_decode.py
@@ -52,7 +52,7 @@ class TestDecoder:
         """
         Simple tests for the matchers.
         """
-        assert re.match(sass.Decoder.HEX, '0x00000a0000017a02') is not None
+        assert re.match(sass.Decoder.HEXADECIMAL, '0x00000a0000017a02') is not None
 
         # Complete SASS line (offset, instruction and hex), without noise.
         matched = re.match(sass.Decoder.MATCHER, '/*0090*/                   ISETP.GE.U32.AND P0, PT, R0, UR9, PT ;           /* 0x0000000900007c0c */')


### PR DESCRIPTION
I needed to rename `HEX` to `HEXADECIMAL`.

This is likely due to some `cl.exe` macro being named `HEX`. `mypyc` generated C code would not compile. Renaming fixed it.