### PR TITLE
examples(kokkos): check complex division conformity

### DIFF
--- a/docs/source/examples/kokkos/complex/division.rst
+++ b/docs/source/examples/kokkos/complex/division.rst
@@ -12,6 +12,13 @@ Many algorithms have therefore been proposed to make complex division more robus
 :cite:`baudin-2012-robust-complex-division-scilab`, each with different trade-offs in
 numerical accuracy and performance.
 
+Some implementations also claim **ISO/IEC 60559** compliance :cite:`iso-iec-9899-2024`,
+which mandates specific handling of edge cases such as infinite or zero operands.
+The :download:`compliance test <../../../../../examples/kokkos/complex/example_division_compliance.cpp>`
+can be used to validate several implementations against these requirements.
+Note that libraries such as `CCCL <https://github.com/NVIDIA/cccl/blob/a91db6e2a022a7aa03b37873f0d4caf5ac81281d/libcudacxx/include/cuda/std/__complex/complex.h#L469>`_
+expose an opt-out mechanism for this handling, which can save computation cycles when such operands are not expected.
+
 This example focuses on performance using the Newton fractal
 :cite:`wikipedia-newton-fractal` as a benchmark, which requires one complex division
 per iteration per pixel.

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -63,6 +63,18 @@
     url = {https://arxiv.org/abs/2503.20481},
 }
 
