### PR TITLE
tools(kernel profiling): uniformise metric factories

### DIFF
--- a/examples/kokkos/complex/example_alignment.py
+++ b/examples/kokkos/complex/example_alignment.py
@@ -174,11 +174,11 @@ class TestNCU(TestAlignment):
         # Specific instruction counts (LDG and STG and others).
         MetricCorrelation(name='sass__inst_executed_per_opcode'),
         # Memory traffic.
-        L1TEXCache.GlobalLoad.Instructions.create(),
-        L1TEXCache.GlobalLoad.Sectors.create(),
-        L1TEXCache.GlobalLoad.SectorMisses.create(),
-        L1TEXCache.GlobalStore.Instructions.create(),
-        L1TEXCache.LocalStore.Instructions.create(),
+        *L1TEXCache.GlobalLoad.Instructions.create(),
+        *L1TEXCache.GlobalLoad.Sectors.create(),
+        *L1TEXCache.GlobalLoad.SectorMisses.create(),
+        *L1TEXCache.GlobalStore.Instructions.create(),
+        *L1TEXCache.LocalStore.Instructions.create(),
         MetricCounter(name='lts__t_sectors_srcunit_tex_op_read_lookup_miss', subs=(MetricCounterRollUp.SUM,)),
     )
 

--- a/examples/kokkos/view/example_restrict.py
+++ b/examples/kokkos/view/example_restrict.py
@@ -497,9 +497,9 @@ class TestNCU(TestRestrict):
     Kernel profiling.
     """
     METRICS: tuple[ncu.Metric | ncu.MetricCorrelation, ...] = (
-        ncu.L1TEXCache.GlobalLoad.Sectors.create(),
-        ncu.L1TEXCache.GlobalLoad.SectorMisses.create(),
-        ncu.L1TEXCache.GlobalStore.Sectors.create(),
+        *ncu.L1TEXCache.GlobalLoad.Sectors.create(),
+        *ncu.L1TEXCache.GlobalLoad.SectorMisses.create(),
+        *ncu.L1TEXCache.GlobalStore.Sectors.create(),
         ncu.MetricCounter(name='lts__t_sectors_srcunit_tex_op_read_lookup_miss', subs=(ncu.MetricCounterRollUp.SUM,)),
     )
 

--- a/reprospect/tools/ncu/metrics.py
+++ b/reprospect/tools/ncu/metrics.py
@@ -149,11 +149,15 @@ class XYZBase:
     """
     prefix: typing.ClassVar[str]
 
+    pretty_prefix: typing.ClassVar[str | None] = None
+
     @classmethod
-    def create(cls, dims: typing.Iterable[str] | None = None) -> typing.Iterable[Metric]:
+    def create(cls, dims: typing.Iterable[str] | None = None) -> tuple[Metric, ...]:
         if not dims:
             dims = ('x', 'y', 'z')
-        return (Metric(name=cls.prefix + dim) for dim in dims)
+        if cls.pretty_prefix:
+            return tuple(Metric(name=cls.prefix + dim, pretty_name=f'{cls.pretty_prefix} {dim}') for dim in dims)
+        return tuple(Metric(name=cls.prefix + dim) for dim in dims)
 
 class LaunchBlock(XYZBase):
     """
@@ -161,11 +165,15 @@ class LaunchBlock(XYZBase):
     """
     prefix: typing.ClassVar[str] = 'launch__block_dim_'
 
+    pretty_prefix: typing.ClassVar[str | None] = 'launch block size'
+
 class LaunchGrid(XYZBase):
     """
     Factory of metrics ``launch__grid_dim_x``, ``launch__grid_dim_y`` and ``launch__grid_dim_z``.
     """
     prefix: typing.ClassVar[str] = 'launch__grid_dim_'
