### PR TITLE
paper(joss): clearly defining what we mean by prospecting

### DIFF
--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -187,6 +187,8 @@ def runs_on(spec: Runner, jtype: typing.Literal['tests', 'examples']) -> tuple[s
     We do require the architecture as a label if the architecture is part of our
     available runner fleet.
 
+    Test jobs for `amd64` run on our runner fleet for caching efficiency.
+
     Example jobs for which we don't have a runner available run on the provider runners.
     """
     if spec in AVAILABLE_RUNNERS:

--- a/README.md
+++ b/README.md
@@ -12,8 +12,14 @@
 
 [![JOSS](https://joss.theoj.org/papers/31d0b8cb561f2ae10c399e2373543e7f/status.svg)](https://joss.theoj.org/papers/31d0b8cb561f2ae10c399e2373543e7f)
 
-# reprospect
+# ReProspect
 
-`ReProspect` provides a framework for reproducible prospecting of CUDA applications.
+`ReProspect` [/riːˈprɒs.pɛkt/] is a Python framework for prospecting CUDA code,
+designed to ensure reproducibility through a fully programmatic approach.
+Prospecting encompasses three complementary ways of characterizing
+CUDA-based libraries and software components:
+how they interact with the CUDA runtime through API tracing,
+how kernels perform through kernel profiling,
+and how source constructs translate into machine code through binary analysis.
 
 See [the documentation](https://uliegecsm.github.io/reprospect/) for more information.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,5 @@
-ReProspect documentation
-========================
-
-For a quick introduction to `ReProspect`, see :ref:`overview`.
+.. include:: ../../README.md
+    :parser: myst_parser.sphinx_
 
 .. toctree::
    :maxdepth: 4

--- a/papers/joss/2025/paper.md
+++ b/papers/joss/2025/paper.md
@@ -29,14 +29,20 @@ bibliography: paper.bib
 
 # Summary
 
-`ReProspect` is a Python framework designed to support reproducible prospecting of CUDA code---that is, the systematic analysis of CUDA-based libraries and software components through API tracing, kernel profiling, and binary analysis.
+`ReProspect` is a Python framework for prospecting CUDA code,
+designed to ensure reproducibility through a fully programmatic approach.
+Prospecting encompasses three complementary ways of characterizing
+CUDA-based libraries and software components:
+how they interact with the CUDA runtime through API tracing,
+how kernels perform through kernel profiling,
+and how source constructs translate into machine code through binary analysis.
 
 `ReProspect` builds on NVIDIA tools:
 Nsight Systems,
 Nsight Compute, and
 the CUDA binary utilities.
 It streamlines data collection and extraction using these tools,
-and it complements them with new functionalities for a fully programmatic analysis of these data,
+and it complements them with new functionalities for programmatic analysis of these data,
 thus making it possible to encapsulate the entire prospecting analysis in a single Python script.
 
 `ReProspect` provides a practical foundation for developing novel use cases of CUDA code prospecting.


### PR DESCRIPTION
This PR addresses:
- #585

by making more explicit what we mean by prospecting.

The first paragraph of the paper is copy/pasted into the readme, and the readme is included in the Sphinx documentation to fully address #585.

Closes #585.