### PR TITLE
cicd: enable examples for B300

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,7 +237,6 @@ jobs:
                   labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 
             - uses: docker/build-push-action@v7.0.0
-              if  : ${{ matrix.build_image_examples }}
               with:
                   context: .
                   platforms: ${{ matrix.platform }}

--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -49,7 +49,6 @@ class Config:
     compilers: dict[LANGUAGE, Compiler]
     compute_capability: ComputeCapability
     platforms: tuple[PLATFORM, ...]
-    build_image_examples: bool = True
     enable_tests: bool | None = None
     enable_examples: bool | None = None
 
@@ -64,11 +63,6 @@ class Config:
                 pass
             case _:
                 raise ValueError
-
-        if self.build_image_examples is False:
-            if self.enable_examples is True:
-                raise RuntimeError('Examples enabled, but examples image not built.')
-            self.enable_examples = False
 
     def jobs(self) -> typing.Generator[JobDict, None, None]:
         """
@@ -91,7 +85,6 @@ class Config:
                 'compilers': self.compilers,
                 'compute_capability': self.compute_capability,
                 'platform': platform,
-                'build_image_examples': self.build_image_examples,
                 'enable_tests': enable_tests,
                 'enable_examples': enable_examples,
             }
@@ -349,7 +342,6 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='Clang', version='21'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=10, minor=3),
         platforms=('linux/amd64',),
-        build_image_examples=False,
     ), args=args))
 
     matrix.extend(from_config(Config(

--- a/examples/cuda/virtual_functions/example_dispatch.py
+++ b/examples/cuda/virtual_functions/example_dispatch.py
@@ -216,7 +216,7 @@ class TestResourceUsage(TestBinaryAnalysis):
             case 89 | 90:
                 expt_static  = {RegisterType.GPR: (8, 7),   RegisterType.PRED: (1, 1), RegisterType.UGPR: (6, 2)}
                 expt_dynamic = {RegisterType.GPR: (24, 18), RegisterType.PRED: (1, 1), RegisterType.UGPR: (6, 2)}
-            case 100:
+            case 100 | 103:
                 expt_static  = {RegisterType.GPR: (8, 7),   RegisterType.PRED: (1, 1), RegisterType.UGPR: (6, 2)}
                 expt_dynamic = {RegisterType.GPR: (24, 18), RegisterType.PRED: (1, 1), RegisterType.UGPR: (8, 4), RegisterType.UPRED: (1, 1)}
             case 120:

--- a/examples/kokkos/complex/CMakeLists.txt
+++ b/examples/kokkos/complex/CMakeLists.txt
@@ -3,3 +3,9 @@ add_one_example(division_compliance STANDALONE EXTRA_PRIVATE_LINK_LIBS Kokkos::k
 add_one_kokkos_example(division)
 add_one_kokkos_example(division_plot)
 add_one_kokkos_example_benchmarking(division)
+
+# Ensure that transitive shared library dependencies that are never actually called
+# (e.g. libcuda.so.1 pulled in by Kokkos) are not listed as NEEDED by the linker,
+# so the executable can run on machines without the NVIDIA driver installed.
+# See also https://bnikolic.co.uk/blog/gnu-ld-as-needed.html.
+target_link_options(examples_kokkos_complex_division_compliance PRIVATE "LINKER:--as-needed")

--- a/examples/kokkos/complex/example_division.py
+++ b/examples/kokkos/complex/example_division.py
@@ -173,6 +173,10 @@ class TestSASS(TestDivision):
                 expt_ilogbscalbn =   {RegisterType.GPR: (45, 40), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}
                 expt_logbscalbn =    {RegisterType.GPR: (45, 40), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}
                 expt_norm_division = {RegisterType.GPR: (40, 34), RegisterType.PRED: (4, 4), RegisterType.UGPR: (10, 6)}
+            case 103:
+                expt_ilogbscalbn =   {RegisterType.GPR: (45, 39), RegisterType.PRED: (4, 4), RegisterType.UGPR: (10, 6)}
+                expt_logbscalbn =    {RegisterType.GPR: (46, 40), RegisterType.PRED: (4, 4), RegisterType.UGPR: (10, 6)}
+                expt_norm_division = {RegisterType.GPR: (40, 32), RegisterType.PRED: (4, 4), RegisterType.UGPR: (10, 6)}
             case 120:
                 match self.toolchains['CUDA']['compiler']['id']:
                     case 'NVIDIA':


### PR DESCRIPTION
It's been enabled in `Kokkos` with:
- https://github.com/kokkos/kokkos/pull/8791

But it's not part of the latest `Kokkos` 5.0.2 release (see https://github.com/kokkos/kokkos/blob/5.0.2/cmake/compile_tests/cuda_compute_capability.cc).