+
+    pretty_prefix: typing.ClassVar[str | None] = 'launch grid size'
 
 class Unit(StrEnum):
     """
@@ -236,7 +244,7 @@ class L1TEXCacheGlobalLoadInstructions:
         unit: Unit = Unit.SMSP,
         mode: typing.Literal['sass'] | None = 'sass',
         subs: tuple[MetricCounterRollUp, ...] = (MetricCounterRollUp.SUM,),
-    ) -> MetricCounter:
+    ) -> tuple[MetricCounter, ...]:
         name = counter_name_from(
             unit=unit,
             quantity=f'sass_{Quantity.INSTRUCTION}' if mode == 'sass' else Quantity.INSTRUCTION,
@@ -245,7 +253,7 @@ class L1TEXCacheGlobalLoadInstructions:
 
         pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.GlobalLoad.NAME, 'instructions', mode)))
 
-        return MetricCounter(name=name, pretty_name=pretty_name, subs=subs)
+        return (MetricCounter(name=name, pretty_name=pretty_name, subs=subs),)
 
 class L1TEXCacheGlobalLoadRequests:
     """
@@ -254,7 +262,7 @@ class L1TEXCacheGlobalLoadRequests:
     @staticmethod
     def create(*,
         subs: tuple[MetricCounterRollUp, ...] = (MetricCounterRollUp.SUM,),
-    ) -> MetricCounter:
+    ) -> tuple[MetricCounter, ...]:
         name = counter_name_from(
             unit=Unit.L1TEX,
             pipestage=PipeStage.TAG,
@@ -264,7 +272,7 @@ class L1TEXCacheGlobalLoadRequests:
 
         pretty_name = f'{L1TEXCache.NAME} {L1TEXCache.GlobalLoad.NAME} requests'
 
-        return MetricCounter(name=name, pretty_name=pretty_name, subs=subs)
+        return (MetricCounter(name=name, pretty_name=pretty_name, subs=subs),)
 
 class L1TEXCacheGlobalLoadSectors:
     """
@@ -274,7 +282,7 @@ class L1TEXCacheGlobalLoadSectors:
     def create(*,
         subs: tuple[MetricCounterRollUp, ...] = (MetricCounterRollUp.SUM,),
         suffix: typing.Literal['hit', 'miss'] | None = None,
-    ) -> MetricCounter:
+    ) -> tuple[MetricCounter, ...]:
         qualifier = f'pipe_lsu_mem_global_op_ld_lookup_{suffix}' if suffix else 'pipe_lsu_mem_global_op_ld'
 
         name = counter_name_from(
@@ -286,7 +294,7 @@ class L1TEXCacheGlobalLoadSectors:
 
         pretty_name = ' '.join((L1TEXCache.NAME, L1TEXCache.GlobalLoad.NAME, f'sectors {suffix}' if suffix else 'sectors'))
 
-        return MetricCounter(name=name, pretty_name=pretty_name, subs=subs)
+        return (MetricCounter(name=name, pretty_name=pretty_name, subs=subs),)
 
 class L1TEXCacheGlobalLoadSectorHits:
     """
@@ -295,7 +303,7 @@ class L1TEXCacheGlobalLoadSectorHits:
     @staticmethod
     def create(*,
         subs: tuple[MetricCounterRollUp, ...] = (MetricCounterRollUp.SUM,),
-    ) -> MetricCounter:
+    ) -> tuple[MetricCounter, ...]:
         return L1TEXCacheGlobalLoadSectors.create(subs=subs, suffix='hit')
 
 class L1TEXCacheGlobalLoadSectorMisses:
@@ -305,7 +313,7 @@ class L1TEXCacheGlobalLoadSectorMisses:
     @staticmethod
     def create(*,
         subs: tuple[MetricCounterRollUp, ...] = (MetricCounterRollUp.SUM,),
-    ) -> MetricCounter:
+    ) -> tuple[MetricCounter, ...]:
         return L1TEXCacheGlobalLoadSectors.create(subs=subs, suffix='miss')
 
 class L1TEXCacheGlobalLoadWavefronts:
