### PR TITLE
Remove 'ruff' from build.yml tools list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -592,7 +592,6 @@ jobs:
             examples,
             mypy,
             pylint,
-            ruff,
             tests,
         ]
         runs-on: [self-hosted, linux, docker, amd64]
@@ -625,7 +624,6 @@ jobs:
             examples,
             mypy,
             pylint,
-            ruff,
             tests,
         ]
         runs-on: ubuntu-latest


### PR DESCRIPTION
Removed 'ruff' from the list of tools in the build workflow.