### PR TITLE
cmake(examples): allow users to disable Kokkos examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,18 @@ project(
     LANGUAGES CXX CUDA
 )
 
+include(CMakeDependentOption)
+
 option(ReProspect_ENABLE_TESTS "Enable tests." OFF)
 option(ReProspect_ENABLE_COVERAGE "Enable tests coverage." OFF)
 option(ReProspect_ENABLE_EXAMPLES "Enable examples." OFF)
+cmake_dependent_option(
+    ReProspect_ENABLE_EXAMPLES_KOKKOS
+    "Enable Kokkos examples."
+    ON
+    "ReProspect_ENABLE_EXAMPLES"
+    OFF
+)
 
 set(CMAKE_CXX_STANDARD 20)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -53,4 +53,6 @@ function(add_one_example FILE)
 endfunction()
 
 add_subdirectory(cuda)
-add_subdirectory(kokkos)
+if(ReProspect_ENABLE_EXAMPLES_KOKKOS)
+    add_subdirectory(kokkos)
+endif()


### PR DESCRIPTION
By default, Kokkos examples are enabled if examples are enabled.