@@ -315,7 +323,7 @@ class L1TEXCacheGlobalLoadWavefronts:
     @staticmethod
     def create(*,
         subs: tuple[MetricCounterRollUp, ...] = (MetricCounterRollUp.SUM,),
-    ) -> MetricCounter:
+    ) -> tuple[MetricCounter, ...]:
         name = counter_name_from(
             unit=Unit.L1TEX,
             pipestage=PipeStage.TAG_OUTPUT,
@@ -325,7 +333,7 @@ class L1TEXCacheGlobalLoadWavefronts:
 
         pretty_name = f'{L1TEXCache.NAME} {L1TEXCache.GlobalLoad.NAME} wavefronts'
 
-        return MetricCounter(name=name, pretty_name=pretty_name, subs=subs)
+        return (MetricCounter(name=name, pretty_name=pretty_name, subs=subs),)
 
 class L1TEXCacheGlobalLoad:
 
@@ -352,7 +360,7 @@ class L1TEXCacheGlobalStoreInstructions:
         unit: Unit = Unit.SMSP,
         mode: typing.Literal['sass'] | None = 'sass',
         subs: tuple[MetricCounterRollUp, ...] = (MetricCounterRollUp.SUM,),
-    ) -> MetricCounter:
+    ) -> tuple[MetricCounter, ...]:
         name = counter_name_from(
             unit=unit,
             quantity=f'sass_{Quantity.INSTRUCTION}' if mode == 'sass' else Quantity.INSTRUCTION,
@@ -361,7 +369,7 @@ class L1TEXCacheGlobalStoreInstructions:
 
         pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.GlobalStore.NAME, 'instructions', mode)))
 
-        return MetricCounter(name=name, pretty_name=pretty_name, subs=subs)
+        return (MetricCounter(name=name, pretty_name=pretty_name, subs=subs),)
 
 class L1TEXCacheGlobalStoreRequests:
     """
@@ -370,7 +378,7 @@ class L1TEXCacheGlobalStoreRequests:
     @staticmethod
     def create(*,
         subs: tuple[MetricCounterRollUp, ...] = (MetricCounterRollUp.SUM,),
-    ) -> MetricCounter:
+    ) -> tuple[MetricCounter, ...]:
         name = counter_name_from(
             unit=Unit.L1TEX,
             pipestage=PipeStage.TAG,
@@ -380,7 +388,7 @@ class L1TEXCacheGlobalStoreRequests:
 
         pretty_name = f'{L1TEXCache.NAME} {L1TEXCache.GlobalStore.NAME} requests'
 
-        return MetricCounter(name=name, pretty_name=pretty_name, subs=subs)
+        return (MetricCounter(name=name, pretty_name=pretty_name, subs=subs),)
 
 class L1TEXCacheGlobalStoreSectors:
     """
@@ -389,7 +397,7 @@ class L1TEXCacheGlobalStoreSectors:
     @staticmethod
     def create(*,
         subs: tuple[MetricCounterRollUp, ...] = (MetricCounterRollUp.SUM,),
-    ) -> MetricCounter:
+    ) -> tuple[MetricCounter, ...]:
         name = counter_name_from(
             unit=Unit.L1TEX,
             pipestage=PipeStage.TAG,
@@ -399,7 +407,7 @@ class L1TEXCacheGlobalStoreSectors:
 
         pretty_name = f'{L1TEXCache.NAME} {L1TEXCache.GlobalStore.NAME} sectors'
 
-        return MetricCounter(name=name, pretty_name=pretty_name, subs=subs)
+        return (MetricCounter(name=name, pretty_name=pretty_name, subs=subs),)
 
 class L1TEXCacheGlobalStore:
 
@@ -420,7 +428,7 @@ class L1TEXCacheLocalStoreInstructions:
         unit: Unit = Unit.SMSP,
         mode: typing.Literal['sass'] | None = 'sass',
         subs: tuple[MetricCounterRollUp, ...] = (MetricCounterRollUp.SUM,),
-    ) -> MetricCounter:
+    ) -> tuple[MetricCounter, ...]:
         name = counter_name_from(
             unit=unit,
             quantity=f'sass_{Quantity.INSTRUCTION}' if mode == 'sass' else Quantity.INSTRUCTION,
@@ -429,7 +437,7 @@ class L1TEXCacheLocalStoreInstructions:
 
         pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.LocalStore.NAME, 'instructions', mode)))
 
