### PR TITLE
tests(cmake-file-api): compiler for toolchain

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -127,6 +127,7 @@ nitpick_ignore_regex = [
     ('py:class', r'_regex.Pattern'),
     ('py:class', r'regex.Pattern'),
     ('py:class', r'elftools.*'),
+    ('py:class', r'cmake_file_api.*'),
 ]
 
 # Configuration for 'myst_nb', see also https://myst-nb.readthedocs.io/en/latest/configuration.html.

--- a/examples/cuda/virtual_functions/example_dispatch.py
+++ b/examples/cuda/virtual_functions/example_dispatch.py
@@ -218,7 +218,7 @@ class TestResourceUsage(TestBinaryAnalysis):
                 expt_dynamic = {RegisterType.GPR: (24, 18), RegisterType.PRED: (1, 1), RegisterType.UGPR: (6, 2)}
             case 100 | 103:
                 expt_static  = {RegisterType.GPR: (8, 7),   RegisterType.PRED: (1, 1), RegisterType.UGPR: (6, 2)}
-                match self.toolchains['CUDA']['compiler']['id']:
+                match self.compiler(toolchain='CUDA').id:
                     case 'NVIDIA':
                         expt_dynamic = {RegisterType.GPR: (24, 18), RegisterType.PRED: (1, 1), RegisterType.UGPR: (8, 4), RegisterType.UPRED: (1, 1)}
                     case 'Clang':

--- a/examples/kokkos/atomic/desul.py
+++ b/examples/kokkos/atomic/desul.py
@@ -39,6 +39,8 @@ import logging
 import sys
 import typing
 
