### PR TITLE
docs: add CICD strategy matrix

### DIFF
--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -303,6 +303,8 @@ def main(*, args: argparse.Namespace) -> None:
     """
     matrix = []
 
+    # STRATEGY-MATRIX-START
+
     matrix.extend(from_config(Config(
         cuda_version='12.8.1',
         ubuntu_version='24.04',
@@ -455,6 +457,8 @@ def main(*, args: argparse.Namespace) -> None:
         compute_capability=ComputeCapability(major=12, minor=0),
         platforms=(Platform.from_str('linux/amd64'),),
     ), args=args))
+
+    # STRATEGY-MATRIX-END
 
     logging.info(f'Strategy matrix:\n{pprint.pformat(matrix)}')
 

--- a/docs/source/tests.rst
+++ b/docs/source/tests.rst
@@ -46,3 +46,17 @@ Test assets are located in:
    :maxdepth: 1
 
    tests/assets
+
+CI/CD strategy matrix
+---------------------
+
+The CI/CD strategy matrix covers:
+
+- many CUDA versions
+- many architectures
+- ``nvcc`` or ``clang`` as CUDA compiler
+
+.. literalinclude:: ../../.github/workflows/strategy.py
+   :language: python
+   :start-after: STRATEGY-MATRIX-START
+   :end-before: STRATEGY-MATRIX-END


### PR DESCRIPTION
This PR adds our strategy matrix in the documentation to help readers understand how nice our testing coverage is :wing: 