### PR TITLE
examples(kokkos): graph definition stage API call sequence

### DIFF
--- a/docs/source/examples/kokkos/graph.rst
+++ b/docs/source/examples/kokkos/graph.rst
@@ -4,5 +4,6 @@
 .. toctree::
    :maxdepth: 1
 
+   graph/definition
    graph/dispatch
    graph/then

--- a/docs/source/examples/kokkos/graph/definition.rst
+++ b/docs/source/examples/kokkos/graph/definition.rst
@@ -1,0 +1,4 @@
+Definition stage
+================
+
+.. automodule:: examples.kokkos.graph.example_definition

--- a/examples/kokkos/graph/CMakeLists.txt
+++ b/examples/kokkos/graph/CMakeLists.txt
@@ -1,2 +1,3 @@
+add_one_kokkos_example(definition)
 add_one_kokkos_example(dispatch)
 add_one_kokkos_example(then)

--- a/examples/kokkos/graph/example_definition.cpp
+++ b/examples/kokkos/graph/example_definition.cpp
@@ -1,0 +1,67 @@
+#include "Kokkos_Core.hpp"
+#include "Kokkos_Graph.hpp"
+#include "Kokkos_Profiling_ProfileSection.hpp"
+#include "Kokkos_Profiling_ScopedRegion.hpp"
+
+/**
+ * @file
+ *
+ * Companion of @ref examples/kokkos/graph/example_definition.py.
+ */
+
+namespace reprospect::examples::kokkos::graph {
+
+template <typename ViewType>
+struct Functor {
+    ViewType data;
+
+    KOKKOS_FUNCTION void operator()() const {
+        Kokkos::atomic_add(data.data(), typename ViewType::value_type{1});
+    }
+};
+
+class Definition {
+   private:
+    using graph_t = Kokkos::Experimental::Graph<Kokkos::Cuda>;
+    using view_t = Kokkos::View<int, Kokkos::SharedSpace>;
+
+   public:
+    static void run(const Kokkos::Cuda& exec) {
+        const view_t data(Kokkos::view_alloc(exec, "data"));
+
+        const auto device_handle = Kokkos::Experimental::get_device_handle(exec);
+
+        std::optional<graph_t> graph = std::nullopt;
+
+        {
+            const Kokkos::Profiling::ScopedRegion region("graph - definition");
+
+            graph = Kokkos::Experimental::create_graph(device_handle, [&](const auto& root) {
+                const auto node_A = root.then(Functor<view_t>{.data = data});
+                Kokkos::Experimental::when_all(
+                    node_A.then(Functor<view_t>{.data = data}), node_A.then(Functor<view_t>{.data = data}))
+                    .then(Functor<view_t>{.data = data});
+            });
+        }
+
+        graph->submit(exec);
+
+        exec.fence();
+
+        if (data() != 4)
+            throw std::runtime_error("Unexpected value.");
+    }
+};
+} // namespace reprospect::examples::kokkos::graph
+
+int main(int argc, char* argv[]) {
+    Kokkos::ScopeGuard guard{argc, argv};
+    {
+        Kokkos::Profiling::ProfilingSection profiling_section{"definition"};
+        profiling_section.start();
+
+        reprospect::examples::kokkos::graph::Definition::run(Kokkos::Cuda{});
+
+        profiling_section.stop();
+    }
+}