+from cmake_file_api.kinds.toolchains.v1 import CMakeToolchainCompiler
+
 from reprospect.test.sass.composite import (
     instruction_is,
     instructions_are,
@@ -69,17 +71,17 @@ if sys.version_info >= (3, 12):
 else:
     from typing_extensions import override
 
-def get_atomic_memory_suffix(compiler_id: str) -> typing.Literal['G', '']:
+def get_atomic_memory_suffix(compiler: CMakeToolchainCompiler) -> typing.Literal['G', '']:
     """
     See :py:meth:`tests.test.sass.test_atomic.TestAtomicMatcher.test_exch_device_ptr`.
     """
-    match compiler_id:
+    match compiler.id:
         case 'NVIDIA':
             return 'G'
         case 'Clang':
             return ''
         case _:
-            raise ValueError(f'unsupported compiler ID {compiler_id}')
+            raise ValueError(f'unsupported compiler ID {compiler.id}')
 
 class AtomicAcquireMatcher:
     """
@@ -91,12 +93,12 @@ class AtomicAcquireMatcher:
     * https://github.com/desul/desul/blob/79f928075837ffb5d302aae188e0ec7b7a79ae94/atomics/include/desul/atomics/Lock_Array_CUDA.hpp#L83
     """
     @classmethod
-    def build(cls, arch: NVIDIAArch, compiler_id: str) -> OrderedInSequenceMatcher:
+    def build(cls, arch: NVIDIAArch, compiler: CMakeToolchainCompiler) -> OrderedInSequenceMatcher:
         return instructions_are(
             # Storing 1 in a register can be done in different ways.
             Move32Matcher(src='0x1'),
             AtomicMatcher(
-                memory=get_atomic_memory_suffix(compiler_id=compiler_id),
+                memory=get_atomic_memory_suffix(compiler=compiler),
                 arch=arch,
                 operation='EXCH',
                 scope='DEVICE',
@@ -114,9 +116,9 @@ class AtomicReleaseMatcher:
     * https://github.com/desul/desul/blob/79f928075837ffb5d302aae188e0ec7b7a79ae94/atomics/include/desul/atomics/Lock_Array_CUDA.hpp#L102
     """
     @classmethod
-    def build(cls, arch: NVIDIAArch, compiler_id: str) -> InstructionMatcher:
+    def build(cls, arch: NVIDIAArch, compiler: CMakeToolchainCompiler) -> InstructionMatcher:
         return instruction_is(AtomicMatcher(
-            memory=get_atomic_memory_suffix(compiler_id=compiler_id),
+            memory=get_atomic_memory_suffix(compiler=compiler),
             arch=arch,
             operation='EXCH',
             scope='DEVICE',
@@ -159,7 +161,7 @@ class LockBasedAtomicMatcher(SequenceMatcher):
     def __init__(self, *,
         arch: NVIDIAArch,
         operation: Operation,
-        compiler_id: str,
+        compiler: CMakeToolchainCompiler,
         size: int = 128,
         level: int = logging.INFO,
         load: SequenceMatcher | None = None,
@@ -167,7 +169,7 @@ class LockBasedAtomicMatcher(SequenceMatcher):
     ) -> None:
         self.arch: typing.Final[NVIDIAArch] = arch
         self.operation: typing.Final[Operation] = operation
-        self.compiler_id: typing.Final[str] = compiler_id
+        self.compiler: typing.Final[CMakeToolchainCompiler] = compiler
         self.level: typing.Final[int] = level
         self.load:  typing.Final[SequenceMatcher] = load  or InSequenceAtMatcher(matcher=LoadGlobalMatcher (arch=self.arch, size=size, readonly=False))
         self.store: typing.Final[SequenceMatcher] = store or InSequenceAtMatcher(matcher=StoreGlobalMatcher(arch=self.arch, size=size))
@@ -195,7 +197,7 @@ class LockBasedAtomicMatcher(SequenceMatcher):
         matched: list[InstructionMatch] = []
 
         # First, try to atomically acquire a lock.
-        matcher_start = instructions_contain(matcher=AtomicAcquireMatcher.build(arch=self.arch, compiler_id=self.compiler_id))
+        matcher_start = instructions_contain(matcher=AtomicAcquireMatcher.build(arch=self.arch, compiler=self.compiler))
         matched_atomic_acquire = matcher_start.match(instructions=instructions)
 
         if matched_atomic_acquire is None:
@@ -215,13 +217,13 @@ class LockBasedAtomicMatcher(SequenceMatcher):
 
         # Then, ISETP.NE.AND that reuses the register in which the atomic acquire put its result.
         modifiers: tuple[str, ...]
-        match self.compiler_id:
+        match self.compiler.id:
             case 'NVIDIA':
                 modifiers = ('NE', 'AND')
             case 'Clang':
                 modifiers = ('NE', 'U32', 'AND')
             case _:
-                raise ValueError(f'unsupported compiler ID {self.compiler_id}')
+                raise ValueError(f'unsupported compiler ID {self.compiler.id}')
         matcher_isetp_enter = OpcodeModsWithOperandsMatcher(
             opcode='ISETP', modifiers=modifiers,
             operands=(
@@ -314,7 +316,7 @@ class LockBasedAtomicMatcher(SequenceMatcher):
                 raise ValueError
 
         # Atomic release.
-        matched_atomic_release = AtomicReleaseMatcher.build(arch=self.arch, compiler_id=self.compiler_id).match(inst=instructions[offset])
+        matched_atomic_release = AtomicReleaseMatcher.build(arch=self.arch, compiler=self.compiler).match(inst=instructions[offset])
 
         if matched_atomic_release is None:
             return None

--- a/examples/kokkos/atomic/example_add_complex128.py
+++ b/examples/kokkos/atomic/example_add_complex128.py
@@ -76,7 +76,7 @@ class TestAtomicAddComplex128(add.TestCase):
         matched = desul.LockBasedAtomicMatcher(
             arch=self.arch,
             operation=AddComplex128(),
-            compiler_id=self.toolchains['CUDA']['compiler']['id'],
+            compiler=self.compiler(toolchain='CUDA'),
         ).match(instructions=decoder.instructions)
 
         if self.arch.compute_capability.as_int >= 90:

--- a/examples/kokkos/atomic/example_add_double256.py
+++ b/examples/kokkos/atomic/example_add_double256.py
@@ -130,5 +130,5 @@ class TestAtomicAddDouble256(add.TestCase):
             load=Load256Matcher(arch=self.arch).build(),
             operation=AddDouble4(arch=self.arch),
             store=Store256Matcher(arch=self.arch).build(),
-            compiler_id=self.toolchains['CUDA']['compiler']['id'],
+            compiler=self.compiler(toolchain='CUDA'),
         ).assert_matches(instructions=decoder.instructions)

--- a/examples/kokkos/atomic/example_add_int128.py
+++ b/examples/kokkos/atomic/example_add_int128.py
@@ -58,7 +58,7 @@ class TestAtomicAddInt128(add.TestCase):
         matched = desul.LockBasedAtomicMatcher(
             arch=self.arch,
             operation=AddInt128(),
-            compiler_id=self.toolchains['CUDA']['compiler']['id'],
+            compiler=self.compiler(toolchain='CUDA'),
         ).match(instructions=decoder.instructions)
 
         if self.arch.compute_capability.as_int >= 90:

--- a/examples/kokkos/complex/example_division.py
+++ b/examples/kokkos/complex/example_division.py
@@ -114,8 +114,8 @@ class TestSASS(TestDivision):
         """
         matcher_mufu = OpcodeModsMatcher(opcode='MUFU', modifiers=('RCP64H',))
         if self.arch.compute_capability < 100 or \
-            (semantic_version.Version(os.environ['CUDA_VERSION']) in semantic_version.SimpleSpec('<13.0') and self.toolchains['CUDA']['compiler']['id'] == 'NVIDIA') or \
-            self.toolchains['CUDA']['compiler']['id'] == 'Clang':
+            (semantic_version.Version(os.environ['CUDA_VERSION']) in semantic_version.SimpleSpec('<13.0') and self.compiler(toolchain='CUDA').id == 'NVIDIA') or \
+            self.compiler(toolchain='CUDA').id == 'Clang':
             expt_mufu_norm_division = 7
         else:
             expt_mufu_norm_division = 9
@@ -170,7 +170,7 @@ class TestSASS(TestDivision):
                 expt_logbscalbn =    {RegisterType.GPR: (40, 32), RegisterType.PRED: (4, 4), RegisterType.UGPR: (8, 4)}
                 expt_norm_division = {RegisterType.GPR: (39, 30), RegisterType.PRED: (5, 5), RegisterType.UGPR: (8, 4)}
             case 90:
-                match self.toolchains['CUDA']['compiler']['id']:
+                match self.compiler(toolchain='CUDA').id:
                     case 'NVIDIA':
                         expt_ilogbscalbn =   {RegisterType.GPR: (40, 32), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}
                         expt_logbscalbn =    {RegisterType.GPR: (40, 34), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}
@@ -182,7 +182,7 @@ class TestSASS(TestDivision):
                     case _:
                         raise ValueError
             case 100:
-                match self.toolchains['CUDA']['compiler']['id']:
+                match self.compiler(toolchain='CUDA').id:
                     case 'NVIDIA':
                         expt_ilogbscalbn =   {RegisterType.GPR: (45, 40), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}
                         expt_logbscalbn =    {RegisterType.GPR: (45, 40), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}
@@ -198,7 +198,7 @@ class TestSASS(TestDivision):
                 expt_logbscalbn =    {RegisterType.GPR: (46, 40), RegisterType.PRED: (4, 4), RegisterType.UGPR: (10, 6)}
                 expt_norm_division = {RegisterType.GPR: (40, 32), RegisterType.PRED: (4, 4), RegisterType.UGPR: (10, 6)}
             case 120:
-                match self.toolchains['CUDA']['compiler']['id']:
+                match self.compiler(toolchain='CUDA').id:
                     case 'NVIDIA':
                         if semantic_version.Version(os.environ['CUDA_VERSION']) in semantic_version.SimpleSpec('<13.1'):
                             expt_ilogbscalbn = {RegisterType.GPR: (40, 33), RegisterType.PRED: (3, 3), RegisterType.UGPR: (14, 10)}
@@ -286,7 +286,7 @@ class TestNCU(TestDivision):
         """
         comp: typing.Callable
 
-        if self.arch.compute_capability == 120 and self.toolchains['CUDA']['compiler']['id'] == 'NVIDIA' and semantic_version.Version(os.environ['CUDA_VERSION']) in semantic_version.SimpleSpec('=13.0'):
+        if self.arch.compute_capability == 120 and self.compiler(toolchain='CUDA').id == 'NVIDIA' and semantic_version.Version(os.environ['CUDA_VERSION']) in semantic_version.SimpleSpec('=13.0'):
             comp = operator.eq
         else:
             comp = operator.gt
@@ -321,7 +321,7 @@ class TestNCU(TestDivision):
         inst_op: typing.Callable
         cycles_op: typing.Callable
 
-        if self.arch.compute_capability == 120 and self.toolchains['CUDA']['compiler']['id'] == 'NVIDIA' and semantic_version.Version(os.environ['CUDA_VERSION']) in semantic_version.SimpleSpec('<=13.0'):
+        if self.arch.compute_capability == 120 and self.compiler(toolchain='CUDA').id == 'NVIDIA' and semantic_version.Version(os.environ['CUDA_VERSION']) in semantic_version.SimpleSpec('<=13.0'):
             inst_op = cycles_op = operator.eq
         else:
             inst_op = cycles_op = operator.gt

--- a/examples/kokkos/view/example_restrict.py
+++ b/examples/kokkos/view/example_restrict.py
@@ -403,8 +403,8 @@ class TestSASS(TestRestrict):
         """
         logging.info(decoder[Method.RESTRICT_RECAST_LAMBDA])
         cfg = ControlFlow.analyze(instructions=decoder[Method.RESTRICT_RECAST_LAMBDA].instructions)
-        if self.toolchains['CUDA']['compiler']['id'] == 'Clang' and \
-            semantic_version.Version(self.toolchains['CUDA']['compiler']['version']) in semantic_version.SimpleSpec('>21'):
+        if self.compiler(toolchain='CUDA').id == 'Clang' and \
+            semantic_version.Version(self.compiler(toolchain='CUDA').version) in semantic_version.SimpleSpec('>21'):
             readonly = False
         else:
             readonly = self.arch.compute_capability.as_int in {70, 75, 80, 86, 89, 90}
@@ -422,7 +422,7 @@ class TestSASS(TestRestrict):
         """
         logging.info(decoder[Method.RESTRICT_RECAST_LOCAL])
         cfg = ControlFlow.analyze(instructions=decoder[Method.RESTRICT_RECAST_LOCAL].instructions)
-        match self.toolchains['CUDA']['compiler']['id']:
+        match self.compiler(toolchain='CUDA').id:
             case 'NVIDIA':
                 assert self.match_repeated(cfg=cfg) is False
                 assert self.match_single(cfg=cfg, readonly=False) is False
@@ -563,7 +563,7 @@ class TestNCU(TestRestrict):
                 factor = {
                     'NVIDIA': 1,
                     'Clang':  2,
-                }[self.toolchains['CUDA']['compiler']['id']]
+                }[self.compiler(toolchain='CUDA').id]
             case _:
                 raise ValueError(method)
 

--- a/reprospect/test/cmake.py
+++ b/reprospect/test/cmake.py
@@ -4,6 +4,8 @@ import json
 import pathlib
 import typing
 
+from cmake_file_api.kinds.toolchains.v1 import CMakeToolchainCompiler
+
 from reprospect.test.environment import EnvironmentField
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.tools.binaries.demangle import CuppFilt, LlvmCppFilt
@@ -11,17 +13,17 @@ from reprospect.utils import cmake
 from reprospect.utils.compile_command import get_arch_from_compile_command
 
 
-def get_demangler_for_compiler(compiler_id: str) -> type[CuppFilt | LlvmCppFilt]:
+def get_demangler_for_compiler(compiler: CMakeToolchainCompiler) -> type[CuppFilt | LlvmCppFilt]:
     """
     Get demangler for compiler with given id.
     """
-    match compiler_id:
+    match compiler.id:
         case 'NVIDIA':
             return CuppFilt
         case 'Clang':
             return LlvmCppFilt
         case _:
-            raise ValueError(f'unsupported compiler ID {compiler_id}')
+            raise ValueError(f'unsupported compiler ID {compiler.id}')
 
 class CMakeMixin(abc.ABC):
     """
@@ -74,6 +76,10 @@ class CMakeMixin(abc.ABC):
         """
         return self.cmake_file_api.target(self.get_target_name())
 
+    @functools.lru_cache(maxsize=128) # noqa: B019
+    def compiler(self, *, toolchain: str) -> CMakeToolchainCompiler:
+        return self.cmake_file_api.compiler(toolchain=toolchain)
+
     @functools.cached_property
     def target_sources(self) -> typing.Generator[pathlib.Path, None, None]:
         """
@@ -89,12 +95,5 @@ class CMakeMixin(abc.ABC):
         return self.CMAKE_BINARY_DIR / self.target['paths']['build'] / self.target['nameOnDisk']
 
     @functools.cached_property
-    def toolchains(self) -> cmake.ToolchainDict:
-        """
-        Retrieve the toolchains information from the read CMake file API.
-        """
-        return self.cmake_file_api.toolchains
-
-    @functools.cached_property
     def demangler(self) -> type[CuppFilt | LlvmCppFilt]:
-        return get_demangler_for_compiler(self.toolchains['CUDA']['compiler']['id'])
+        return get_demangler_for_compiler(self.compiler(toolchain='CUDA'))

--- a/reprospect/utils/cmake.py
+++ b/reprospect/utils/cmake.py
@@ -4,6 +4,7 @@ import pathlib
 import typing
 
 import cmake_file_api.kinds
+import cmake_file_api.kinds.toolchains.v1
 import cmake_file_api.reply.v1
 import ijson
 
@@ -114,3 +115,10 @@ class FileAPI:
                 with (self.cmake_reply_path / target['jsonFile']).open() as file:
                     return json.load(file)
         raise ValueError(f'Target {name!r} not found.')
+
+    @functools.lru_cache(maxsize=128) # noqa: B019
+    def compiler(self, toolchain: str) -> cmake_file_api.kinds.toolchains.v1.CMakeToolchainCompiler:
+        """
+        Retrieve the compiler for a given toolchain.
+        """
+        return cmake_file_api.kinds.toolchains.v1.CMakeToolchainCompiler.from_dict(self.toolchains[toolchain]['compiler'])

--- a/tests/compilation.py
+++ b/tests/compilation.py
@@ -3,8 +3,10 @@ import logging
 import os
 import pathlib
 import subprocess
+import typing
 
 import semantic_version
+from cmake_file_api.kinds.toolchains.v1 import CMakeToolchainCompiler
 
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.utils import cmake
@@ -12,7 +14,7 @@ from reprospect.utils import cmake
 QUALITY_FLAGS: tuple[str, ...] = ('-Wall', '-Wextra', '-Werror')
 
 @functools.cache
-def clang_cuda_fix_cccl_include(*, implicit_includes: tuple[str], cuda_version: semantic_version.Version) -> tuple[pathlib.Path, ...]:
+def clang_cuda_fix_cccl_include(*, compiler: CMakeToolchainCompiler, cuda_version: semantic_version.Version) -> tuple[pathlib.Path, ...]:
     """
     Return any missing include path for when `clang` is used to compile for CUDA 13 and above.
 
@@ -22,8 +24,8 @@ def clang_cuda_fix_cccl_include(*, implicit_includes: tuple[str], cuda_version: 
     if cuda_version not in semantic_version.SimpleSpec('>=13'):
         return ()
 
-    cuda_includes = tuple(
-        p for p in map(pathlib.Path, implicit_includes)
+    cuda_includes: typing.Final[tuple[pathlib.Path, ...]] = tuple(
+        p for p in compiler.implicit.includeDirectories
         if 'cuda' in p.parent.name
     )
 
@@ -52,41 +54,40 @@ def get_compilation_output(*, # pylint: disable=too-many-branches
 
     :param object_file: Whether to compile into an object file.
     """
-    cuda_toolchain = cmake_file_api.toolchains['CUDA']
-    cuda_compiler_id = cuda_toolchain['compiler']['id']
+    cuda_compiler = cmake_file_api.compiler(toolchain='CUDA')
 
     output = cwd / (source.stem + '.' + arch.as_sm + ('.o' if object_file else ''))
 
     cmd = [
         cmake_file_api.cache['CMAKE_CUDA_COMPILER_LAUNCHER']['value'],
-        cuda_toolchain['compiler']['path'],
+        cuda_compiler.path,
         '-std=c++20',
     ]
 
     # Code quality flags.
-    match cuda_compiler_id:
+    match cuda_compiler.id:
         case 'NVIDIA':
             cmd.extend(f'-Xcompiler={x}' for x in QUALITY_FLAGS)
         case 'Clang':
             cmd.extend(QUALITY_FLAGS)
             cmd.append('-Wno-error=unknown-cuda-version')
         case _:
-            raise ValueError(f'unsupported compiler ID {cuda_compiler_id}')
+            raise ValueError(f'unsupported compiler ID {cuda_compiler.id}')
 
     # For compiling an executable, if the source ends with '.cpp', we need '-x cu' for nvcc and '-x cuda' for clang.
     if not object_file and source.suffix == '.cpp':
-        match cuda_compiler_id:
+        match cuda_compiler.id:
             case 'NVIDIA':
                 cmd += ['-x', 'cu']
             case 'Clang':
                 cmd += ['-x', 'cuda']
             case _:
-                raise ValueError(f"unsupported compiler ID {cuda_compiler_id}")
+                raise ValueError(f'unsupported compiler ID {cuda_compiler.id}')
 
     # Clang tends to add a lot of debug code otherwise.
     cmd.append('-O3')
 
-    match cuda_compiler_id:
+    match cuda_compiler.id:
         case 'NVIDIA':
             cmd.append('--gpu-architecture=' + arch.as_compute)
             if ptx:
@@ -102,14 +103,14 @@ def get_compilation_output(*, # pylint: disable=too-many-branches
             if resource_usage:
                 cmd += ['-Xcuda-ptxas', '-v']
         case _:
-            raise ValueError(f"unsupported compiler ID {cuda_compiler_id}")
+            raise ValueError(f'unsupported compiler ID {cuda_compiler.id}')
 
     # Allow any include within the repository.
     cmd.append(f"-I{cmake_file_api.cache['reprospect_SOURCE_DIR']['value']}")
 
-    if cuda_compiler_id == 'Clang':
+    if cuda_compiler.id == 'Clang':
         cmd.extend(f'-I{x}' for x in clang_cuda_fix_cccl_include(
-            implicit_includes=tuple(cuda_toolchain['compiler']['implicit']['includeDirectories']),
+            compiler=cuda_compiler,
             cuda_version=version or semantic_version.Version(os.environ['CUDA_VERSION']),
         ))
 
@@ -135,7 +136,7 @@ def get_compilation_output(*, # pylint: disable=too-many-branches
         stderr=subprocess.STDOUT,
     ).decode())
 
-def get_cubin_name(*, compiler_id: str, file: pathlib.Path, arch: NVIDIAArch, object_file: bool = False) -> str:
+def get_cubin_name(*, compiler: CMakeToolchainCompiler, file: pathlib.Path, arch: NVIDIAArch, object_file: bool = False) -> str:
     """
     When the compilation is *not* into an object file, the resulting file may contain:
 
@@ -147,10 +148,10 @@ def get_cubin_name(*, compiler_id: str, file: pathlib.Path, arch: NVIDIAArch, ob
     if object_file:
         return f'{file.stem}.1.{arch.as_sm}.cubin'
 
-    match compiler_id:
+    match compiler.id:
         case 'NVIDIA':
             return f'{file.stem}.2.{arch.as_sm}.cubin'
         case 'Clang':
             return f'{file.stem}.1.{arch.as_sm}.cubin'
         case _:
-            raise ValueError(f'unsupported compiler ID {compiler_id}')
+            raise ValueError(f'unsupported compiler ID {compiler.id}')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 
 import pytest
+from cmake_file_api.kinds.toolchains.v1 import CMakeToolchainCompiler
 
 from reprospect.utils import cmake
 
@@ -17,3 +18,7 @@ def cmake_file_api(bindir) -> cmake.FileAPI:
 @pytest.fixture(scope='session')
 def workdir() -> pathlib.Path:
     return pathlib.Path(os.environ['CMAKE_CURRENT_BINARY_DIR'])
+
+@pytest.fixture(scope='session')
+def cmake_cuda_compiler(cmake_file_api) -> CMakeToolchainCompiler:
+    return cmake_file_api.compiler(toolchain='CUDA')

--- a/tests/test/sass/test_atomic.py
+++ b/tests/test/sass/test_atomic.py
@@ -7,6 +7,7 @@ import numpy
 import pytest
 import regex
 import semantic_version
+from cmake_file_api.kinds.toolchains.v1 import CMakeToolchainCompiler
 
 from reprospect.test.sass.instruction import (
     AtomicMatcher,
@@ -172,7 +173,7 @@ __global__ void atomic_exch_kernel() {
             ( 32, 'float',     'unsigned int'),
             ( 64, 'double',    'unsigned long long int'),
     ], ids=str)
-    def test_atomicCAS(self, request, workdir, word, parameters: Parameters, cmake_file_api: cmake.FileAPI):
+    def test_atomicCAS(self, request, workdir, word, parameters: Parameters, cmake_file_api: cmake.FileAPI, cmake_cuda_compiler: CMakeToolchainCompiler):
         """
         Test with :py:attr:`CODE_ADD_BASED_ON_CAS`.
         """
@@ -186,8 +187,8 @@ __global__ void atomic_exch_kernel() {
         decoder, _ = get_decoder(cwd=workdir, arch=parameters.arch, file=FILE, cmake_file_api=cmake_file_api)
 
         # Find the atomic CAS.
-        if cmake_file_api.toolchains['CUDA']['compiler']['id'] == 'Clang' and \
-            semantic_version.Version(cmake_file_api.toolchains['CUDA']['compiler']['version']) in semantic_version.SimpleSpec('>21'):
+        if cmake_cuda_compiler.id == 'Clang' and \
+            semantic_version.Version(cmake_cuda_compiler.version) in semantic_version.SimpleSpec('>21'):
             expt_scope = 'SYSTEM'
         else:
             expt_scope = 'DEVICE'
@@ -202,7 +203,7 @@ __global__ void atomic_exch_kernel() {
         assert len(matched.operands) == 5
         assert matched.operands[0] == 'PT'
 
-    def test_atomicCAS_128(self, request, workdir, parameters: Parameters, cmake_file_api: cmake.FileAPI):
+    def test_atomicCAS_128(self, request, workdir, parameters: Parameters, cmake_file_api: cmake.FileAPI, cmake_cuda_compiler: CMakeToolchainCompiler):
         """
         Supported from compute capability 9.x.
         """
@@ -211,7 +212,7 @@ __global__ void atomic_exch_kernel() {
 
         # Under some circumstances, 128-bit atomicCAS will not compile.
         expecting_failure = False
-        match cmake_file_api.toolchains['CUDA']['compiler']['id']:
+        match cmake_cuda_compiler.id:
             case 'NVIDIA':
                 if parameters.arch.compute_capability < 90:
                     logging.warning('The 128-bit atomicCAS() is only supported by devices of compute capability 9.x and higher.')
@@ -220,7 +221,7 @@ __global__ void atomic_exch_kernel() {
                 logging.warning('The 128-bit atomicCAS() does not compile with Clang.')
                 expecting_failure = True
             case _:
-                raise ValueError(f"unsupported compiler {cmake_file_api.toolchains['CUDA']['compiler']}")
+                raise ValueError(f'unsupported compiler {cmake_cuda_compiler}')
 
         kwargs = {'cwd': workdir, 'arch': parameters.arch, 'file': FILE, 'cmake_file_api': cmake_file_api}
 
@@ -547,7 +548,7 @@ __global__ void atomic_exch_kernel() {
 
         assert {'EXCH'}.issubset(matched.modifiers)
 
-    def test_exch_device_ptr(self, request, workdir: pathlib.Path, parameters: Parameters, cmake_file_api: cmake.FileAPI) -> None:
+    def test_exch_device_ptr(self, request, workdir: pathlib.Path, parameters: Parameters, cmake_file_api: cmake.FileAPI, cmake_cuda_compiler: CMakeToolchainCompiler) -> None:
         """
         This test demonstrates that while ``nvcc`` emits an ``ATOMG`` instruction for an atomic exchange using a device pointer marked with
         :code:`__constant__`, ``clang`` (as of 21.1.5) is not able to infer that the referenced memory resides in global memory and therefore falls back
@@ -567,13 +568,13 @@ __global__ void atomic_exch_kernel() {
 
         # Find the atomic exchange.
         memory: MemorySpace
-        match cmake_file_api.toolchains['CUDA']['compiler']['id']:
+        match cmake_cuda_compiler.id:
             case 'NVIDIA':
                 memory = MemorySpace.GLOBAL
             case 'Clang':
                 memory = MemorySpace.GENERIC
             case _:
-                raise ValueError(f"unsupported compiler {cmake_file_api.toolchains['CUDA']['compiler']}")
+                raise ValueError(f'unsupported compiler {cmake_cuda_compiler}')
 
         _, _, matched = self.match_one(
             decoder=decoder,
@@ -586,10 +587,10 @@ __global__ void atomic_exch_kernel() {
         # In the PTX, we can see the '.global' for NVIDIA, but not for Clang.
         result = subprocess.check_output(('cuobjdump', '--dump-ptx', output)).decode()
 
-        match cmake_file_api.toolchains['CUDA']['compiler']['id']:
+        match cmake_cuda_compiler.id:
             case 'NVIDIA':
                 assert 'atom.global.exch.b32' in result
             case 'Clang':
                 assert 'atom.exch.b32' in result
             case _:
-                raise ValueError(f"unsupported compiler {cmake_file_api.toolchains['CUDA']['compiler']}")
+                raise ValueError(f'unsupported compiler {cmake_cuda_compiler}')

--- a/tests/test/sass/test_load.py
+++ b/tests/test/sass/test_load.py
@@ -4,6 +4,7 @@ import re
 import typing
 
 import pytest
+from cmake_file_api.kinds.toolchains.v1 import CMakeToolchainCompiler
 
 from reprospect.test import features
 from reprospect.test.sass.composite import (
@@ -292,7 +293,7 @@ __global__ void extend({dst}* {restrict} const dst, {src}* {restrict} const src,
         ).assert_matches(decoder.instructions)
 
     @pytest.mark.parametrize('parameters', PARAMETERS, ids=str)
-    def test_sign_extend_s16(self, request, workdir: pathlib.Path, parameters: Parameters, cmake_file_api: cmake.FileAPI) -> None:
+    def test_sign_extend_s16(self, request, workdir: pathlib.Path, parameters: Parameters, cmake_file_api: cmake.FileAPI, cmake_cuda_compiler: CMakeToolchainCompiler) -> None:
         """
         Check when :py:attr:`CODE_EXTEND` leads to sign extension.
 
@@ -315,7 +316,7 @@ __global__ void extend({dst}* {restrict} const dst, {src}* {restrict} const src,
         matcher_s16_ro = LoadGlobalMatcher(arch=parameters.arch, size=16, readonly=True, extend='S')
         assert instructions_contain(matcher_s16).match(decoder_u16.instructions) is None
 
-        if not features.Memory(arch=parameters.arch).sign_extension(compiler_id=cmake_file_api.toolchains['CUDA']['compiler']['id']):
+        if not features.Memory(arch=parameters.arch).sign_extension(compiler_id=typing.cast(str, cmake_cuda_compiler.id)):
             assert instructions_contain(matcher_s16_ro).match(decoder_u16.instructions) is None
 
             # But it rather lead to zero extension with permutation.

--- a/tests/test/test_graph.py
+++ b/tests/test/test_graph.py
@@ -4,6 +4,7 @@ import sys
 import typing
 
 import pytest
+from cmake_file_api.kinds.toolchains.v1 import CMakeToolchainCompiler
 
 from reprospect.test import CMakeAwareTestCase
 from reprospect.tools import ncu
@@ -56,11 +57,11 @@ class TestSASS(TestGraph):
         assert len(cuobjdump.functions) == 4
         logging.info(str(cuobjdump))
 
-    def test_instruction_count(self, cuobjdump: CuObjDump) -> None:
+    def test_instruction_count(self, cuobjdump: CuObjDump, cmake_cuda_compiler: CMakeToolchainCompiler) -> None:
         """
         Check how many instructions there are in the first graph node kernel.
         """
-        decoder = Decoder(code=cuobjdump.functions[self.DEMANGLED_NODE_A[self.toolchains['CUDA']['compiler']['id']]].code)
+        decoder = Decoder(code=cuobjdump.functions[self.DEMANGLED_NODE_A[cmake_cuda_compiler.id]].code)
         assert len(decoder.instructions) >= 8
 
 @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason='needs a GPU')
@@ -101,12 +102,12 @@ class TestNCU(TestGraph):
         assert report.report.num_ranges() == 1
         assert len(results) == 4
 
-    def test_launch_registers_per_thread_allocated_node_A(self, results: ncu.ProfilingResults) -> None:
+    def test_launch_registers_per_thread_allocated_node_A(self, results: ncu.ProfilingResults, cmake_cuda_compiler: CMakeToolchainCompiler) -> None:
         """
         Check metric `launch__registers_per_thread_allocated` for graph node A.
         """
         def matcher(value: tuple[str, ncu.ProfilingMetrics]) -> bool:
-            return value[1]['demangled'] == TestGraph.DEMANGLED_NODE_A[self.toolchains['CUDA']['compiler']['id']]
+            return value[1]['demangled'] == TestGraph.DEMANGLED_NODE_A[cmake_cuda_compiler.id]
 
         [(key, metrics)] = filter(matcher, results.iter_metrics(accessors=()))
 

--- a/tests/tools/binaries/test_cuobjdump.py
+++ b/tests/tools/binaries/test_cuobjdump.py
@@ -4,6 +4,7 @@ import random
 import typing
 
 import pytest
+from cmake_file_api.kinds.toolchains.v1 import CMakeToolchainCompiler
 
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.tools.binaries import CuObjDump, CuppFilt, Function, ResourceUsage
@@ -70,7 +71,7 @@ class TestResourceUsage:
         FILE: typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / 'assets' / 'wide_load_store.cu'
         SIGNATURE: typing.Final[str] = '_Z22wide_load_store_kernelP15MyAlignedStructIdEPKS0_'
 
-        def test(self, workdir: pathlib.Path, parameters: Parameters, cmake_file_api: cmake.FileAPI) -> None:
+        def test(self, workdir: pathlib.Path, parameters: Parameters, cmake_file_api: cmake.FileAPI, cmake_cuda_compiler: CMakeToolchainCompiler) -> None:
             output, compilation = get_compilation_output(
                 source=self.FILE,
                 cwd=workdir,
@@ -91,7 +92,7 @@ class TestResourceUsage:
                 expt_regs = {
                     'NVIDIA': 14,
                     'Clang': 12,
-                }[cmake_file_api.toolchains['CUDA']['compiler']['id']]
+                }[cmake_cuda_compiler.id]
                 assert f'Used {expt_regs} registers, used 0 barriers' in compilation, compilation
                 assert ru == ResourceUsage(register=expt_regs, constant={0: 544})
             else:
@@ -239,7 +240,7 @@ class TestCuObjDump:
 
             assert cuobjdump.functions[self.SIGNATURE].symbol == self.SYMBOL
 
-        def test_extract_cubin_from_file(self, workdir, parameters: Parameters, cmake_file_api: cmake.FileAPI) -> None:
+        def test_extract_cubin_from_file(self, workdir, parameters: Parameters, cmake_file_api: cmake.FileAPI, cmake_cuda_compiler: CMakeToolchainCompiler) -> None:
             """
             Compile :py:attr:`CPP_FILE` as an executable, and extract the `cubin` from it.
             """
@@ -257,7 +258,7 @@ class TestCuObjDump:
                 arch=parameters.arch,
                 cwd=workdir,
                 cubin=get_cubin_name(
-                    compiler_id=cmake_file_api.toolchains['CUDA']['compiler']['id'],
+                    compiler=cmake_cuda_compiler,
                     file=output,
                     arch=parameters.arch,
                     object_file=False,
@@ -270,7 +271,7 @@ class TestCuObjDump:
             assert len(cuobjdump.functions) == 1
             assert self.SIGNATURE in cuobjdump.functions
 
-        def test_extract_symbol_table(self, workdir, parameters: Parameters, cmake_file_api: cmake.FileAPI) -> None:
+        def test_extract_symbol_table(self, workdir, parameters: Parameters, cmake_file_api: cmake.FileAPI, cmake_cuda_compiler: CMakeToolchainCompiler) -> None:
             """
             Compile :py:attr:`CPP_FILE` as an executable, and extract the symbol table from it.
             """
@@ -286,7 +287,7 @@ class TestCuObjDump:
 
             # This binary is not compiled to an object file. With `nvcc` as the compiler, the binary then contains
             # more than one embedded CUDA binary file. Hence, check that calling symtab raises.
-            if cmake_file_api.toolchains['CUDA']['compiler']['id'] == 'NVIDIA':
+            if cmake_cuda_compiler.id == 'NVIDIA':
                 with pytest.raises(RuntimeError, match=r'The host binary file contains more than one embedded CUDA binary file.'):
                     cuobjdump.symtab # pylint: disable=pointless-statement # noqa: B018
 
@@ -296,7 +297,7 @@ class TestCuObjDump:
                 arch=parameters.arch,
                 cwd=workdir,
                 cubin=get_cubin_name(
-                    compiler_id=cmake_file_api.toolchains['CUDA']['compiler']['id'],
+                    compiler=cmake_cuda_compiler,
                     file=output,
                     arch=parameters.arch,
                     object_file=False,
@@ -346,7 +347,7 @@ class TestCuObjDump:
 
             assert all(cuobjdump.functions[signature].symbol == symbol for symbol, signature in self.FUNCTIONS.items())
 
-        def test_extract_cubin_from_file(self, workdir, parameters: Parameters, cmake_file_api: cmake.FileAPI) -> None:
+        def test_extract_cubin_from_file(self, workdir, parameters: Parameters, cmake_file_api: cmake.FileAPI, cmake_cuda_compiler: CMakeToolchainCompiler) -> None:
             """
             Compile :py:attr:`CPP_FILE` as an executable, and extract the `cubin` from it.
             """
@@ -363,7 +364,7 @@ class TestCuObjDump:
                 arch=parameters.arch,
                 cwd=workdir,
                 cubin=get_cubin_name(
-                    compiler_id=cmake_file_api.toolchains['CUDA']['compiler']['id'],
+                    compiler=cmake_cuda_compiler,
                     file=output,
                     arch=parameters.arch,
                     object_file=False,
@@ -374,7 +375,7 @@ class TestCuObjDump:
 
             assert set(cuobjdump.functions.keys()) == set(self.FUNCTIONS.values())
 
-        def test_extract_symbol_table(self, workdir, parameters: Parameters, cmake_file_api: cmake.FileAPI) -> None:
+        def test_extract_symbol_table(self, workdir, parameters: Parameters, cmake_file_api: cmake.FileAPI, cmake_cuda_compiler: CMakeToolchainCompiler) -> None:
             """
             Compile :py:attr:`CPP_FILE` as an executable, and extract the symbol table from it.
             """
@@ -391,7 +392,7 @@ class TestCuObjDump:
                 arch=parameters.arch,
                 cwd=workdir,
                 cubin=get_cubin_name(
-                    compiler_id=cmake_file_api.toolchains['CUDA']['compiler']['id'],
+                    compiler=cmake_cuda_compiler,
                     file=output,
                     arch=parameters.arch,
                     object_file=False,

--- a/tests/tools/binaries/test_elf.py
+++ b/tests/tools/binaries/test_elf.py
@@ -9,6 +9,7 @@ import typing
 import elftools.elf.sections
 import pytest
 import semantic_version
+from cmake_file_api.kinds.toolchains.v1 import CMakeToolchainCompiler
 
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.tools.binaries import CuObjDump
@@ -264,7 +265,7 @@ class TestSaxpy:
             assert elf.is_cuda
             assert elf.arch == parameters.arch
 
-    def test_embedded_cubin_cuinfo_and_tkinfo(self, parameters: Parameters, object_file: pathlib.Path, workdir: pathlib.Path, cmake_file_api: cmake.FileAPI) -> None:
+    def test_embedded_cubin_cuinfo_and_tkinfo(self, parameters: Parameters, object_file: pathlib.Path, workdir: pathlib.Path, cmake_cuda_compiler: CMakeToolchainCompiler) -> None:
         """
         Retrieve the `cuinfo` and `tkinfo` note sections from a compiled output.
         """
@@ -283,7 +284,7 @@ class TestSaxpy:
             expt_tool_version = re.search(r'Cuda compilation tools, release [0-9.]+, V[0-9.]+', output).group()
             expt_tool_options = ['-v', f'-arch {parameters.arch.as_sm}', '-m 64']
 
-            match cmake_file_api.toolchains['CUDA']['compiler']['id']:
+            match cmake_cuda_compiler.id:
                 case 'Clang':
                     expt_tool_options.append('-O 3')
                 case _:
@@ -426,7 +427,7 @@ class TestNvInfo:
         return nvcc.get_version()
 
     @pytest.mark.parametrize('parameters', PARAMETERS, ids=str)
-    def test(self, version, parameters: Parameters, cmake_file_api: cmake.FileAPI, workdir: pathlib.Path) -> None:
+    def test(self, version, parameters: Parameters, cmake_file_api: cmake.FileAPI, workdir: pathlib.Path, cmake_cuda_compiler: CMakeToolchainCompiler) -> None:
         """
         Extract the `.nv.info.<mangled>` section of the kernel.
         """
@@ -446,7 +447,7 @@ class TestNvInfo:
             cwd=workdir,
             sass=False,
             cubin=get_cubin_name(
-                compiler_id=cmake_file_api.toolchains['CUDA']['compiler']['id'],
+                compiler=cmake_cuda_compiler,
                 file=output,
                 arch=parameters.arch,
                 object_file=False,

--- a/tests/tools/binaries/test_nvdisasm.py
+++ b/tests/tools/binaries/test_nvdisasm.py
@@ -3,6 +3,7 @@ import typing
 import unittest.mock
 
 import pytest
+from cmake_file_api.kinds.toolchains.v1 import CMakeToolchainCompiler
 
 from reprospect.tools.architecture import NVIDIAArch
 from reprospect.tools.binaries import CuObjDump, CuppFilt, LlvmCppFilt, NVDisasm
@@ -137,7 +138,7 @@ class TestNVDisasm:
         CPP_FILE:  typing.Final[pathlib.Path] = pathlib.Path(__file__).parent / 'assets' / 'many.cpp'
         SYMBOLS:   typing.Final[tuple[str, ...]] = ('_Z6say_hiv', '_Z20vector_atomic_add_42PKfS0_Pfj')
 
-        def test_from_executable(self, workdir, parameters: Parameters, cmake_file_api: cmake.FileAPI) -> None:
+        def test_from_executable(self, workdir, parameters: Parameters, cmake_file_api: cmake.FileAPI, cmake_cuda_compiler: CMakeToolchainCompiler) -> None:
             """
             Compile :py:attr:`CPP_FILE` as an executable, extract cubin and run ``nvdisasm``.
             """
@@ -154,7 +155,7 @@ class TestNVDisasm:
                 arch=parameters.arch,
                 cwd=workdir,
                 cubin=get_cubin_name(
-                    compiler_id=cmake_file_api.toolchains['CUDA']['compiler']['id'],
+                    compiler=cmake_cuda_compiler,
                     file=output,
                     arch=parameters.arch,
                     object_file=False,

--- a/tests/tools/test_ncu.py
+++ b/tests/tools/test_ncu.py
@@ -8,16 +8,13 @@ import typing
 import unittest.mock
 
 import pytest
+from cmake_file_api.kinds.toolchains.v1 import CMakeToolchainCompiler
 
 from reprospect.test.cmake import get_demangler_for_compiler
 from reprospect.tools import ncu
 from reprospect.tools.ncu.metrics import MetricCorrelationData
 from reprospect.utils import detect
 
-
-@pytest.fixture(scope='session')
-def cmake_cuda_compiler(cmake_file_api) -> dict:
-    return cmake_file_api.toolchains['CUDA']['compiler']
 
 class TestProfilingResults:
     """
@@ -358,7 +355,7 @@ class TestSession:
         # The metric 'inst_executed' correlates instruction addresses with how many times they were executed.
         assert all(isinstance(key, int) and isinstance(value, int) for key, value in metrics_saxpy_kernel_0['inst_executed'].correlated.items())
 
-    def test_collect_basic_metrics_graph(self, bindir, workdir, cmake_cuda_compiler: dict) -> None:
+    def test_collect_basic_metrics_graph(self, bindir, workdir, cmake_cuda_compiler: CMakeToolchainCompiler) -> None:
         """
         Collect a few basic metrics for the :py:attr:`GRAPH` executable.
         """
@@ -380,14 +377,14 @@ class TestSession:
         assert report.report.num_ranges() == 1
 
         # Extract results.
-        results = report.extract_results_in_range(metrics=METRICS, demangler=get_demangler_for_compiler(cmake_cuda_compiler['id']))
+        results = report.extract_results_in_range(metrics=METRICS, demangler=get_demangler_for_compiler(cmake_cuda_compiler))
 
         logging.info(results)
 
         # There are 4 nodes.
         assert len(results) == 4
 
-        match cmake_cuda_compiler['id']:
+        match cmake_cuda_compiler.id:
             case 'NVIDIA':
                 NODE_A_MANGLED = '_Z24add_and_increment_kernelILj0EJEEvPj'
                 metrics_node_A = results.query_metrics(accessors=('add_and_increment_kernel-0',))
@@ -396,7 +393,7 @@ class TestSession:
                 NODE_A_MANGLED = '_Z24add_and_increment_kernelILj0ETpTnjJEEvPj'
                 metrics_node_A = results.query_metrics(accessors=(f'{NODE_A_MANGLED}-0',))
             case _:
-                raise ValueError(f"unsupported compiler ID {cmake_cuda_compiler['id']}")
+                raise ValueError(f'unsupported compiler ID {cmake_cuda_compiler.id}')
 
         metrics_node_B = results.query_metrics(accessors=('add_and_increment_kernel-1',))
         metrics_node_C = results.query_metrics(accessors=('add_and_increment_kernel-2',))

--- a/tests/utils/test_cmake.py
+++ b/tests/utils/test_cmake.py
@@ -36,7 +36,7 @@ class TestFileAPI:
         assert 'CUDA' in cmake_file_api.toolchains
         assert 'CXX'  in cmake_file_api.toolchains
 
-        assert cmake_file_api.toolchains['CUDA']['compiler']['id'] in {'NVIDIA', 'Clang'}
+        assert cmake_file_api.compiler(toolchain='CUDA').id in {'NVIDIA', 'Clang'}
 
         for language, toolchain in cmake_file_api.toolchains.items():
             compiler = toolchain['compiler']


### PR DESCRIPTION
Instead of relying on a dictionary, let's rely on what cmake-file-api already provides.