### PR TITLE
fix(doc): `cuda.core.ObjectCode` no longer in the `objects.inv`

### DIFF
--- a/reprospect/tools/binaries/cuobjdump.py
+++ b/reprospect/tools/binaries/cuobjdump.py
@@ -3,7 +3,7 @@ Tools that can be used to extract SASS code and kernel attributes from executabl
 
 .. note::
 
-    Whereas :py:class:`cuda.core.ObjectCode` focuses on compiling with ``nvcc`` and querying a handful
+    Whereas :py:class:`cuda.core._module.KernelAttributes` focuses on compiling with ``nvcc`` and querying a handful
     of kernel properties, this modules provides an interface to the CUDA binary analysis utilities to allow
     the SASS code of each kernel to be extracted for more extensive analysis, *e.g.* with :py:mod:`reprospect.tools.sass`.
 """


### PR DESCRIPTION
After updates in `cuda-python`.