### PR TITLE
cicd: better coverage of python version

### DIFF
--- a/.devcontainer/dockerfile
+++ b/.devcontainer/dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/uliegecsm/reprospect/cuda-gnu-14-nvidia:13.0.0-devel-ubuntu24.04
+FROM ghcr.io/uliegecsm/reprospect/cuda-gnu-14-nvidia-py3.13:13.0.0-devel-ubuntu24.04
 
 # Installing gpg and gnupg2 allows the container to use GPG keys to sign commits.
 # See also:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,7 +233,7 @@ jobs:
                       DOXYGEN_VERSION=1_14_0
                       GOOGLEBENCHMARK_VERSION=1.9.4
                       NVTX3_VERSION=3.4.0
-                      PYTHON_VERSION=${{ matrix.ubuntu_version == '24.04' && '3.12' || '3.10' }}
+                      PYTHON_VERSION=${{ matrix.python_version }}
                       RUST_VERSION=1.92.0
                   labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 

--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -45,6 +45,7 @@ JobDict: typing.TypeAlias = dict[str, typing.Any]
 class Config:
     cuda_version: str
     ubuntu_version: str
+    python_version: str
     compilers: dict[LANGUAGE, Compiler]
     compute_capability: ComputeCapability
     platforms: tuple[PLATFORM, ...]
@@ -86,6 +87,7 @@ class Config:
             yield {
                 'cuda_version': self.cuda_version,
                 'ubuntu_version': self.ubuntu_version,
+                'python_version': self.python_version,
                 'compilers': self.compilers,
                 'compute_capability': self.compute_capability,
                 'platform': platform,
@@ -184,11 +186,10 @@ def complete_job_impl(*, partial: JobDict, args: argparse.Namespace) -> JobDict:
     # Name and tag of the image (lower case).
     name = ('-'.join((
         'cuda',
-        *list(dict.fromkeys([
-            partial['compilers']['CXX'].ID,
-            partial['compilers']['CXX'].version,
-            partial['compilers']['CUDA'].ID,
-        ])),
+        partial['compilers']['CXX'].ID,
+        partial['compilers']['CXX'].version,
+        partial['compilers']['CUDA'].ID,
+        f"py{partial['python_version']}",
     ))).lower()
 
     base_name, base_tag, base_digest = get_base_name_tag_digest(cuda_version=partial['cuda_version'], ubuntu_version=partial['ubuntu_version'])
@@ -209,6 +210,7 @@ def complete_job_impl(*, partial: JobDict, args: argparse.Namespace) -> JobDict:
         partial['compilers']['CXX'].version,
         partial['compilers']['CUDA'].ID,
         partial['ubuntu_version'],
+        partial['python_version'],
         partial['platform'],
     ))
 