-        return MetricCounter(name=name, pretty_name=pretty_name, subs=subs)
+        return (MetricCounter(name=name, pretty_name=pretty_name, subs=subs),)
 
 class L1TEXCacheLocalStore:
 

--- a/tests/integration/test_half.py
+++ b/tests/integration/test_half.py
@@ -140,9 +140,9 @@ class TestNCU:
 
     METRICS: typing.Final[tuple[ncu.metrics.MetricKind, ...]] = (
         ncu.MetricDeviceAttribute(name='display_name'),
-        ncu.L1TEXCacheGlobalLoadInstructions.create(),
-        ncu.L1TEXCacheGlobalLoadRequests.create(),
-        ncu.L1TEXCacheGlobalLoadSectors.create(),
+        *ncu.L1TEXCacheGlobalLoadInstructions.create(),
+        *ncu.L1TEXCacheGlobalLoadRequests.create(),
+        *ncu.L1TEXCacheGlobalLoadSectors.create(),
         *ncu.LaunchGrid.create(),
         *ncu.LaunchBlock.create(),
     )
@@ -183,14 +183,14 @@ class TestNCU:
         _, packed     = results.query_single_next_metrics(('packed',))
 
         for dim in ('x', 'y', 'z'):
-            assert individual[f'launch__grid_dim_{dim}'] == 1
-            assert packed    [f'launch__grid_dim_{dim}'] == 1
+            assert individual[f'launch grid size {dim}'] == 1
+            assert packed    [f'launch grid size {dim}'] == 1
 
-        assert individual['launch__block_dim_y'] == 1 and packed['launch__block_dim_y'] == 1
-        assert individual['launch__block_dim_z'] == 1 and packed['launch__block_dim_z'] == 1
+        assert individual['launch block size y'] == 1 and packed['launch block size y'] == 1
+        assert individual['launch block size z'] == 1 and packed['launch block size z'] == 1
 
