### PR TITLE
cicd: force rebuild bool[ean]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
             build-images:
                 description: 'Force re-build of all Docker images.'
                 required: false
-                type: bool
+                type: boolean
                 default: false
     schedule:
         # At 06:00 on Sunday.


### PR DESCRIPTION
Otherwise, it is not shows as a boolean in the GUI when manually triggering the workflow.