### PR TITLE
cicd(strategy): cuda 12.8.1 + clang 22

### DIFF
--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -353,6 +353,15 @@ def main(*, args: argparse.Namespace) -> None:
         platforms=('linux/amd64',),
     ), args=args))
 
+    matrix.extend(from_config(Config(
+        cuda_version='12.8.1',
+        ubuntu_version='24.04',
+        python_version='3.12',
+        compilers={'CXX': Compiler(ID='Clang', version='22')},
+        compute_capability=ComputeCapability(major=9, minor=0),
+        platforms=('linux/amd64',),
+    ), args=args))
+
     logging.info(f'Strategy matrix:\n{pprint.pformat(matrix)}')
 
     # All jobs in the matrix build an image.

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -58,16 +58,21 @@ ARG CXX_COMPILER_VERSION
 RUN <<EOF
     set -ex
 
-    apt-helpers install-packages --update --packages lsb-release wget software-properties-common gnupg
+    apt-helpers install-packages --update --packages wget gpg lsb-release
 
-    wget https://apt.llvm.org/llvm.sh
-    chmod +x llvm.sh
-    ./llvm.sh ${CXX_COMPILER_VERSION}
-    rm llvm.sh
+    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+        | gpg --dearmor \
+        | tee /usr/share/keyrings/llvm-archive-keyring.gpg > /dev/null
+
+    CODENAME=$(lsb_release -cs)
+
+    echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${CXX_COMPILER_VERSION} main" \
+        | tee /etc/apt/sources.list.d/llvm.list
 
     apt-helpers install-packages --clean   \
         --update --packages                \
         clang-${CXX_COMPILER_VERSION}      \
+        llvm-${CXX_COMPILER_VERSION}       \
         clang-tidy-${CXX_COMPILER_VERSION} \
         clang-format-${CXX_COMPILER_VERSION}
 

--- a/examples/kokkos/complex/example_division.py
+++ b/examples/kokkos/complex/example_division.py
@@ -85,7 +85,6 @@ class TestSASS(TestDivision):
 
     @pytest.fixture(scope='class')
     def function(self, cuobjdump: CuObjDump) -> dict[Method, Function]:
-        logging.info(list(cuobjdump.functions.keys()))
         def get_function(method: Method) -> Function:
             pattern = self.SIGNATURE[method]
             return cuobjdump.functions[next(sig for sig in cuobjdump.functions if pattern.search(sig) is not None)]
@@ -166,9 +165,17 @@ class TestSASS(TestDivision):
                 expt_logbscalbn =    {RegisterType.GPR: (40, 32), RegisterType.PRED: (4, 4), RegisterType.UGPR: (8, 4)}
                 expt_norm_division = {RegisterType.GPR: (39, 30), RegisterType.PRED: (5, 5), RegisterType.UGPR: (8, 4)}
             case 90:
-                expt_ilogbscalbn =   {RegisterType.GPR: (40, 32), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}
-                expt_logbscalbn =    {RegisterType.GPR: (40, 34), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}
-                expt_norm_division = {RegisterType.GPR: (40, 33), RegisterType.PRED: (5, 5), RegisterType.UGPR: (9, 5)}
+                match self.toolchains['CUDA']['compiler']['id']:
+                    case 'NVIDIA':
+                        expt_ilogbscalbn =   {RegisterType.GPR: (40, 32), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}
+                        expt_logbscalbn =    {RegisterType.GPR: (40, 34), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}
+                        expt_norm_division = {RegisterType.GPR: (40, 33), RegisterType.PRED: (5, 5), RegisterType.UGPR: (9, 5)}
+                    case 'Clang':
+                        expt_ilogbscalbn =   {RegisterType.GPR: (45, 43), RegisterType.PRED: (4, 4), RegisterType.UGPR: (10, 6)}
+                        expt_logbscalbn =    {RegisterType.GPR: (45, 41), RegisterType.PRED: (4, 4), RegisterType.UGPR: (10, 6)}
+                        expt_norm_division = {RegisterType.GPR: (40, 32), RegisterType.PRED: (5, 5), RegisterType.UGPR: (10, 6)}
+                    case _:
+                        raise ValueError
             case 100:
                 expt_ilogbscalbn =   {RegisterType.GPR: (45, 40), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}
                 expt_logbscalbn =    {RegisterType.GPR: (45, 40), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}

--- a/examples/kokkos/view/example_restrict.py
+++ b/examples/kokkos/view/example_restrict.py
@@ -111,6 +111,7 @@ import sys
 import typing
 
 import pytest
+import semantic_version
 
 from reprospect.test import CMakeAwareTestCase, environment
 from reprospect.test.sass.composite import (
@@ -398,11 +399,15 @@ class TestSASS(TestRestrict):
         Test for :py:attr:`Method.RESTRICT_RECAST_LAMBDA`.
 
         It generates a single loads/add/store sequence,
-        but misses the ``.CONSTANT`` modifier for recent architectures.
+        but the ``.CONSTANT`` modifier may be missing depending on the architecture/compiler.
         """
         logging.info(decoder[Method.RESTRICT_RECAST_LAMBDA])
         cfg = ControlFlow.analyze(instructions=decoder[Method.RESTRICT_RECAST_LAMBDA].instructions)
-        readonly = self.arch.compute_capability.as_int in {70, 75, 80, 86, 89, 90}
+        if self.toolchains['CUDA']['compiler']['id'] == 'Clang' and \
+            semantic_version.Version(self.toolchains['CUDA']['compiler']['version']) in semantic_version.SimpleSpec('>21'):
+            readonly = False
+        else:
+            readonly = self.arch.compute_capability.as_int in {70, 75, 80, 86, 89, 90}
         assert self.match_repeated(cfg=cfg) is False
         assert self.match_single(cfg=cfg, readonly=False) == (not readonly)
         assert self.match_single(cfg=cfg, readonly=True) == readonly


### PR DESCRIPTION
`clang` 21 works fine with `CUDA` 12.8.1.

So let's first use `clang` 22 with `CUDA` 12.8.1. And do a followup later on to bump to `CUDA` 13.

~~I needed to update `google-benchmark` because of https://github.com/google/benchmark/pull/2108.~~ (done in #534)

~~I removed `rust` as it's not used for now, so it unnecessarily makes our images bigger.~~ (done in #533)