--- a/examples/kokkos/graph/example_definition.py
+++ b/examples/kokkos/graph/example_definition.py
@@ -1,0 +1,101 @@
+"""
+Check the CUDA API calls made when defining a :code:`Kokkos::Experimental::Graph`.
+"""
+
+import logging
+import pathlib
+import sys
+
+import pytest
+
+from reprospect.test import CMakeAwareTestCase, environment
+from reprospect.tools import nsys
+from reprospect.utils import detect
+from reprospect.utils.rich_helpers import df_to_table, to_string
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+class TestDefinition(CMakeAwareTestCase):
+    """
+    Trace the CUDA API calls during :code:`Kokkos::Experimental::Graph` definition stage.
+
+    It uses :file:`examples/kokkos/graph/example_definition.cpp`.
+    """
+    KOKKOS_TOOLS_NVTX_CONNECTOR_LIB = environment.EnvironmentField(converter=pathlib.Path)
+    """Used in :py:meth:`TestNSYS.report`."""
+
+    @classmethod
+    @override
+    def get_target_name(cls) -> str:
+        return 'examples_kokkos_graph_definition'
+
+@pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason='needs a GPU')
+class TestNSYS(TestDefinition):
+    """
+    `nsys`-focused analysis.
+    """
+    @pytest.fixture(scope='class')
+    def report(self) -> nsys.Report:
+        """
+        Analyse with `nsys`, use :py:class:`reprospect.tools.nsys.Cacher`.
+        """
+        with nsys.Cacher() as cacher:
+            command = nsys.Command(
+                executable=self.executable,
+                output=self.cwd / self.executable.name,
+                opts=('--cuda-graph-trace=node',),
+                nvtx_capture='definition',
+                args=(
+                    f'--kokkos-tools-libs={self.KOKKOS_TOOLS_NVTX_CONNECTOR_LIB}',
+                ),
+            )
+            entry = cacher.run(command=command, cwd=self.cwd)
+
+            return nsys.Report(db=cacher.export_to_sqlite(command=command, entry=entry))
+
+    def test_api_calls(self, report: nsys.Report) -> None:
+        """
+        Check the sequence of CUDA API calls to create the graph, nodes and edges.
+        """
+        with report:
+            logging.info(report.nvtx_events)
+
+            api = report.get_events(table='CUPTI_ACTIVITY_KIND_RUNTIME', accessors=('definition', 'graph - definition'))
+
+            logging.info(to_string(df_to_table(api)))
+
+            expt = (
+                'cudaGraphCreate',
+                # The root node is created.
+                'cudaGraphAddEmptyNode',
+                # Node A is added.
+                'cudaGraphAddKernelNode',
+                'cudaGraphAddDependencies',
+                # Node B is added.
+                'cudaGraphAddKernelNode',
+                'cudaGraphAddDependencies',
+                # Node C is added.
+                'cudaGraphAddKernelNode',
+                'cudaGraphAddDependencies',
+                # The aggregate node is added.
+                'cudaGraphAddEmptyNode',
+                'cudaGraphAddDependencies',
+                'cudaGraphAddDependencies',
+                # Node D is added.
+                'cudaGraphAddKernelNode',
+                'cudaGraphAddDependencies',
+            )
+
+            expt_it = iter(expt)
+            current = next(expt_it, None)
+
+            for name in map(nsys.strip_cuda_api_suffix, api['name']):
+                if name == current:
+                    current = next(expt_it, None)
+                    if current is None:
+                        break
+
+            assert current is None

--- a/examples/kokkos/graph/example_dispatch.cpp
+++ b/examples/kokkos/graph/example_dispatch.cpp
@@ -10,6 +10,7 @@
  */
 
 namespace reprospect::examples::kokkos::graph {
+
 template <typename ViewType>
 struct Functor {
     ViewType data;

--- a/examples/kokkos/graph/example_dispatch.py
+++ b/examples/kokkos/graph/example_dispatch.py
@@ -10,7 +10,7 @@ import semantic_version
 
 from reprospect.test import CMakeAwareTestCase, environment
 from reprospect.tools import nsys
-from reprospect.utils import detect
+from reprospect.utils import detect, rich_helpers
 
 if sys.version_info >= (3, 12):
     from typing import override
@@ -107,22 +107,26 @@ class TestNSYS(TestDispatch):
 
             # Select kernels from the first graph submission.
             kernels_0 = self.get(report=report, kernels=kernels, label='graph - submit - 0')
+            logging.info(f'Kernels for the first submission are:\n{rich_helpers.to_string(rich_helpers.df_to_table(kernels_0.T.reset_index()))}.')
+
             assert len(kernels_0) == self.NODE_COUNT
 
             streams_0 = kernels_0['streamId'].to_list()
 
-            logging.info(f'Kernels for the first submission ran on {streams_0}.')
+            logging.info(f'Kernels for the first submission ran on streams {streams_0}.')
 
             assert len(streams_0) == len(set(streams_0))
 
             # Select kernels from the second graph submission.
             # Second submission reuses the streams of the first submission.
             kernels_1 = self.get(report=report, kernels=kernels, label='graph - submit - 1')
+            logging.info(f'Kernels for the second submission are:\n{rich_helpers.to_string(rich_helpers.df_to_table(kernels_0.T.reset_index()))}.')
+
             assert len(kernels_1) == self.NODE_COUNT
 
             streams_1 = kernels_1['streamId'].to_list()
 
-            logging.info(f'Kernels for the second submission ran on {streams_1}.')
+            logging.info(f'Kernels for the second submission ran on streams {streams_1}.')
 
             assert sorted(streams_0) == sorted(streams_1)
 

--- a/examples/kokkos/graph/example_then.cpp
+++ b/examples/kokkos/graph/example_then.cpp
@@ -9,6 +9,7 @@
  */
 
 namespace reprospect::examples::kokkos::graph {
+
 template <typename ViewType>
 struct Functor {
     ViewType data;


### PR DESCRIPTION
This PR introduces a very simple example demonstrating how to test how `Kokkos::Experimental::Graph` definition stage maps to CUDA API calls.