-        assert individual['launch__block_dim_x'] == self.BLOCK_DIM_X['individual']
-        assert packed    ['launch__block_dim_x'] == self.BLOCK_DIM_X['packed']
+        assert individual['launch block size x'] == self.BLOCK_DIM_X['individual']
+        assert packed    ['launch block size x'] == self.BLOCK_DIM_X['packed']
 
         assert individual['L1/TEX cache global load instructions sass.sum'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
         assert packed    ['L1/TEX cache global load instructions sass.sum'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)

--- a/tests/tools/ncu/test_ncu.py
+++ b/tests/tools/ncu/test_ncu.py
@@ -203,18 +203,21 @@ class TestMetrics:
     """
     Tests for :py:mod:`reprospect.tools.ncu.metrics`.
     """
-    METRICS: typing.Final[tuple[tuple[ncu.MetricKind, ncu.MetricKind, tuple[str, ...]], ...]] = (
-        (ncu.L1TEXCache.GlobalStore.Instructions.create(), ncu.MetricCounter(name='smsp__sass_inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions sass', subs=(ncu.MetricCounterRollUp.SUM,)), ('smsp__sass_inst_executed_op_global_st.sum',)),
-        (ncu.L1TEXCache.GlobalStore.Instructions.create(mode=None), ncu.MetricCounter(name='smsp__inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions', subs=(ncu.MetricCounterRollUp.SUM,)), ('smsp__inst_executed_op_global_st.sum',)),
-        (ncu.L1TEXCache.GlobalStore.Instructions.create(subs=(ncu.MetricCounterRollUp.MIN, ncu.MetricCounterRollUp.MAX)), ncu.MetricCounter(name='smsp__sass_inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions sass', subs=(ncu.MetricCounterRollUp.MIN, ncu.MetricCounterRollUp.MAX)), ('smsp__sass_inst_executed_op_global_st.min', 'smsp__sass_inst_executed_op_global_st.max')),
-        (ncu.L1TEXCache.GlobalStore.Requests.create(), ncu.MetricCounter(name='l1tex__t_requests_pipe_lsu_mem_global_op_st', pretty_name='L1/TEX cache global store requests', subs=(ncu.MetricCounterRollUp.SUM,)), ('l1tex__t_requests_pipe_lsu_mem_global_op_st.sum',)),
-        (ncu.L1TEXCache.GlobalStore.Sectors.create(), ncu.MetricCounter(name='l1tex__t_sectors_pipe_lsu_mem_global_op_st', pretty_name='L1/TEX cache global store sectors', subs=(ncu.MetricCounterRollUp.SUM,)), ('l1tex__t_sectors_pipe_lsu_mem_global_op_st.sum',)),
+    METRICS: typing.Final[tuple[tuple[tuple[ncu.MetricKind, ...], tuple[ncu.MetricKind, ...], tuple[str, ...]], ...]] = (
+        (ncu.LaunchBlock.create(), (ncu.Metric(name='launch__block_dim_x', pretty_name='launch block size x'), ncu.Metric(name='launch__block_dim_y', pretty_name='launch block size y'), ncu.Metric(name='launch__block_dim_z', pretty_name='launch block size z')), ('launch__block_dim_x', 'launch__block_dim_y', 'launch__block_dim_z')),
+        (ncu.LaunchBlock.create(dims=()), (ncu.Metric(name='launch__block_dim_x', pretty_name='launch block size x'), ncu.Metric(name='launch__block_dim_y', pretty_name='launch block size y'), ncu.Metric(name='launch__block_dim_z', pretty_name='launch block size z')), ('launch__block_dim_x', 'launch__block_dim_y', 'launch__block_dim_z')),
+        (ncu.LaunchBlock.create(dims=('x',)), (ncu.Metric(name='launch__block_dim_x', pretty_name='launch block size x'),), ('launch__block_dim_x',)),
+        (ncu.L1TEXCache.GlobalStore.Instructions.create(), (ncu.MetricCounter(name='smsp__sass_inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions sass', subs=(ncu.MetricCounterRollUp.SUM,)),), ('smsp__sass_inst_executed_op_global_st.sum',)),
+        (ncu.L1TEXCache.GlobalStore.Instructions.create(mode=None), (ncu.MetricCounter(name='smsp__inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions', subs=(ncu.MetricCounterRollUp.SUM,)),), ('smsp__inst_executed_op_global_st.sum',)),
+        (ncu.L1TEXCache.GlobalStore.Instructions.create(subs=(ncu.MetricCounterRollUp.MIN, ncu.MetricCounterRollUp.MAX)), (ncu.MetricCounter(name='smsp__sass_inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions sass', subs=(ncu.MetricCounterRollUp.MIN, ncu.MetricCounterRollUp.MAX)),), ('smsp__sass_inst_executed_op_global_st.min', 'smsp__sass_inst_executed_op_global_st.max')),
+        (ncu.L1TEXCache.GlobalStore.Requests.create(), (ncu.MetricCounter(name='l1tex__t_requests_pipe_lsu_mem_global_op_st', pretty_name='L1/TEX cache global store requests', subs=(ncu.MetricCounterRollUp.SUM,)),), ('l1tex__t_requests_pipe_lsu_mem_global_op_st.sum',)),
+        (ncu.L1TEXCache.GlobalStore.Sectors.create(), (ncu.MetricCounter(name='l1tex__t_sectors_pipe_lsu_mem_global_op_st', pretty_name='L1/TEX cache global store sectors', subs=(ncu.MetricCounterRollUp.SUM,)),), ('l1tex__t_sectors_pipe_lsu_mem_global_op_st.sum',)),
     )
 
     @pytest.mark.parametrize(('metric', 'expected', 'gather'), METRICS)
-    def test(self, metric: ncu.MetricKind, expected: ncu.MetricKind, gather: tuple[str, ...]) -> None:
+    def test(self, metric: tuple[ncu.MetricKind, ...], expected: tuple[ncu.MetricKind, ...], gather: tuple[str, ...]) -> None:
         assert metric == expected
-        assert ncu.gather([metric]) == gather
+        assert ncu.gather(metric) == gather
 
 @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason='needs a GPU')
 class TestSession:
@@ -237,8 +240,8 @@ class TestSession:
             *ncu.LaunchBlock.create(),
             *ncu.LaunchGrid.create(),
             # A few L1TEX cache metrics.
-            ncu.L1TEXCache.GlobalLoad.Instructions.create(),
-            ncu.L1TEXCache.GlobalLoad.Sectors.create(),
+            *ncu.L1TEXCache.GlobalLoad.Instructions.create(),
+            *ncu.L1TEXCache.GlobalLoad.Sectors.create(),
             # A few device attributes.
             ncu.MetricDeviceAttribute(name='display_name'),
             ncu.MetricDeviceAttribute(name='architecture'),
@@ -252,12 +255,12 @@ class TestSession:
         EXPT_METRICS_AND_METADATA = (
             'launch__registers_per_thread_allocated',
             'smsp__inst_executed.sum',
-            'launch__block_dim_x',
-            'launch__block_dim_y',
-            'launch__block_dim_z',
-            'launch__grid_dim_x',
-            'launch__grid_dim_y',
-            'launch__grid_dim_z',
+            'launch block size x',
+            'launch block size y',
+            'launch block size z',
+            'launch grid size x',
+            'launch grid size y',
+            'launch grid size z',
             'L1/TEX cache global load instructions sass.sum',
             'L1/TEX cache global load sectors.sum',
             'mangled',
@@ -316,12 +319,12 @@ class TestSession:
         assert all(x in metrics_filtered_second_saxpy_kernel_1 for x in EXPT_METRICS_AND_METADATA[:2])
 
         # A few checks.
-        assert metrics_saxpy_kernel_0['launch__block_dim_x'] == 128
-        assert metrics_saxpy_kernel_0['launch__block_dim_y'] == 1
-        assert metrics_saxpy_kernel_0['launch__block_dim_z'] == 1
-        assert metrics_saxpy_kernel_0['launch__grid_dim_x'] == 8
-        assert metrics_saxpy_kernel_0['launch__grid_dim_y'] == 1
-        assert metrics_saxpy_kernel_0['launch__grid_dim_z'] == 1
+        assert metrics_saxpy_kernel_0['launch block size x'] == 128
+        assert metrics_saxpy_kernel_0['launch block size y'] == 1
+        assert metrics_saxpy_kernel_0['launch block size z'] == 1
+        assert metrics_saxpy_kernel_0['launch grid size x'] == 8
+        assert metrics_saxpy_kernel_0['launch grid size y'] == 1
+        assert metrics_saxpy_kernel_0['launch grid size z'] == 1
 
         assert metrics_saxpy_kernel_0['mangled'] == '_Z12saxpy_kerneljfPKfPf'
         assert metrics_saxpy_kernel_0['demangled'] == 'saxpy_kernel(unsigned int, float, const float *, float *)'
@@ -382,8 +385,8 @@ class TestSession:
             # Metric with full name provided.
             ncu.Metric(name='launch__registers_per_thread_allocated'),
             # A few L1TEX cache metrics.
-            ncu.L1TEXCache.GlobalLoad.Sectors.create(),
-            ncu.L1TEXCache.GlobalStore.Sectors.create(),
+            *ncu.L1TEXCache.GlobalLoad.Sectors.create(),
+            *ncu.L1TEXCache.GlobalStore.Sectors.create(),
         )
 
         session = ncu.Session(command=ncu.Command(
@@ -516,8 +519,8 @@ class TestCacher:
         """
         METRICS: typing.Final[tuple[ncu.Metric, ...]] = (
             # A few L1TEX cache metrics.
-            ncu.L1TEXCache.GlobalLoad.Sectors.create(),
-            ncu.L1TEXCache.GlobalStore.Sectors.create(),
+            *ncu.L1TEXCache.GlobalLoad.Sectors.create(),
+            *ncu.L1TEXCache.GlobalStore.Sectors.create(),
         )
 
         FILES = ('report-cached.log', 'report-cached.ncu-rep')


### PR DESCRIPTION
This PR uniformises the metric factories:
- they return a tuple of metrics (instead of either a metric itself or a tuple)
- they set a pretty name (that follows how it appears in a table in Nsight Compute GUI)

Follow-up to:
- #683 

Related to:
- #682 