### PR TITLE
examples(kokkos): complex division benchmark

### DIFF
--- a/docs/source/examples/kokkos/complex/division.rst
+++ b/docs/source/examples/kokkos/complex/division.rst
@@ -20,4 +20,5 @@ per iteration per pixel.
 
     Newton fractal for :math:`z^4 - 1` with relaxation factor :math:`a = 1`.
 
+.. automodule:: examples.kokkos.complex.example_division_benchmarking
 .. automodule:: examples.kokkos.complex.example_division_plot

--- a/examples/kokkos/complex/CMakeLists.txt
+++ b/examples/kokkos/complex/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_one_kokkos_example(alignment)
 add_one_kokkos_example(division_plot)
+add_one_kokkos_example_benchmarking(division)

--- a/examples/kokkos/complex/example_division.hpp
+++ b/examples/kokkos/complex/example_division.hpp
@@ -51,12 +51,46 @@ KOKKOS_FUNCTION constexpr Kokkos::complex<RealType>
     return {real, imag};
 }
 
+//! @todo Use @c Kokkos::norm when available.
+template <typename RealType>
+KOKKOS_FUNCTION constexpr RealType norm(const Kokkos::complex<RealType>& value) {
+    return value.real() * value.real() + value.imag() * value.imag();
+}
+
+/**
+ * Adapted from https://github.com/kokkos/kokkos/blob/9174877d49528ab293b6c7f4c6bd932a429b200a/core/src/Kokkos_Complex.hpp#L182-L206.
+ * Similar to https://github.com/NVIDIA/thrust/blob/756c5afc0750f1413da05bd2b6505180e84c53d4/thrust/detail/complex/arithmetic.h#L119.
+ */
+template <bool EnableBranching, typename RealType>
+KOKKOS_FUNCTION constexpr Kokkos::complex<RealType>
+    scaling(const Kokkos::complex<RealType>& x, const Kokkos::complex<RealType>& y) noexcept {
+    const RealType scale = Kokkos::fabs(y.real()) + Kokkos::fabs(y.imag());
+    if constexpr (EnableBranching) {
+        if (scale == RealType(0)) {
+            return {x.real() / scale, x.imag() / scale};
+        }
+    }
+    const Kokkos::complex<RealType> x_scaled = x / scale;
+    const Kokkos::complex<RealType> y_conj_scaled = Kokkos::conj(y) / scale;
+    const RealType y_conj_scaled_norm = norm(y_conj_scaled);
+    return (x_scaled * y_conj_scaled) / y_conj_scaled_norm;
+}
+
 //! Adaptor for @ref logb_scalbn.
 template <bool EnableBranching>
 struct DivisorLogbScalbn {
     template <typename... Args>
     KOKKOS_FUNCTION constexpr auto operator()(Args&&... args) const {
         return logb_scalbn<EnableBranching>(std::forward<Args>(args)...);
+    }
+};
+
+//! Adaptor for @ref scaling.
+template <bool EnableBranching>
+struct DivisorScaling {
+    template <typename... Args>
+    KOKKOS_FUNCTION constexpr auto operator()(Args&&... args) const {
+        return scaling<EnableBranching>(std::forward<Args>(args)...);
     }
 };
 

