### PR TITLE
cicd: cuda 13.1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,7 +288,7 @@ jobs:
                 coverage combine --keep $(find coverage/ -type f -name "*.cov")
                 coverage report
                 test -f .coverage
-                mv .coverage coverage.${{ matrix.cmake_preset }}-${{ matrix.nvidia_arch }}
+                mv .coverage coverage.${{ matrix.cmake_preset }}-${{ matrix.cuda_version }}-${{ matrix.nvidia_arch }}
 
             - uses: actions/upload-artifact@v7
               with:
@@ -299,8 +299,8 @@ jobs:
 
             - uses: actions/upload-artifact@v7
               with:
-                  name: tests-coverage-${{ matrix.cmake_preset }}-${{ matrix.nvidia_arch }}
-                  path: coverage.${{ matrix.cmake_preset }}-${{ matrix.nvidia_arch }}
+                  name: tests-coverage-${{ matrix.cmake_preset }}-${{ matrix.cuda_version }}-${{ matrix.nvidia_arch }}
+                  path: coverage.${{ matrix.cmake_preset }}-${{ matrix.cuda_version }}-${{ matrix.nvidia_arch }}
                   retention-days: 1
                   if-no-files-found: error
 

--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -109,6 +109,9 @@ def get_base_name_tag_digest(cuda_version: str, ubuntu_version: str) -> tuple[st
         case ('13.1.0', '24.04'):
             tag = '13.1.0-devel-ubuntu24.04'
             digest = 'sha256:7f32ae6e575abb29f2dacf6c75fe94a262bb48dcc5196ac833ced59d9fde8107'
+        case ('13.1.1', '24.04'):
+            tag = '13.1.1-devel-ubuntu24.04'
+            digest = 'sha256:010665864e7eaf8f054dd7097d3d1fdef44a2ee04c8755e6ab52ff85221461ba'
         case _:
             raise ValueError((cuda_version, ubuntu_version))
     return ('nvcr.io/nvidia/cuda', tag, digest)
@@ -319,6 +322,15 @@ def main(*, args: argparse.Namespace) -> None:
 
     matrix.extend(from_config(Config(
         cuda_version='13.1.0',
+        ubuntu_version='24.04',
+        python_version='3.14',
+        compilers={'CXX': Compiler(ID='GNU', version='14'), 'CUDA': Compiler(ID='NVIDIA')},
+        compute_capability=ComputeCapability(major=10, minor=0),
+        platforms=('linux/amd64',),
+    ), args=args))
+
+    matrix.extend(from_config(Config(
+        cuda_version='13.1.1',
         ubuntu_version='24.04',
         python_version='3.14',
         compilers={'CXX': Compiler(ID='GNU', version='14'), 'CUDA': Compiler(ID='NVIDIA')},


### PR DESCRIPTION
The Docker image for CUDA 13.2 is not available yet.

Let's stick to `gcc` because using `clang` 22 leads to:
```bash
In file included from /usr/local/cuda/bin/../targets/x86_64-linux/include/cuda_runtime.h:82:
#13 3.757     /usr/local/cuda/bin/../targets/x86_64-linux/include/crt/host_config.h:151:2: error: -- unsupported clang version! clang version must be less than 22 and greater than 3.2 . The nvcc flag '-allow-unsupported-compiler' can be used to override this version check; however, using an unsupported host compiler may cause compilation failure or incorrect run time execution. Use at your own risk.
#13 3.757       151 | #error -- unsupported clang version! clang version must be less than 22 and greater than 3.2 . The nvcc flag '-allow-unsupported-compiler' can be used to override this version check; however, using an unsupported host compiler may cause compilation failure or incorrect run time execution. Use at your own risk.
```