### PR TITLE
docs(sphinx): better left navigation menu

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -1,0 +1,9 @@
+API reference
+=============
+
+This reference manual is generated from the source code docstrings.
+
+.. toctree::
+   :maxdepth: 4
+
+   api/modules

--- a/docs/source/caching.rst
+++ b/docs/source/caching.rst
@@ -1,5 +1,5 @@
-Caching
-=======
+Caching of API tracing and kernel profiling results
+===================================================
 
 Profiling runs with ``ncu`` and ``nsys`` are time-consuming.
 Since developers are encouraged to write profiling tests whose results remain stable across runs,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
 
 html_theme = 'sphinx_rtd_theme'
 html_theme_options = {
+    "navigation_depth": 8,
     "style_external_links": True,
 }
 html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,11 +8,8 @@ For a quick introduction to `ReProspect`, see :ref:`overview`.
    :caption: Contents:
 
    overview
-   install
-   getting-started
-   analysis
-   caching
-   api/modules
+   user_guide
+   api_reference
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -1,0 +1,13 @@
+User Guide
+==========
+
+This guide walks you through installing and using `ReProspect`,
+covering basic usage and key features.
+
+.. toctree::
+   :maxdepth: 4
+
+   install
+   getting-started
+   analysis
+   caching


### PR DESCRIPTION
This PR reworks the left navigation menu of our documentation, as suggested by @cedricchevalier in:
- #565 

I created a sub-issue to track it:
- #572

This PR closes #572.

The current look is as follows.

<img width="2536" height="1981" alt="image" src="https://github.com/user-attachments/assets/496c79f9-0756-4611-8985-10165c1d88a1" />
