### PR TITLE
examples(dispatch): enhance debugging

### DIFF
--- a/examples/kokkos/graph/example_dispatch.py
+++ b/examples/kokkos/graph/example_dispatch.py
@@ -109,6 +109,11 @@ class TestNSYS(TestDispatch):
             kernels_0 = self.get(report=report, kernels=kernels, label='graph - submit - 0')
             logging.info(f'Kernels for the first submission are:\n{rich_helpers.to_string(rich_helpers.df_to_table(kernels_0.T.reset_index()))}.')
 
+            # Select kernels from the second graph submission.
+            kernels_1 = self.get(report=report, kernels=kernels, label='graph - submit - 1')
+            logging.info(f'Kernels for the second submission are:\n{rich_helpers.to_string(rich_helpers.df_to_table(kernels_0.T.reset_index()))}.')
+
+            # Check kernels of the first graph submission.
             assert len(kernels_0) == self.NODE_COUNT
 
             streams_0 = kernels_0['streamId'].to_list()
@@ -117,11 +122,7 @@ class TestNSYS(TestDispatch):
 
             assert len(streams_0) == len(set(streams_0))
 
-            # Select kernels from the second graph submission.
-            # Second submission reuses the streams of the first submission.
-            kernels_1 = self.get(report=report, kernels=kernels, label='graph - submit - 1')
-            logging.info(f'Kernels for the second submission are:\n{rich_helpers.to_string(rich_helpers.df_to_table(kernels_0.T.reset_index()))}.')
-
+            # Check kernels of the second graph submission.
             assert len(kernels_1) == self.NODE_COUNT
 
             streams_1 = kernels_1['streamId'].to_list()


### PR DESCRIPTION
https://github.com/uliegecsm/reprospect/actions/runs/25238117406/job/74009768750?pr=607 seems to show that one kernel from the second submission is selected by the "select kernels from first submission" logic.

This happens quite rarely, and I wonder if it is a bug on our side, or not.

Note that we first look for the graph submission event, and then look for the graph nodes that are correlated. So the extraneous node has the correletion ID of the first graph submission, though even if it has the same `graphNodeId` as the first node, clearly started later. It seems to indicate that it's from the second launch.

This PR simply moves the printing of the selection of the kernels of the second submission, for later debugging. I could not reproduce on my computer (ampere 86, CUDA 13.0), did not tested on blackwell. May be related to CUDA 13.2.

```bash

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃ index                           ┃ 0               ┃ 1               ┃ 2               ┃ 3               ┃ 4               ┃ 5               ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ start                           │ 28897009        │ 28906097        │ 28906321        │ 28908049        │ 28909841        │ 28911506        │
│ end                             │ 28897585        │ 28906833        │ 28906993        │ 28908625        │ 28910385        │ 28912050        │
...
│ correlationId                   │ 769             │ 769             │ 769             │ 769             │ 769             │ 769             │
...
│ graphNodeId                     │ 8589934593      │ 8589934594      │ 8589934596      │ 8589934595      │ 8589934597      │ 8589934594      │
```