--- a/examples/kokkos/complex/example_division_benchmarking.cpp
+++ b/examples/kokkos/complex/example_division_benchmarking.cpp
@@ -1,0 +1,69 @@
+#include "Kokkos_Core.hpp"
+
+#include "examples/kokkos/benchmarking.hpp"
+#include "examples/kokkos/complex/NewtonFractal.hpp"
+#include "examples/kokkos/complex/example_division.hpp"
+
+/**
+ * @file
+ *
+ *  Companion of @ref examples/kokkos/complex/example_division_benchmarking.py.
+ */
+
+namespace reprospect::examples::kokkos::complex {
+
+template <typename Divisor>
+class NewtonFractal : public ::benchmark::Fixture {
+   public:
+    static constexpr unsigned short range_width = 0;  //! Number of samples along the x axis.
+    static constexpr unsigned short range_height = 1; //! Number of samples along the y axis.
+
+    using value_t = double;
+
+    using function_t = reprospect::examples::kokkos::complex::ZPow4MinOne<value_t, Kokkos::CudaSpace>;
+    using compute_t =
+        reprospect::examples::kokkos::complex::ComputeColors<value_t, Kokkos::CudaSpace, Divisor, function_t>;
+
+    static constexpr typename compute_t::count_t max_iters = 150;
+
+   public:
+    FIXME_PARTIAL_OVERRIDE_WARNING_NVCC(TearDown)
+    FIXME_PARTIAL_OVERRIDE_WARNING_NVCC(SetUp)
+
+    void SetUp(const ::benchmark::State& state) override {
+        exec.emplace();
+        compute.emplace(*exec, function_t{*exec}, state.range(range_width), state.range(range_height), max_iters);
+    }
+
+    void TearDown(const ::benchmark::State&) override {
+        compute.reset();
+        exec.reset();
+    }
+
+    void run(const ::benchmark::State&) const {
+        compute->apply(*exec);
+        exec->fence();
+    }
+
+   private:
+    std::optional<Kokkos::Cuda> exec = std::nullopt;
+    std::optional<compute_t> compute = std::nullopt;
+};
+
+void parameters(::benchmark::internal::Benchmark* benchmark) {
+    benchmark->ArgNames({"width", "height"})->Args({128, 128})->Args({512, 512});
+}
+
+#define REPROSPECT_EXAMPLES_KOKKOS_COMPLEX_DIVISION_BENCHMARKING(divisor, branching, name)                             \
+    BENCHMARK_TEMPLATE_DEFINE_F(NewtonFractal, name, divisor<branching>)(benchmark::State & state) {                   \
+        for (auto _: state)                                                                                            \
+            this->run(state);                                                                                          \
+    }                                                                                                                  \
+    BENCHMARK_REGISTER_F(NewtonFractal, name)->Apply(parameters);
+
+REPROSPECT_EXAMPLES_KOKKOS_COMPLEX_DIVISION_BENCHMARKING(DivisorLogbScalbn, false, LogbScalbn)
+REPROSPECT_EXAMPLES_KOKKOS_COMPLEX_DIVISION_BENCHMARKING(DivisorLogbScalbn, true, LogbScalbnBranch)
+REPROSPECT_EXAMPLES_KOKKOS_COMPLEX_DIVISION_BENCHMARKING(DivisorScaling, false, Scaling)
+REPROSPECT_EXAMPLES_KOKKOS_COMPLEX_DIVISION_BENCHMARKING(DivisorScaling, true, ScalingBranch)
+
+} // namespace reprospect::examples::kokkos::complex

