### PR TITLE
cicd: examples arm64

### DIFF
--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -102,14 +102,8 @@ class Config:
         Each platform is a separate job, because multi-arch builds are too slow due to emulation.
         """
         for platform in self.platforms:
-            enable_tests = self.enable_tests is not False
-            # We don't run examples for 'linux/arm64'.
-            if platform.os == 'linux' and platform.architecture == 'arm64':
-                if self.enable_examples is True:
-                    raise RuntimeError(f'Running examples for {platform} is not supported yet.')
-                enable_examples = False
-            else:
-                enable_examples = self.enable_examples is not False
+            enable_tests    = self.enable_tests    is not False
+            enable_examples = self.enable_examples is not False
 
             yield {
                 'cuda_version': self.cuda_version,
@@ -208,7 +202,13 @@ def runs_on(spec: Runner, jtype: typing.Literal['tests', 'examples']) -> tuple[s
                 case _:
                     raise ValueError(spec)
         case 'examples':
-            return ('ubuntu-latest',)
+            match (spec.platform.os, spec.platform.architecture):
+                case ('linux', 'amd64'):
+                    return ('ubuntu-latest',)
+                case ('linux', 'arm64'):
+                    return ('ubuntu-24.04-arm',)
+                case _:
+                    raise ValueError(spec)
         case _:
             raise ValueError
 

--- a/docs/source/examples/kokkos/complex/division.rst
+++ b/docs/source/examples/kokkos/complex/division.rst
@@ -11,17 +11,54 @@ computes :math:`c^2 + d^2`, which can overflow for large inputs. Underflow regim
 Many algorithms have therefore been proposed to make complex division more robust
 :cite:`baudin-2012-robust-complex-division-scilab`, each with different trade-offs in
 numerical accuracy and performance.
+These algorithms typically use a scaling strategy.
+A further challenge in complex division is the handling of edge cases such as infinite or zero operands.
 
-Some implementations also claim **ISO/IEC 60559** compliance :cite:`iso-iec-9899-2024`,
-which mandates specific handling of edge cases such as infinite or zero operands.
-The :download:`compliance test <../../../../../examples/kokkos/complex/example_division_compliance.cpp>`
-can be used to validate several implementations against these requirements.
-Note that libraries such as `CCCL <https://github.com/NVIDIA/cccl/blob/a91db6e2a022a7aa03b37873f0d4caf5ac81281d/libcudacxx/include/cuda/std/__complex/complex.h#L469>`_
-expose an opt-out mechanism for this handling, which can save computation cycles when such operands are not expected.
+The standard **ISO/IEC 9899 (Annex G)** :cite:`iso-iec-9899-2024` raises the issue of overflow
+and underflow and specifies the expected outcomes for the edge cases to comply with **IEC 60599** real floating-point arithmetic.
+It also suggests an implementation that adopts a scaling approach using the :code:`scalbn` function
+and relies on branching to handle the edge cases.
+Compilers such as `LLVM <https://github.com/llvm/llvm-project/blob/2342db00ab4d0305580814fb00f477b4b5cebec6/compiler-rt/lib/builtins/divdc3.c>`_
+and libraries such as `CCCL <https://github.com/NVIDIA/cccl/blob/a91db6e2a022a7aa03b37873f0d4caf5ac81281d/libcudacxx/include/cuda/std/__complex/complex.h#L469>`_
+follow this suggested implementation.
+They also expose mechanisms to disable the branching,
+which can save computation cycles when such operands are not expected.
 
-This example focuses on performance using the Newton fractal
-:cite:`wikipedia-newton-fractal` as a benchmark, which requires one complex division
-per iteration per pixel.
+The current implementation of `complex division in Kokkos <https://github.com/kokkos/kokkos/blob/e3a19e1c5bd4dcc5f59fba216b72967692f5a33e/core/src/Kokkos_Complex.hpp#L181-L206>`_
+does not follow the **ISO/IEC 9899 (Annex G)** implementation.
+Instead, it adopts a scaling approach using a division, and it only partially
+complies with the handling of the edge cases.
+Their implementation thus entails more divisions than the **ISO/IEC 9899 (Annex G)** implementation, see
+:py:meth:`examples.kokkos.complex.example_division.TestSASS.test_norm_division_uses_more_rcp`.
+
+This example also explores a potential improvement of the
+**ISO/IEC 9899 (Annex G)** implementation that replaces the use of :code:`logb` followed by a cast to :code:`int`
+with a use of :code:`ilogb`.
+This change decreases the number of `fp64` instructions and cycles, see
+:py:meth:`examples.kokkos.complex.example_division.TestNCU.test_fp64_instructions_and_cycles`.
+
+This example thus compares three implementations:
+
+1. :py:attr:`examples.kokkos.complex.example_division.Method.NormDivision`
+2. :py:attr:`examples.kokkos.complex.example_division.Method.LogbScalbn`
+3. :py:attr:`examples.kokkos.complex.example_division.Method.ILogbScalbn`
+
+Both :py:attr:`examples.kokkos.complex.example_division.Method.LogbScalbn`
+and :py:attr:`examples.kokkos.complex.example_division.Method.ILogbScalbn` use a common C++ implementation templated
+on a flag that allows the handling of edge cases to be disabled
+and another flag that controls the use of :code:`ilogb`.
+
+This example has three parts:
+
+1. A :download:`compliance test <../../../../../examples/kokkos/complex/example_division_compliance.cpp>` that checks
+   whether each implementation complies with the expected outcomes for the edge cases.
+2. A binary analysis in :py:meth:`examples.kokkos.complex.example_division.TestSASS`
+   and a kernel profiling in :py:meth:`examples.kokkos.complex.example_division.TestNCU`.
+3. A benchmark in :py:meth:`examples.kokkos.complex.example_division_benchmarking.TestDivision`.
+
+The benchmark compares the performance of the three implementations using the Newton fractal
+:cite:`wikipedia-newton-fractal`, which requires one complex division
+per iteration per pixel:
 
 .. figure:: ../../../../../artifacts/examples/kokkos/complex/example_division_plot.cpp/fractal.svg
 

--- a/examples/kokkos/complex/example_division.hpp
+++ b/examples/kokkos/complex/example_division.hpp
@@ -24,16 +24,12 @@ namespace reprospect::examples::kokkos::complex {
  * Adapted from https://github.com/jtravs/cuda_complex/blob/master/cuda_complex.hpp#L553.
  * Similar to https://github.com/NVIDIA/cccl/blob/a91db6e2a022a7aa03b37873f0d4caf5ac81281d/libcudacxx/include/cuda/std/__complex/complex.h#L400-L496.
  *
- * @tparam EnableCompliance Enable ISO/IEC 60559 compliance.
+ * @tparam EnableCompliance Enable IEC 60599 compliance.
  * @tparam UseIlogb         Use @c ilogb instead of @c logb.
- *                          Only available when @c ILOGB_NAN_INF_DISTINGUISHABLE is defined.
  */
 template <bool EnableCompliance, bool UseIlogb, typename RealType>
 KOKKOS_FUNCTION constexpr Kokkos::complex<RealType>
     logb_scalbn(const Kokkos::complex<RealType>& x, const Kokkos::complex<RealType>& y) {
-#if !defined(ILOGB_NAN_INF_DISTINGUISHABLE)
-    static_assert(!UseIlogb);
-#endif
 
     RealType a = x.real();
     RealType b = x.imag();
@@ -78,7 +74,11 @@ KOKKOS_FUNCTION constexpr Kokkos::complex<RealType>
             } else if (
                 [&]() {
                     if constexpr (UseIlogb) {
+#if defined(ILOGB_NAN_INF_DISTINGUISHABLE)
                         return iexp == INT_MAX;
+#else
+                        return Kokkos::isinf(c) || Kokkos::isinf(d);
+#endif
                     } else {
                         return Kokkos::isinf(logbw);
                     }

--- a/examples/kokkos/complex/example_division.py
+++ b/examples/kokkos/complex/example_division.py
@@ -49,8 +49,19 @@ else:
 
 class Method(StrEnum):
     LogbScalbn = 'LogbScalbn'
+    """
+    Implementation that uses a scaling with the :code:`scalbn` function as suggested in :cite:`iso-iec-9899-2024`.
+    """
+
     ILogbScalbn = 'ILogbScalbn'
+    """
+    Same as :py:attr:`Method.LogbScalbn`, but using the :code:`ilogb` function.
+    """
+
     NormDivision = 'NormDivision'
+    """
+    Implementation that uses the division-based scaling `currently implemented in Kokkos <https://github.com/kokkos/kokkos/blob/e3a19e1c5bd4dcc5f59fba216b72967692f5a33e/core/src/Kokkos_Complex.hpp#L181-L206>`_.
+    """
 
 class TestDivision(CMakeAwareTestCase):
     KOKKOS_TOOLS_NVTX_CONNECTOR_LIB = environment.EnvironmentField(converter=pathlib.Path)
@@ -148,9 +159,15 @@ class TestSASS(TestDivision):
         assert len(findall(matcher=matcher_fp64_to_int32, instructions=decoder[Method.LogbScalbn].instructions)) == 1
 
     def test_detailed_register_usage(self, detailed_register_usage: dict[Method, DetailedRegisterUsage]) -> None: # pylint: disable=too-many-branches,too-many-statements
+        # CUDA compilation shares headers with the C++ standard library, thus bringing in their definition of FP_ILOGBNAN.
+        on_arm64 = any('aarch64' in str(p) for p in self.compiler(toolchain='CUDA').implicit.includeDirectories)
+
         match self.arch.compute_capability.as_int:
             case 70:
-                expt_ilogbscalbn =   {RegisterType.GPR: (40, 36), RegisterType.PRED: (4, 4)}
+                if on_arm64:
+                    expt_ilogbscalbn = {RegisterType.GPR: (40, 30), RegisterType.PRED: (4, 4)}
+                else:
+                    expt_ilogbscalbn = {RegisterType.GPR: (40, 36), RegisterType.PRED: (4, 4)}
                 expt_logbscalbn =    {RegisterType.GPR: (42, 38), RegisterType.PRED: (4, 4)}
                 expt_norm_division = {RegisterType.GPR: (40, 34), RegisterType.PRED: (5, 5)}
             case 75:
@@ -184,7 +201,10 @@ class TestSASS(TestDivision):
             case 100:
                 match self.compiler(toolchain='CUDA').id:
                     case 'NVIDIA':
-                        expt_ilogbscalbn =   {RegisterType.GPR: (45, 40), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}
+                        if on_arm64:
+                            expt_ilogbscalbn = {RegisterType.GPR: (42, 37), RegisterType.PRED: (4, 4), RegisterType.UGPR: (10, 6)}
+                        else:
+                            expt_ilogbscalbn = {RegisterType.GPR: (45, 40), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}
                         expt_logbscalbn =    {RegisterType.GPR: (45, 40), RegisterType.PRED: (4, 4), RegisterType.UGPR: (9, 5)}
                         expt_norm_division = {RegisterType.GPR: (40, 34), RegisterType.PRED: (4, 4), RegisterType.UGPR: (10, 6)}
                     case 'Clang':
@@ -204,7 +224,10 @@ class TestSASS(TestDivision):
                             expt_ilogbscalbn = {RegisterType.GPR: (40, 33), RegisterType.PRED: (3, 3), RegisterType.UGPR: (14, 10)}
                             expt_logbscalbn =  {RegisterType.GPR: (45, 40), RegisterType.PRED: (4, 4), RegisterType.UGPR: (11, 7)}
                         else:
-                            expt_ilogbscalbn = {RegisterType.GPR: (45, 39), RegisterType.PRED: (4, 4), RegisterType.UGPR: (10, 6)}
+                            if on_arm64:
+                                expt_ilogbscalbn = {RegisterType.GPR: (42, 34), RegisterType.PRED: (4, 4), RegisterType.UGPR: (10, 6)}
+                            else:
+                                expt_ilogbscalbn = {RegisterType.GPR: (45, 39), RegisterType.PRED: (4, 4), RegisterType.UGPR: (10, 6)}
                             if semantic_version.Version(os.environ['CUDA_VERSION']) in semantic_version.SimpleSpec('<13.2'):
                                 expt_logbscalbn = {RegisterType.GPR: (45, 40), RegisterType.PRED: (4, 4), RegisterType.UGPR: (10, 6)}
                             else:

--- a/examples/kokkos/complex/example_division_compliance.cpp
+++ b/examples/kokkos/complex/example_division_compliance.cpp
@@ -7,18 +7,18 @@
 #include "examples/kokkos/complex/example_division.hpp"
 
 #if !defined(__STDC_IEC_60559_COMPLEX__)
-#    error "Your compiler does not comply to ISO/IEC 60559."
+#    error "Your compiler does not comply to IEC 60599."
 #endif
 
 /**
  * @addtogroup unittests
  *
- * compliance of complex division w.r.t. ISO/IEC 60559
- * ---------------------------------------------------
+ * Compliance of complex division w.r.t. IEC 60599
+ * -----------------------------------------------
  *
- * Tests to check compliance to ISO/IEC 60559 of several complex division implementations.
+ * Tests that check compliance with IEC 60599 of several complex division implementations.
  *
- * See also @cite iso-iec-9899-2024, section G.5.2.
+ * See also @cite iso-iec-9899-2024 (Annex G).
  *
  * The tests can be found in @ref examples/kokkos/complex/example_division_compliance.cpp.
  */


### PR DESCRIPTION
The complex division example needed to be reworked because on ARM64, `FP_ILOGBNAN` maps to `INT_MAX`, making the previous implementation impractical.

With `logb`, we have:
- `+-0` -> `logb` -> `-\infty`
- `+-\infty` -> `logb` -> `+\infty`
- `nan` -> `logb` -> `nan`

With `ilogb`, we have:
- `+-0` -> `ilogb` -> `fp_ilogb0`
- `+-\infty` -> `ilogb` -> `int_max`
- `nan` -> `ilogb` -> `fp_ilogbnan` -> `int_min` on x86 vs `int_max` on arm64

So on arm64, we can't distinguish `+-\infty` from `nan` input.

The conditional that checks whether scaling will be used is ok, we exclude all infinities/nans.

In the conditional that ensures the compliance, the third branch is an issue. It wants to protect against the denominator being infinity. And so we must know whether we are in the `+-\infty` or `nan` case. The fix is to check based directly on the ilogb input, instead of based on the ilogb result. 
