### PR TITLE
cicd(artifacts): add cuda version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,7 +292,7 @@ jobs:
 
             - uses: actions/upload-artifact@v7
               with:
-                  name: tests-${{ matrix.cmake_preset }}-${{ matrix.nvidia_arch }}
+                  name: tests-${{ matrix.cmake_preset }}-${{ matrix.cuda_version }}-${{ matrix.nvidia_arch }}
                   path: artifacts
                   retention-days: 1
                   if-no-files-found: error
@@ -410,7 +410,7 @@ jobs:
 
             - uses: actions/upload-artifact@v7
               with:
-                  name: examples-${{ matrix.cmake_preset }}-${{ matrix.nvidia_arch }}
+                  name: examples-${{ matrix.cmake_preset }}-${{ matrix.cuda_version }}-${{ matrix.nvidia_arch }}
                   path: artifacts
                   retention-days: 1
 
@@ -469,12 +469,12 @@ jobs:
 
             - uses: actions/download-artifact@v8
               with:
-                  name: tests-gnu-nvidia-BLACKWELL120
+                  name: tests-gnu-nvidia-13.1.0-BLACKWELL120
                   path: artifacts
 
             - uses: actions/download-artifact@v8
               with:
-                  name: examples-gnu-nvidia-BLACKWELL120
+                  name: examples-gnu-nvidia-13.1.0-BLACKWELL120
                   path: artifacts
 
             - run: cd docs && make -j4 doctest


### PR DESCRIPTION
To distinguish between several same compiler/same architecture configurations.