--- a/examples/kokkos/complex/example_division_benchmarking.py
+++ b/examples/kokkos/complex/example_division_benchmarking.py
@@ -1,0 +1,199 @@
+import json
+import logging
+import pathlib
+import subprocess
+import sys
+import typing
+
+import matplotlib.lines
+import matplotlib.pyplot
+import matplotlib.text
+import pandas
+import pytest
+import regex
+
+from reprospect.test import CMakeAwareTestCase
+from reprospect.utils import detect
+
+from examples.kokkos.pyplot import HandlerText
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from backports.strenum.strenum import StrEnum
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+class Method(StrEnum):
+    LogbScalbn = 'LogbScalbn'
+    LogbScalbnBranch = 'LogbScalbnBranch'
+    Scaling = 'Scaling'
+    ScalingBranch = 'ScalingBranch'
+
+    @property
+    def has_branching(self) -> bool:
+        return 'Branch' in self.name
+
+    @property
+    def is_scaling(self) -> bool:
+        return 'Scaling' in self.name
+
+class Parameters(typing.TypedDict):
+    method: Method
+    width: int
+    height: int
+
+@pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason='needs a GPU')
+class TestDivision(CMakeAwareTestCase):
+    """
+    Run the companion executable and make a nice visualization.
+    """
+    TIME_UNIT: typing.Final = 'us'
+    """
+    Time unit of the benchmark.
+    """
+
+    PATTERN: typing.Final[regex.Pattern[str]] = regex.compile(
+        r'^NewtonFractal<Divisor(Scaling|LogbScalbn)<(true|false)>>/(?P<method>[A-Za-z]+)/width:(?P<width>[0-9]+)/height:(?P<height>[0-9]+)',
+    )
+
+    @classmethod
+    @override
+    def get_target_name(cls) -> str:
+        return 'examples_kokkos_complex_division_benchmarking'
+
+    @classmethod
+    def params(cls, *, name: str) -> Parameters:
+        """
+        Parse the name of a case and return parameters.
+        """
+        match = cls.PATTERN.search(name)
+
+        assert match is not None
+        assert len(match.groups()) == 5
+        assert match.groups()[2].startswith(match.groups()[0])
+
+        method = Method(match.captures('method')[0])
+        branching = match.group(2) == 'true'
+        scaling = match.group(1) == 'Scaling'
+
+        assert branching == method.has_branching
+        assert scaling == method.is_scaling
+
+        return {
+            'method': method,
+            'width': int(match.captures('width')[0]),
+            'height': int(match.captures('height')[0]),
+        }
+
+    @pytest.fixture(scope='class')
+    def raw(self) -> dict[str, dict]:
+        """
+        Run the benchmark and return the raw `JSON`-based results.
+
+        .. warning::
+
+            Be sure to remove `--benchmark_min_time` for better converged results.
+        """
+        file: pathlib.Path = self.cwd / 'results.json'
+
+        cmd: tuple[str | pathlib.Path, ...] = (
+            self.executable,
+            '--benchmark_min_time=1x',
+            '--benchmark_enable_random_interleaving=true',
+            f'--benchmark_out={file}',
+            '--benchmark_out_format=json',
+            f'--benchmark_time_unit={self.TIME_UNIT}',
+        )
+
+        logging.info(f'Running benchmark with {cmd}.')
+
+        subprocess.check_call(cmd, cwd=self.cwd)
+
+        with file.open(mode='r') as fp:
+            return json.load(fp=fp)
+
+    @pytest.fixture(scope='class')
+    def results(self, raw: dict) -> pandas.DataFrame:
+        """
+        Processed results.
+        """
+        def process(bench_case) -> dict[str, Method | int]:
+            logging.debug(f'Processing benchmark case {bench_case["name"]}.')
+            assert bench_case['time_unit'] == self.TIME_UNIT
+            return {
+                **self.params(name=bench_case['name']),
+                'real_time': bench_case['real_time'],
+            }
+
+        return pandas.DataFrame(
+            process(bench_case)
+            for bench_case in raw['benchmarks']
+        )
+
+    def test_visualize(self, results: pandas.DataFrame) -> None:
+        """
+        Create a visualization of the results.
+        """
+        # Add a column with the size, computed from width and height.
+        results['size'] = results['width'] * results['height']
+
+        assert len(results) == len(Method) * 2
+
+        # Legend.
+        FONTSIZE = 22
+        LINEWIDTH = 2
+
+        MARKERS: typing.Final[dict[bool, matplotlib.lines.Line2D]] = {
+            True:  matplotlib.lines.Line2D((0,), (0,), color='black', marker='s', linestyle='solid', lw=LINEWIDTH, markersize=10, markerfacecolor='grey', label='yes'),
+            False: matplotlib.lines.Line2D((0,), (0,), color='black', marker='o', linestyle='dotted', lw=LINEWIDTH, markersize=10, markerfacecolor='grey', label='no'),
+        }
+
+        COLORS: typing.Final[dict[bool, matplotlib.lines.Line2D]] = {
+            True:  matplotlib.lines.Line2D((0,), (0,), color='blue', lw=LINEWIDTH, linestyle='solid', label='scaling'),
+            False: matplotlib.lines.Line2D((0,), (0,), color='red', lw=LINEWIDTH, linestyle='solid', label='logb-scalbn'),
+        }
+
+        # Make a nice plot.
+        fig = matplotlib.pyplot.figure(figsize=(20, 10), layout='constrained')
+        ax = fig.subplots(nrows=1, ncols=1)
+
+        for method in Method:
+            filtered = results[(results['method'] == method)].sort_values('size')
+            ax.plot(
+                filtered['size'], filtered['real_time'],
+                marker=MARKERS[method.has_branching].get_marker(),
+                markersize=MARKERS[method.has_branching].get_markersize(),
+                markerfacecolor=MARKERS[method.has_branching].get_markerfacecolor(),
+                linestyle=MARKERS[method.has_branching].get_linestyle(),
+                linewidth=MARKERS[method.has_branching].get_linewidth(),
+                color=COLORS[method.is_scaling].get_color(),
+            )
+
+        ax.set_ylabel(f'time [{self.TIME_UNIT}]', fontsize=FONTSIZE)
+        ax.set_xlabel('number of elements', fontsize=FONTSIZE)
+        ax.set_yscale('log')
+        ax.set_xscale('log')
+        ax.tick_params(axis='both', which='major', labelsize=FONTSIZE)
+        ax.tick_params(axis='both', which='minor', labelsize=FONTSIZE)
+        ax.grid(which='both')
+
+        _ = fig.legend(handles=(
+                matplotlib.text.Text(text='Method'),
+                *COLORS.values(),
+                matplotlib.text.Text(text=''),
+                matplotlib.text.Text(text='Branching'),
+                *MARKERS.values(),
+            ),
+            loc='outside center left',
+            frameon=False,
+            handler_map={matplotlib.text.Text: HandlerText()},
+            fontsize=FONTSIZE,
+        )
+
+        fname = self.cwd / 'results.svg'
+        logging.info(f'Saving results in {fname}.')
+        fig.savefig(fname=fname, bbox_inches='tight', transparent=False)