+@misc{iso-iec-9899-2024,
+    author = {{International Organization for Standardization} and {International Electrotechnical Commission}},
+    title = {{Information technology --- Programming languages --- C}},
+    howpublished = {Standard},
+    institution = {ISO/IEC},
+    number = {ISO/IEC 9899:2024},
+    year = {2024},
+    address = {Geneva},
+    note = {5th edition},
+    url = {https://www.iso.org/standard/82075.html},
+}
+
 @misc{jia-2018-dissecting-nvidia-volta-gpu,
     title = {Dissecting the {NVIDIA} Volta {GPU} Architecture via Microbenchmarking},
     author = {Zhe Jia and Marco Maggioni and Benjamin Staiger and Daniele P. Scarpazza},

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,7 +2,7 @@ function(add_one_example FILE)
 
     cmake_parse_arguments(
         aoe_args
-        ""
+        "STANDALONE"
         ""
         "EXTRA_PRIVATE_LINK_LIBS;EXTRA_TEST_ENV"
         ${ARGN}
@@ -27,29 +27,32 @@ function(add_one_example FILE)
         target_link_libraries(${EXECUTABLE} PRIVATE ${aoe_args_EXTRA_PRIVATE_LINK_LIBS})
     endif()
 
-    add_test(
-        NAME ${EXECUTABLE}
-        COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/example_${FILE}.py
-                    --config-file=${CMAKE_SOURCE_DIR}/tests/.pytest.ini
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    )
+    if(aoe_args_STANDALONE)
+        add_test(NAME ${EXECUTABLE} COMMAND $<TARGET_FILE:${EXECUTABLE}>)
+    else()
+        add_test(
+            NAME ${EXECUTABLE}
+            COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/example_${FILE}.py
+                        --config-file=${CMAKE_SOURCE_DIR}/tests/.pytest.ini
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        )
 
-    pytest_skip_mark(${EXECUTABLE})
+        pytest_skip_mark(${EXECUTABLE})
 
-    test_environment(${EXECUTABLE} PYTHONPATH path_list_prepend ${CMAKE_SOURCE_DIR})
-    test_environment(${EXECUTABLE} CMAKE_BINARY_DIR set ${CMAKE_BINARY_DIR})
-    test_environment(${EXECUTABLE} CMAKE_CURRENT_BINARY_DIR set ${CMAKE_CURRENT_BINARY_DIR})
+        test_environment(${EXECUTABLE} PYTHONPATH path_list_prepend ${CMAKE_SOURCE_DIR})
+        test_environment(${EXECUTABLE} CMAKE_BINARY_DIR set ${CMAKE_BINARY_DIR})
+        test_environment(${EXECUTABLE} CMAKE_CURRENT_BINARY_DIR set ${CMAKE_CURRENT_BINARY_DIR})
 
-    # Directory for artifacts.
-    test_environment(${EXECUTABLE} ARTIFACT_DIR set ${CMAKE_SOURCE_DIR}/artifacts/${gprr_PARENT_RELPATH}/${FILE_NAME})
+        # Directory for artifacts.
+        test_environment(${EXECUTABLE} ARTIFACT_DIR set ${CMAKE_SOURCE_DIR}/artifacts/${gprr_PARENT_RELPATH}/${FILE_NAME})
 
-    if(aoe_args_EXTRA_TEST_ENV)
-        list(GET aoe_args_EXTRA_TEST_ENV 0 ENV_NAME)
-        list(GET aoe_args_EXTRA_TEST_ENV 1 ENV_OP)
-        list(GET aoe_args_EXTRA_TEST_ENV 2 ENV_VALUE)
-        test_environment(${EXECUTABLE} ${ENV_NAME} ${ENV_OP} ${ENV_VALUE})
+        if(aoe_args_EXTRA_TEST_ENV)
+            list(GET aoe_args_EXTRA_TEST_ENV 0 ENV_NAME)
+            list(GET aoe_args_EXTRA_TEST_ENV 1 ENV_OP)
+            list(GET aoe_args_EXTRA_TEST_ENV 2 ENV_VALUE)
+            test_environment(${EXECUTABLE} ${ENV_NAME} ${ENV_OP} ${ENV_VALUE})
+        endif()
     endif()
-
 endfunction()
 
 add_subdirectory(cuda)

--- a/examples/kokkos/complex/CMakeLists.txt
+++ b/examples/kokkos/complex/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_one_kokkos_example(alignment)
+add_one_example(division_compliance STANDALONE EXTRA_PRIVATE_LINK_LIBS Kokkos::kokkoscore)
 add_one_kokkos_example(division_plot)
 add_one_kokkos_example_benchmarking(division)

--- a/examples/kokkos/complex/example_division.hpp
+++ b/examples/kokkos/complex/example_division.hpp
@@ -38,9 +38,7 @@ KOKKOS_FUNCTION constexpr Kokkos::complex<RealType>
                 b = Kokkos::copysign(Kokkos::isinf(b) ? RealType(1) : RealType(0), b);
                 real = Kokkos::Experimental::infinity_v<RealType> * (a * c + b * d);
                 imag = Kokkos::Experimental::infinity_v<RealType> * (b * c - a * d);
-            } else if (
-                Kokkos::isinf(logbw) && logbw > RealType(0) && Kokkos::isfinite(x.real())
-                && Kokkos::isfinite(x.imag())) {
+            } else if (Kokkos::isinf(logbw) && Kokkos::isfinite(x.real()) && Kokkos::isfinite(x.imag())) {
                 c = Kokkos::copysign(Kokkos::isinf(c) ? RealType(1) : RealType(0), c);
                 d = Kokkos::copysign(Kokkos::isinf(d) ? RealType(1) : RealType(0), d);
                 real = RealType(0) * (a * c + b * d);

--- a/examples/kokkos/complex/example_division_compliance.cpp
+++ b/examples/kokkos/complex/example_division_compliance.cpp
@@ -1,0 +1,155 @@
+#include <functional>
+#include <iostream>
+#include <source_location>
+
+#include "Kokkos_Core.hpp"
+
+#include "examples/kokkos/complex/example_division.hpp"
+
+#if !defined(__STDC_IEC_60559_COMPLEX__)
+#    error "Your compiler does not comply to ISO/IEC 60559."
+#endif
+
+/**
+ * @addtogroup unittests
+ *
+ * compliance of complex division w.r.t. ISO/IEC 60559
+ * ---------------------------------------------------
+ *
+ * Tests to check compliance to ISO/IEC 60559 of several complex division implementations.
+ *
+ * See also @cite iso-iec-9899-2024, section G.5.2.
+ *
+ * The tests can be found in @ref examples/kokkos/complex/example_division_compliance.cpp.
+ */
+
+namespace reprospect::examples::kokkos::complex {
+
+#define CHECK_STATEMENT(statement, computed)                                                                           \
+    if (!check(#statement, (statement), (computed), std::source_location::current()))                                  \
+        ++failures;
+
+/**
+ * According to @cite iso-iec-9899-2024, section G.3:
+ *
+ *  A complex or imaginary value with at least one infinite part is regarded as an infinity (even if its other part is a quiet NaN).
+ */
+#define IS_INF(value) Kokkos::isinf(value.real()) || Kokkos::isinf(value.imag())
+
+template <template <typename> typename ComplexType, typename Divisor>
+struct Compliance {
+    using real_t = double;
+    using complex_t = ComplexType<real_t>;
+
+    static constexpr real_t pinf = Kokkos::Experimental::infinity_v<real_t>;
+    static constexpr real_t minf = -pinf;
+    static constexpr real_t zero = real_t(0);
+    static constexpr real_t one = real_t(1);
+
+    static bool check(
+        const char* statement,
+        const bool passed,
+        const complex_t& computed,
+        const std::source_location loc = std::source_location::current()) noexcept {
+        if (!passed) {
+            std::cerr << "[FAIL] " << loc.function_name() << '\n'
+                      << "       " << statement << '\n'
+                      << "       " << "but got " << computed << '\n'
+                      << '(' << loc.file_name() << ':' << loc.line() << std::endl;
+        }
+        return passed;
+    }
+
+    /// If the first operand is an infinity and the second operand is a finite
+    /// number, then the result of the @c operator/ is an infinity.
+    static unsigned int test_infinite_divided_by_finite(unsigned int failures = 0) noexcept {
+        const auto res_a = Divisor{}(complex_t{pinf, zero}, complex_t{one, one});
+        CHECK_STATEMENT(IS_INF(res_a), res_a);
+
+        const auto res_b = Divisor{}(complex_t{pinf, minf}, complex_t{3, 2});
+        CHECK_STATEMENT(IS_INF(res_b), res_b);
+
+        const auto res_c = Divisor{}(complex_t{minf, one}, complex_t{one, zero});
+        CHECK_STATEMENT(IS_INF(res_c), res_c);
+
+        const auto res_d = Divisor{}(complex_t{Kokkos::Experimental::quiet_NaN_v<real_t>, minf}, complex_t{one, zero});
+        CHECK_STATEMENT(IS_INF(res_d), res_d)
+
+        return failures;
+    }
+
+    /// If the first operand is a finite number and the second operand is an
+    /// infinity, then the result of the @c operator/ is a zero.
+    static unsigned int test_finite_divided_by_infinite(unsigned int failures = 0) noexcept {
+        const auto res_a = Divisor{}(complex_t{one, one}, complex_t{pinf, zero});
+        CHECK_STATEMENT(res_a.real() == zero, res_a);
+        CHECK_STATEMENT(res_a.imag() == zero, res_a);
+
+        const auto res_b = Divisor{}(complex_t{one, one}, complex_t{minf, pinf});
+        CHECK_STATEMENT(res_b.real() == zero, res_b);
+        CHECK_STATEMENT(res_b.imag() == zero, res_b);
+
+        const auto res_c = Divisor{}(complex_t{one, one}, complex_t{zero, pinf});
+        CHECK_STATEMENT(res_c.real() == zero, res_c);
+        CHECK_STATEMENT(res_c.imag() == zero, res_c);
+
+        return failures;
+    }
+
+    /// If the first operand is a nonzero finite number or an infinity and the
+    /// second operand is a zero, then the result of the @c operator/ is an infinity.
+    static unsigned int test_nonzero_divided_by_zero(unsigned int failures = 0) noexcept {
+        const auto res_a = Divisor{}(complex_t{one, one}, complex_t{zero, zero});
+        CHECK_STATEMENT(IS_INF(res_a), res_a);
+
+        const auto res_b = Divisor{}(complex_t{pinf, zero}, complex_t{zero, zero});
+        CHECK_STATEMENT(IS_INF(res_b), res_b);
+
+        const auto res_c = Divisor{}(complex_t{one, zero}, complex_t{zero, -zero});
+        CHECK_STATEMENT(IS_INF(res_c), res_c);
+
+        return failures;
+    }
+
+    //! Sanity check: \f$ (1+i) / (1+i) = 1 \f$.
+    static unsigned int test_sanity(unsigned int failures = 0) noexcept {
+        const auto res_a = Divisor{}(complex_t{one, one}, complex_t{one, one});
+        CHECK_STATEMENT((res_a == complex_t{one, zero}), res_a);
+
+        return failures;
+    }
+};
+
+} // namespace reprospect::examples::kokkos::complex
+
+#define CHECK_COMPLEX_COMPLIANT_IMPL(_test_, type, divisor, expt, compare)                                             \
+    std::cout << "=== " << #type << " with " << #divisor << " is " << expt << "compliant to " << #_test_               \
+              << " ===" << std::endl;                                                                                  \
+    if (reprospect::examples::kokkos::complex::Compliance<type, divisor>::test_##_test_() compare) {                   \
+        throw std::runtime_error("Should be " expt "compliant.");                                                      \
+    }
+
+#define CHECK_COMPLEX_COMPLIANT(test, type, divisor)     CHECK_COMPLEX_COMPLIANT_IMPL(test, type, divisor, "", != 0)
+#define CHECK_COMPLEX_NOT_COMPLIANT(test, type, divisor) CHECK_COMPLEX_COMPLIANT_IMPL(test, type, divisor, "NOT ", == 0)
+
+int main() {
+    using namespace reprospect::examples::kokkos::complex;
+
+    CHECK_COMPLEX_COMPLIANT(sanity, std::complex, std::divides<void>)
+    CHECK_COMPLEX_COMPLIANT(sanity, Kokkos::complex, DivisorLogbScalbn<true>)
+    CHECK_COMPLEX_COMPLIANT(sanity, Kokkos::complex, std::divides<void>)
+
+    CHECK_COMPLEX_COMPLIANT(infinite_divided_by_finite, std::complex, std::divides<void>)
+    CHECK_COMPLEX_COMPLIANT(infinite_divided_by_finite, Kokkos::complex, DivisorLogbScalbn<true>)
+    CHECK_COMPLEX_NOT_COMPLIANT(infinite_divided_by_finite, Kokkos::complex, std::divides<void>)
+
+    CHECK_COMPLEX_COMPLIANT(finite_divided_by_infinite, std::complex, std::divides<void>)
+    CHECK_COMPLEX_COMPLIANT(finite_divided_by_infinite, Kokkos::complex, DivisorLogbScalbn<true>)
+    CHECK_COMPLEX_NOT_COMPLIANT(finite_divided_by_infinite, Kokkos::complex, std::divides<void>)
+
+    CHECK_COMPLEX_COMPLIANT(nonzero_divided_by_zero, std::complex, std::divides<void>)
+    CHECK_COMPLEX_COMPLIANT(nonzero_divided_by_zero, Kokkos::complex, DivisorLogbScalbn<true>)
+    CHECK_COMPLEX_COMPLIANT(nonzero_divided_by_zero, Kokkos::complex, std::divides<void>)
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Need to ensure that a given complex division implementation not only performs well, but is (or not) conforming to ISO/IEC 60559.