### PR TITLE
docs(sphinx): linking contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,3 @@ Start a discussion by [opening an issue](https://github.com/uliegecsm/reprospect
 
 If you've created an example or demonstration that could help others, please share it by [opening a pull request](https://github.com/uliegecsm/reprospect/pulls).
 Be sure to include a short description and usage notes.
-
----
-
-Thank you for your interest in `ReProspect`!

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,0 +1,2 @@
+.. include:: ../../CONTRIBUTING.md
+    :parser: myst_parser.sphinx_

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,3 +20,4 @@ For a quick introduction to `ReProspect`, see :ref:`overview`.
    examples
    tests
    bibliography
+   contributing


### PR DESCRIPTION
This PR addresses the problem @cedricchevalier pointed out in:
* #565

I created
- #573 

to track the fix.

This PR fixes #573.

I also removed the closing "Thank you", which was redundant with the first sentence of the file.