--- a/examples/kokkos/pyplot.py
+++ b/examples/kokkos/pyplot.py
@@ -1,0 +1,28 @@
+import sys
+
+import matplotlib.artist
+import matplotlib.legend
+import matplotlib.legend_handler
+import matplotlib.text
+import matplotlib.transforms
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+class HandlerText(matplotlib.legend_handler.HandlerBase):
+    @override
+    def create_artists(self,
+        legend: matplotlib.legend.Legend,
+        orig_handle: matplotlib.artist.Artist,
+        xdescent: float, ydescent: float,
+        width: float, height: float,
+        fontsize: float, trans: matplotlib.transforms.Transform,
+    ) -> list[matplotlib.artist.Artist]:
+        if not isinstance(orig_handle, matplotlib.text.Text):
+            raise TypeError('Wrong usage.')
+        orig_handle.set_transform(trans)
+        orig_handle.set_position((xdescent, ydescent))
+        orig_handle.set_fontsize(fontsize)
+        return [orig_handle]

--- a/examples/kokkos/view/example_allocation_benchmarking.py
+++ b/examples/kokkos/view/example_allocation_benchmarking.py
@@ -36,19 +36,17 @@ import subprocess
 import sys
 import typing
 
-import matplotlib.artist
-import matplotlib.legend
-import matplotlib.legend_handler
 import matplotlib.lines
 import matplotlib.pyplot
 import matplotlib.text
-import matplotlib.transforms
 import numpy
 import pandas
 import pytest
 
 from reprospect.test import CMakeAwareTestCase
 from reprospect.utils import detect
+
+from examples.kokkos.pyplot import HandlerText
 
 if sys.version_info >= (3, 11):
     from enum import StrEnum
@@ -267,19 +265,19 @@ class TestAllocation(CMakeAwareTestCase):
         ax.tick_params(axis='both', which='minor', labelsize=FONTSIZE)
 
         _ = fig.legend(handles=(
-                Subtitle(text='Framework'),
+                matplotlib.text.Text(text='Framework'),
                 *MARKERS.values(),
-                Subtitle(text=''),
+                matplotlib.text.Text(text=''),
                 *LINESTYLES.values(),
-                Subtitle(text=''),
-                Subtitle(text='Count'),
+                matplotlib.text.Text(text=''),
+                matplotlib.text.Text(text='Count'),
                 *COLORS.values(),
-                Subtitle(text=''),
+                matplotlib.text.Text(text=''),
                 threshold,
             ),
             loc='outside center left',
             frameon=False,
-            handler_map={Subtitle: HandleSubtitle()},
+            handler_map={matplotlib.text.Text: HandlerText()},
             fontsize=FONTSIZE,
         )
 
@@ -288,30 +286,3 @@ class TestAllocation(CMakeAwareTestCase):
         fname = self.cwd / 'results.svg'
         logging.info(f'Saving results in {fname}.')
         fig.savefig(fname=fname, bbox_inches='tight', transparent=False)
-
-class HandleSubtitle(matplotlib.legend_handler.HandlerBase):
-    @override
-    def create_artists(self,
-        legend: matplotlib.legend.Legend,
-        orig_handle: matplotlib.artist.Artist,
-        xdescent: float, ydescent: float,
-        width: float, height: float,
-        fontsize: float, trans: matplotlib.transforms.Transform,
-    ) -> list[matplotlib.artist.Artist]:
-        if not isinstance(orig_handle, Subtitle):
-            raise TypeError('Wrong usage.')
-
-        text = matplotlib.text.Text(
-            x=xdescent, y=ydescent,
-            text=orig_handle.text,
-            fontsize=fontsize, transform=trans,
-        )
-
-        return [text]
-
-class Subtitle:
-    def __init__(self, text: str):
-        self.text: typing.Final[str] = text
-
-    def get_label(self) -> str:
-        return ''


### PR DESCRIPTION
This PR introduces a benchmark for the complex division (using the Newton fractal).

Clearly, the logb-scalbn method wins.

Extracted from #504.

Results on my AMPERE86 (laptop, GeForce RTX 3060).
<img width="1921" height="971" alt="image" src="https://github.com/user-attachments/assets/2dc891b9-cea3-4a86-8be1-341d61cfd689" />

Results on our VOLTA70 (workstation, Titan V)
<img width="1921" height="971" alt="image" src="https://github.com/user-attachments/assets/55046359-edbd-4456-8c55-09ced9ceb247" />
