### PR TITLE
tests(sass): cublas detected `SB[0-9]` operand

### DIFF
--- a/tests/test/sass/instruction/test_cublas.py
+++ b/tests/test/sass/instruction/test_cublas.py
@@ -87,6 +87,7 @@ class TestCuBLAS:
         # Matchers for other operands.
         matchers_op.extend((
             regex.compile(r'B[0-9]+'),
+            regex.compile(r'SB[0-9]'),
             regex.compile(r'PR'),
             regex.compile(r'(SR_TID|SR_CTAID)\.(X|Y|Z)'),
             regex.compile(r'SR(X|Y|Z)'),


### PR DESCRIPTION
Seen in a CI job for CUDA 12.6.3:
```bash
INFO     root:cuobjdump.py:172 Extracting 'SASS' from /__w/reprospect/reprospect/build-with-gnu-nvidia/tests/test/sass/instruction/libcublas.39.sm_90.cubin using ('cuobjdump', '--gpu-architecture', 'sm_90', '--dump-sass', '--dump-resource-usage', PosixPath('/__w/reprospect/reprospect/build-with-gnu-nvidia/tests/test/sass/instruction/libcublas.39.sm_90.cubin')).
INFO     root:test_cublas.py:97 Picked function void trsv_lt_exec_up_64addr<float2, (unsigned int)32, (unsigned int)32, (unsigned int)4, (bool)1, (bool)1>(int, const T1 *, long, T1 *, long, int *) from /__w/reprospect/reprospect/build-with-gnu-nvidia/tests/test/sass/instruction/libcublas.39.sm_90.cubin for HOPPER90.
INFO     root:test_cublas.py:106 Instruction DEPBAR.LE SB0, 0x0 has unmatched operand SB0.
```

For the record, here is the code I used to reproduce the instruction:
```c++
#include <cooperative_groups.h>
#include <cooperative_groups/memcpy_async.h>

__global__ void depbar_test(const int *src, int *dst, int n) {
    extern __shared__ int smem[];

    int i = threadIdx.x;
    if (i >= n) return;

    auto block = cooperative_groups::this_thread_block();

    cooperative_groups::memcpy_async(block, smem, src, sizeof(int) * n);
    cooperative_groups::wait(block);

    dst[i] = smem[i];
}
```