@@ -253,6 +255,7 @@ def main(*, args: argparse.Namespace) -> None:
     matrix.extend(from_config(Config(
         cuda_version='12.8.1',
         ubuntu_version='24.04',
+        python_version='3.12',
         compilers={'CXX': Compiler(ID='GNU', version='13'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=7, minor=0),
         platforms=('linux/amd64', 'linux/arm64'),
@@ -261,6 +264,7 @@ def main(*, args: argparse.Namespace) -> None:
     matrix.extend(from_config(Config(
         cuda_version='12.8.1',
         ubuntu_version='24.04',
+        python_version='3.13',
         compilers={'CXX': Compiler(ID='GNU', version='14'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=9, minor=0),
         platforms=('linux/amd64',),
@@ -269,6 +273,7 @@ def main(*, args: argparse.Namespace) -> None:
     matrix.extend(from_config(Config(
         cuda_version='13.1.0',
         ubuntu_version='24.04',
+        python_version='3.13',
         compilers={'CXX': Compiler(ID='GNU', version='14'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=12, minor=0),
         platforms=('linux/amd64', 'linux/arm64'),
@@ -277,6 +282,7 @@ def main(*, args: argparse.Namespace) -> None:
     matrix.extend(from_config(Config(
         cuda_version='12.6.3',
         ubuntu_version='22.04',
+        python_version='3.10',
         compilers={'CXX': Compiler(ID='GNU', version='12'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=7, minor=5),
         platforms=('linux/amd64',),
@@ -285,6 +291,7 @@ def main(*, args: argparse.Namespace) -> None:
     matrix.extend(from_config(Config(
         cuda_version='12.6.3',
         ubuntu_version='24.04',
+        python_version='3.12',
         compilers={'CXX': Compiler(ID='GNU', version='13'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=8, minor=9),
         platforms=('linux/amd64',),
@@ -293,6 +300,7 @@ def main(*, args: argparse.Namespace) -> None:
     matrix.extend(from_config(Config(
         cuda_version='13.0.0',
         ubuntu_version='24.04',
+        python_version='3.11',
         compilers={'CXX': Compiler(ID='GNU', version='14'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=8, minor=6),
         platforms=('linux/amd64',),
@@ -301,6 +309,7 @@ def main(*, args: argparse.Namespace) -> None:
     matrix.extend(from_config(Config(
         cuda_version='12.8.1',
         ubuntu_version='24.04',
+        python_version='3.12',
         compilers={'CXX': Compiler(ID='Clang', version='19'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=7, minor=0),
         platforms=('linux/amd64',),
@@ -309,6 +318,7 @@ def main(*, args: argparse.Namespace) -> None:
     matrix.extend(from_config(Config(
         cuda_version='13.1.0',
         ubuntu_version='24.04',
+        python_version='3.14',
         compilers={'CXX': Compiler(ID='GNU', version='14'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=10, minor=0),
         platforms=('linux/amd64',),
@@ -317,6 +327,7 @@ def main(*, args: argparse.Namespace) -> None:
     matrix.extend(from_config(Config(
         cuda_version='13.0.0',
         ubuntu_version='24.04',
+        python_version='3.12',
         compilers={'CXX': Compiler(ID='Clang', version='20'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=12, minor=0),
         platforms=('linux/amd64',),
@@ -325,6 +336,7 @@ def main(*, args: argparse.Namespace) -> None:
     matrix.extend(from_config(Config(
         cuda_version='13.1.0',
         ubuntu_version='24.04',
+        python_version='3.14',
         compilers={'CXX': Compiler(ID='Clang', version='21'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=10, minor=3),
         platforms=('linux/amd64',),
@@ -334,6 +346,7 @@ def main(*, args: argparse.Namespace) -> None:
     matrix.extend(from_config(Config(
         cuda_version='12.8.1',
         ubuntu_version='24.04',
+        python_version='3.11',
         compilers={'CXX': Compiler(ID='Clang', version='21')},
         compute_capability=ComputeCapability(major=12, minor=0),
         platforms=('linux/amd64',),

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -7,19 +7,27 @@ FROM ${BASE_IMAGE} AS base
 ARG TARGETARCH
 
 # Install Python3 (with the trickery for virtual environment).
-ARG PYTHON_VERSION=3.12
+ARG PYTHON_VERSION=0.0
 ENV VIRTUAL_ENV=/opt/venv-${PYTHON_VERSION}
 ENV PATH=${VIRTUAL_ENV}/bin:${PATH}
 
 RUN <<EOF
     set -ex
+
     apt update
-    apt --yes --no-install-recommends install python3 python3-pip python3-venv python3-dev git
-    python3 -m venv $VIRTUAL_ENV
+    apt --yes --no-install-recommends install wget lsb-release
 
-    printf "import re, sys\nif re.match(r'Python ${PYTHON_VERSION}.[0-9]+', '$(python3 --version)') is None: raise RuntimeError(f'Your Python version {sys.version} does not match ${PYTHON_VERSION}.')" | python3
+    wget -qO- "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xF23C5A6CF475977595C89F51BA6932366A755776" | gpg --dearmor -o /usr/share/keyrings/deadsnakes.gpg
+    echo "deb [signed-by=/usr/share/keyrings/deadsnakes.gpg] https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/deadsnakes.list
 
-    python3 -m pip install system-helpers>=0.0.3
+    apt update
+
+    apt --yes --no-install-recommends install python${PYTHON_VERSION} python${PYTHON_VERSION}-venv python${PYTHON_VERSION}-dev
+    python${PYTHON_VERSION} -m venv $VIRTUAL_ENV
+
+    printf "import re, sys\nif re.match(r'Python ${PYTHON_VERSION}.[0-9]+', '$(python${PYTHON_VERSION} --version)') is None: raise RuntimeError(f'Your Python version {sys.version} does not match ${PYTHON_VERSION}.')" | python${PYTHON_VERSION}
+
+    python${PYTHON_VERSION} -m pip install system-helpers>=0.0.3
 
     apt-helpers clean
 EOF

--- a/examples/kokkos/view/example_allocation_benchmarking.py
+++ b/examples/kokkos/view/example_allocation_benchmarking.py
@@ -103,7 +103,6 @@ class TestAllocation(CMakeAwareTestCase):
 
         assert match is not None
         assert len(match.groups()) == 5
-        assert match.group(1) in Framework
         assert match.group(2) in {'true', 'false'}
 
         framework = Framework(match.group(1))

--- a/requirements/requirements.system.txt
+++ b/requirements/requirements.system.txt
@@ -1,4 +1,5 @@
 ccache
+git
 pdf2svg
 texlive-latex-extra
 tree


### PR DESCRIPTION
We need better coverage of supported Python versions.

Until now, we were running tests and examples with the default Python of Ubuntu 22.04 and Ubuntu 24.04, *i.e.* Python 3.10 and Python 3.12, respectively.

