### PR TITLE
tests: add "integration" directory for "more involved" tests

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -1,3 +1,5 @@
+.. _examples:
+
 Examples
 ========
 

--- a/docs/source/tests.rst
+++ b/docs/source/tests.rst
@@ -11,7 +11,7 @@ Tests
 
    tests/compilation
    tests/cublas
-   tests/extensibility
+   tests/integration
    tests/parameters
    tests/test
    tests/tools

--- a/docs/source/tests/extensibility.rst
+++ b/docs/source/tests/extensibility.rst
@@ -1,4 +1,0 @@
-Extensibility
-=============
-
-.. automodule:: tests.test_extensibility

--- a/docs/source/tests/integration.rst
+++ b/docs/source/tests/integration.rst
@@ -1,0 +1,8 @@
+Integration tests
+=================
+
+Tests that exercise many features,
+but do not seek to exemplify use cases.
+For use cases, see :ref:`examples`.
+
+.. automodule:: tests.integration.test_half

--- a/docs/source/tests/test.rst
+++ b/docs/source/tests/test.rst
@@ -13,8 +13,3 @@ SASS
    :maxdepth: 1
 
    test/sass
-
-Others
-------
-
-.. automodule:: tests.test.test_half

--- a/docs/source/tests/test/sass.rst
+++ b/docs/source/tests/test/sass.rst
@@ -6,6 +6,7 @@ SASS
 .. automodule:: tests.test.sass.test_branch
 .. automodule:: tests.test.sass.test_composite
 .. automodule:: tests.test.sass.test_composite_impl
+.. automodule:: tests.test.sass.test_extensibility
 .. automodule:: tests.test.sass.test_instruction
 .. automodule:: tests.test.sass.test_load
 .. automodule:: tests.test.sass.test_store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -260,7 +260,7 @@ archs = []
 build-verbosity = 1
 
 test-command = [
-    "python -m pytest {package}/tests/test_extensibility.py",
+    "python -m pytest {package}/tests/test/sass/test_extensibility.py",
 ]
 test-requires = "pytest==9.0.2"
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ function(add_pytest FILE)
 endfunction()
 
 add_subdirectory(assets)
+add_subdirectory(integration)
 add_subdirectory(test)
 add_subdirectory(tools)
 add_subdirectory(utils)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_pytest(half)

--- a/tests/integration/test_half.py
+++ b/tests/integration/test_half.py
@@ -1,3 +1,13 @@
+"""
+Half types
+==========
+
+Analyze two kernels that compute the square of half-precision values with and without packing using:
+
+* many matchers from :py:mod:`reprospect.test.sass`
+* some profiling with :py:mod:`reprospect.tools.ncu`
+"""
+
 import math
 import pathlib
 import re

--- a/tests/test/CMakeLists.txt
+++ b/tests/test/CMakeLists.txt
@@ -1,5 +1,3 @@
 add_pytest(environment)
 
-add_pytest(half)
-
 add_subdirectory(sass)

--- a/tests/test/sass/controlflow/test_block.py
+++ b/tests/test/sass/controlflow/test_block.py
@@ -53,8 +53,8 @@ class TestBasicBlockMatcher(TestBasicBlock):
 
         Built on the observations from:
 
-        * :py:meth:`tests.test.test_half.TestSASS.test_individual`
-        * :py:meth:`tests.test.test_half.TestSASS.test_packed`
+        * :py:meth:`tests.integration.test_half.TestSASS.test_individual`
+        * :py:meth:`tests.integration.test_half.TestSASS.test_packed`
         """
         cfg_individual = ControlFlow.analyze(instructions=Decoder(code=cuobjdump.functions[self.SIGNATURE_INDIVIDUAL].code).instructions)
         cfg_packed     = ControlFlow.analyze(instructions=Decoder(code=cuobjdump.functions[self.SIGNATURE_PACKED].code).instructions)

--- a/tests/test/sass/test_extensibility.py
+++ b/tests/test/sass/test_extensibility.py
@@ -1,10 +1,19 @@
 """
-Ensure that the distributed package supports user extensions.
+Extensibility
+=============
 
 ``mypyc`` compilation can inadvertently seal classes, preventing inheritance.
-This module verifies that :py:mod:`reprospect` extension points (*e.g.*,
-:py:class:`reprospect.test.sass.instruction.InstructionMatcher`) remain
-subclassable after compilation, allowing users to extend :py:mod:`reprospect` capabilities.
+This module verifies that the following types remain
+subclassable after compilation, allowing users to extend :py:mod:`reprospect` capabilities:
+
+* :py:class:`reprospect.test.sass.instruction.InstructionMatcher` (see :py:class:`tests.test.sass.test_extensibility.NewInstructionMatcher`)
+* :py:class:`reprospect.test.sass.instruction.PatternMatcher` (see :py:class:`tests.test.sass.test_extensibility.NewPatternMatcher`)
+
+.. warning::
+
+    This test must be run with the compiled binary distribution of :py:mod:`reprospect`.
+    Using the source distribution makes :py:class:`tests.test.sass.test_extensibility.CannotBeExtended`
+    a valid extension.
 """
 
 import inspect


### PR DESCRIPTION
Towards:
- #576

This PR clarifies that the extensibility test is for the instructions only, that the `test_half.py` is an integration test (see documentation for what we mean by that).