### PR TITLE
docs(tests): better main test page experience

### DIFF
--- a/docs/source/tests.rst
+++ b/docs/source/tests.rst
@@ -1,18 +1,48 @@
 Tests
 =====
 
+The test directory structure mirrors
+the :py:mod:`reprospect` package source directory structure.
+
+The tests for the three main subpackages can be found in:
+
+.. toctree::
+   :maxdepth: 1
+
+   tests/test
+   tests/tools
+   tests/utils
+
+Tests that involve many subpackages are grouped in:
+
+.. toctree::
+   :maxdepth: 1
+
+   tests/integration
+
+Utilities for testing
+---------------------
+
+`ReProspect` tests use helpers for diverse tasks such as
+compiling or
+extracting random bits from cuBLAS.
+
+.. toctree::
+   :maxdepth: 1
+
+   tests/compilation
+   tests/cublas
+   tests/parameters
+
+Test assets
+-----------
+
+Test assets are located in:
+
+* a subdirectory named `assets` next to the test file that uses them
+* the central `tests/assets` directory if shared across multiple tests
+
 .. toctree::
    :maxdepth: 1
 
    tests/assets
-
-.. toctree::
-   :maxdepth: 4
-
-   tests/compilation
-   tests/cublas
-   tests/integration
-   tests/parameters
-   tests/test
-   tests/tools
-   tests/utils

--- a/docs/source/tests/test.rst
+++ b/docs/source/tests/test.rst
@@ -1,6 +1,8 @@
 Test
 ====
 
+Tests for :py:mod:`reprospect.test`.
+
 Environment
 -----------
 

--- a/docs/source/tests/tools.rst
+++ b/docs/source/tests/tools.rst
@@ -1,6 +1,8 @@
 Tools
 =====
 
+Tests for :py:mod:`reprospect.tools`.
+
 Architecture
 ------------
 

--- a/docs/source/tests/utils.rst
+++ b/docs/source/tests/utils.rst
@@ -1,6 +1,8 @@
 Utils
 =====
 
+Tests for :py:mod:`reprospect.utils`.
+
 `CMake`
 -------
 


### PR DESCRIPTION
This PR improves the user experience when landing on the main test page.

It has been split in 3 parts:
* tests
* utilities
* assets

to better guide the reader.

Some `.rst` were improved by telling which module they contain tests for.

Closes #576.