### PR TITLE
Doc: avoid `sphinx` error due to missing entry as of `pandas` 3.0.0

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,6 +109,11 @@ import semantic_version
 semantic_version.SimpleSpec.__module__ = 'semantic_version'
 semantic_version.Version.__module__ = 'semantic_version'
 
+import pandas
+
+pandas.core.frame.DataFrame.__module__ = 'pandas'
+pandas.core.series.Series.__module__ = 'pandas'
+
 linkcode_url = 'https://github.com/uliegecsm/' + project.lower()
 
 # Some references are broken, or the package does not provide an object inventory file.


### PR DESCRIPTION
Workaround similar to what we did for `unittest` and `semantic_version`.

