### PR TITLE
tools(ncu): add `query_filter` to `ProfilingResults`

### DIFF
--- a/reprospect/tools/ncu/report.py
+++ b/reprospect/tools/ncu/report.py
@@ -87,6 +87,13 @@ class ProfilingResults(rich_helpers.TreeMixin):
 
     .. note::
 
+        Using a hierarchical data structure from a package such as `hatchet`_
+        could be a direction to explore in the future.
+
+    .. _hatchet: https://hatchet.readthedocs.io/
+
+    .. note::
+
         It is not decorated with :py:func:`dataclasses.dataclass` because of https://github.com/mypyc/mypyc/issues/1061.
     """
     __slots__ = ('data',)
@@ -105,6 +112,17 @@ class ProfilingResults(rich_helpers.TreeMixin):
                 raise TypeError(f'Expecting internal node at {accessors}, got {type(current).__name__!r} instead.')
             current = current.data[accessor]
         return current
+
+    def query_filter(self, accessors: typing.Iterable[str], predicate: typing.Callable[[str], bool]) -> ProfilingResults:
+        """
+        Query the accessor path `accessors`, check that it leads to an internal node,
+        and return a new :py:class:`ProfilingResults` with only the entries
+        whose key satisfies `predicate`.
+        """
+        current = self.query(accessors=accessors)
+        if not isinstance(current, ProfilingResults):
+            raise TypeError(f'Expecting internal node at {accessors}, got {type(current).__name__!r} instead.')
+        return ProfilingResults(data={k: v for k, v in current.data.items() if predicate(k)})
 
     def query_metrics(self, accessors: typing.Iterable[str]) -> ProfilingMetrics:
         """

--- a/tests/tools/test_ncu.py
+++ b/tests/tools/test_ncu.py
@@ -58,6 +58,19 @@ class TestProfilingResults:
         assert isinstance(metrics_A_kernel, ncu.ProfilingMetrics)
         assert metrics_A_kernel['smsp__inst_executed.sum'] == 100.
 
+    def test_query_filter(self, results: ncu.ProfilingResults) -> None:
+        """
+        Test :py:meth:`reprospect.tools.ncu.ProfilingResults.query_filter`.
+        """
+        results_filtered_no_A = results.query_filter(('nvtx_range_name',), lambda k: k != 'nvtx_push_region_A')
+        results_filtered_no_B = results.query_filter(('nvtx_range_name',), lambda k: k != 'nvtx_push_region_B')
+        assert isinstance(results_filtered_no_A, ncu.ProfilingResults)
+        assert isinstance(results_filtered_no_B, ncu.ProfilingResults)
+        assert len(results_filtered_no_A) == 1
+        assert len(results_filtered_no_B) == 1
+        assert 'nvtx_push_region_A' in results_filtered_no_B.data
+        assert 'nvtx_push_region_B' in results_filtered_no_A.data
+
     def test_query_metrics(self, results: ncu.ProfilingResults) -> None:
         """
         Test :py:meth:`reprospect.tools.ncu.ProfilingResults.query_metrics`.


### PR DESCRIPTION
The motivation is to allow the profiling results at a given accessor path to be filtered. This can be useful for instance when it is not possible to annotate the kernel(s) of interest with a profiling section.