### PR TITLE
tools(kernel profiling): add `labels` helper function to metric

### DIFF
--- a/examples/kokkos/complex/example_alignment.py
+++ b/examples/kokkos/complex/example_alignment.py
@@ -247,14 +247,14 @@ class TestNCU(TestAlignment):
         expt_stg_count_specified = self.WARP_COUNT * self.STORE_COUNT
         expt_stg_count_default   = expt_stg_count_specified * 2
 
-        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global load instructions sass.sum'] == expt_ldg_count_default
-        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global load instructions sass.sum'] == expt_ldg_count_specified
+        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global load instructions sass sum'] == expt_ldg_count_default
+        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global load instructions sass sum'] == expt_ldg_count_specified
 
-        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global store instructions sass.sum'] == expt_stg_count_default
-        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global store instructions sass.sum'] == expt_stg_count_specified
+        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global store instructions sass sum'] == expt_stg_count_default
+        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global store instructions sass sum'] == expt_stg_count_specified
 
-        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache local store instructions sass.sum'] == 0
-        assert metrics[Alignment.SPECIFIED]['L1/TEX cache local store instructions sass.sum'] == 0
+        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache local store instructions sass sum'] == 0
+        assert metrics[Alignment.SPECIFIED]['L1/TEX cache local store instructions sass sum'] == 0
 
     def test_l1tex_memory_traffic_sector_count(self, metrics: dict[Alignment, ProfilingMetrics]) -> None:
         """
@@ -269,8 +269,8 @@ class TestNCU(TestAlignment):
         read_memory = self.LOAD_COUNT * self.ELEMENT_COUNT * self.COMPLEX_DOUBLE_SIZE
         sector_count = read_memory / self.SECTOR_SIZE
 
-        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global load sectors.sum'] == sector_count * 2
-        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global load sectors.sum'] == sector_count
+        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global load sectors sum'] == sector_count * 2
+        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global load sectors sum'] == sector_count
 
     def test_l2_memory_traffic_sector_count(self, metrics: dict[Alignment, ProfilingMetrics]) -> None:
         """
@@ -280,7 +280,7 @@ class TestNCU(TestAlignment):
         the same sector as the first load and can thus be expected to hit in L1 cache.
         """
         keys_sectors_lookup_misses = (
-            'L1/TEX cache global load sectors miss.sum',
+            'L1/TEX cache global load sectors miss sum',
             'lts__t_sectors_srcunit_tex_op_read_lookup_miss.sum',
         )
 

--- a/examples/kokkos/view/example_restrict.py
+++ b/examples/kokkos/view/example_restrict.py
@@ -565,8 +565,8 @@ class TestNCU(TestRestrict):
             case _:
                 raise ValueError(method)
 
-        assert metrics['L1/TEX cache global load sectors.sum']  == factor * self.SECTOR_COUNT_LOAD
-        assert metrics['L1/TEX cache global store sectors.sum'] == factor * self.SECTOR_COUNT_STORE
+        assert metrics['L1/TEX cache global load sectors sum']  == factor * self.SECTOR_COUNT_LOAD
+        assert metrics['L1/TEX cache global store sectors sum'] == factor * self.SECTOR_COUNT_STORE
 
-        assert metrics['L1/TEX cache global load sectors miss.sum']          == self.SECTOR_COUNT_LOAD
+        assert metrics['L1/TEX cache global load sectors miss sum']          == self.SECTOR_COUNT_LOAD
         assert metrics['lts__t_sectors_srcunit_tex_op_read_lookup_miss.sum'] == self.SECTOR_COUNT_LOAD

--- a/reprospect/tools/ncu/__init__.py
+++ b/reprospect/tools/ncu/__init__.py
@@ -26,6 +26,7 @@ from .metrics import (
     MetricRatio,
     MetricRatioRollUp,
     gather,
+    labels,
 )
 from .report import (
     ProfilingMetrics,
@@ -67,4 +68,5 @@ __all__ = (
     'Report',
     'Session',
     'gather',
+    'labels',
 )

--- a/reprospect/tools/ncu/metrics.py
+++ b/reprospect/tools/ncu/metrics.py
@@ -38,7 +38,6 @@ class Metric:
     subs: tuple[str | tuple[str, ...], ...] | None = None
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, 'pretty_name', self.pretty_name or self.name)
         if self.subs is not None:
             object.__setattr__(self, 'subs',
                 tuple((sub,) if isinstance(sub, str) else sub for sub in self.subs))
@@ -50,6 +49,16 @@ class Metric:
         if self.subs is not None:
             return tuple('.'.join((self.name, *sub)) for sub in self.subs)
         return (self.name,)
+
+    def labels(self) -> tuple[str, ...]:
+        """
+        Get the list of sub-metric labels. Parallel to :py:meth:`gather`, but uses the pretty name.
+        """
+        if self.pretty_name is not None:
+            if self.subs is not None:
+                return tuple(' '.join((self.pretty_name, *sub)) for sub in self.subs)
+            return (self.pretty_name,)
+        return self.gather()
 
 class MetricCounterRollUpQuantity(StrEnum):
     """
@@ -121,6 +130,9 @@ class MetricDeviceAttribute:
     def gather(self) -> tuple[str]:
         return (self.full_name,)
 
+    def labels(self) -> tuple[str]:
+        return self.gather()
+
 MetricCorrelationDataType: typing.TypeAlias = dict[str | int, ValueType]
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -148,6 +160,9 @@ class MetricCorrelation:
 
     def gather(self) -> tuple[str]:
         return (self.name,)
+
+    def labels(self) -> tuple[str]:
+        return self.gather()
 
 class XYZBase:
     """
@@ -476,3 +491,9 @@ def gather(metrics: typing.Iterable[MetricKind]) -> tuple[str, ...]:
     Retrieve all sub-metric names, e.g. to pass them to ``ncu``.
     """
     return tuple(name for metric in metrics for name in metric.gather())
+
+def labels(metrics: typing.Iterable[MetricKind]) -> tuple[str, ...]:
+    """
+    Retrieve all sub-metric labels, e.g. to lookup collected data by label.
+    """
+    return tuple(label for metric in metrics for label in metric.labels())

--- a/reprospect/tools/ncu/report.py
+++ b/reprospect/tools/ncu/report.py
@@ -78,12 +78,12 @@ class ProfilingResults(rich_helpers.TreeMixin):
         └── 'nvtx range'
             ├── 'nvtx region'
             │   └── 'kernel'
-            │       ├── 'metric i'  -> ProfilingMetricData
-            │       └── 'metric ii' -> ProfilingMetricData
+            │       ├── 'metric i label'  -> ProfilingMetricData
+            │       └── 'metric ii label' -> ProfilingMetricData
             └── 'other nvtx region'
                 └── 'other kernel'
-                    ├── 'metric i'  -> ProfilingMetricData
-                    └── 'metric ii' -> ProfilingMetricData
+                    ├── 'metric i label'  -> ProfilingMetricData
+                    └── 'metric ii label' -> ProfilingMetricData
 
     .. note::
 
@@ -463,22 +463,17 @@ class Report:
                     correlated[key] = metric_correlation.value(icor)
                 value = self.get_metric_value(metric=metric_correlation)
                 assert isinstance(value, ValueType)
-                results[metric.name] = MetricCorrelationData(
+                label, = metric.labels()
+                results[label] = MetricCorrelationData(
                     value=value,
                     correlated=correlated,
                 )
             elif isinstance(metric, Metric):
-                assert metric.pretty_name is not None
-                metric_data = self.fill_metric(action=action, metric=metric)
-                if metric.subs is not None:
-                    assert isinstance(metric_data, dict)
-                    for sub, value in metric_data.items():
-                        results[f'{metric.pretty_name}.{sub}'] = value
-                else:
-                    assert metric_data is not None
-                    results[metric.pretty_name] = metric_data
+                for name, label in zip(metric.gather(), metric.labels(), strict=True):
+                    results[label] = self.get_metric_by_name(action=action, metric=name).value()
             elif isinstance(metric, MetricDeviceAttribute):
-                results[metric.full_name] = self.get_metric_by_name(action=action, metric=metric.full_name).value()
+                label, = metric.labels()
+                results[label] = self.get_metric_by_name(action=action, metric=metric.full_name).value()
             else:
                 raise NotImplementedError(metric)
 
@@ -492,15 +487,6 @@ class Report:
             converter = self.ncu_report.IMetric_kind_to_value_func[metric.kind()]
             return converter(metric, index) if index is not None else converter(metric)
         return metric.value(idx=index)
-
-    @classmethod
-    def fill_metric(cls, action: Action, metric: Metric) -> MetricData:
-        """
-        Loop over submetrics of `metric`.
-        """
-        if metric.subs is not None:
-            return {f'{".".join(sub)}': cls.get_metric_by_name(action=action, metric=f'{".".join((metric.name, *sub))}').value() for sub in metric.subs}
-        return cls.get_metric_by_name(action=action, metric=metric.name).value()
 
     @classmethod
     def get_metric_by_name(cls, *, action: Action, metric: str):

--- a/tests/integration/test_half.py
+++ b/tests/integration/test_half.py
@@ -192,13 +192,13 @@ class TestNCU:
         assert individual['launch block size x'] == self.BLOCK_DIM_X['individual']
         assert packed    ['launch block size x'] == self.BLOCK_DIM_X['packed']
 
-        assert individual['L1/TEX cache global load instructions sass.sum'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
-        assert packed    ['L1/TEX cache global load instructions sass.sum'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)
+        assert individual['L1/TEX cache global load instructions sass sum'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
+        assert packed    ['L1/TEX cache global load instructions sass sum'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)
 
-        assert individual['L1/TEX cache global load requests.sum'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
-        assert packed    ['L1/TEX cache global load requests.sum'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)
+        assert individual['L1/TEX cache global load requests sum'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
+        assert packed    ['L1/TEX cache global load requests sum'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)
 
         sectors = math.ceil(self.SIZE * self.SIZEOF / self.WARP_SIZE)
 
-        assert individual['L1/TEX cache global load sectors.sum'] == sectors
-        assert packed    ['L1/TEX cache global load sectors.sum'] == sectors
+        assert individual['L1/TEX cache global load sectors sum'] == sectors
+        assert packed    ['L1/TEX cache global load sectors sum'] == sectors

--- a/tests/tools/ncu/test_ncu.py
+++ b/tests/tools/ncu/test_ncu.py
@@ -28,7 +28,7 @@ class TestProfilingResults:
             data=ncu.ProfilingMetrics({
                 'smsp__inst_executed.sum': 100.,
                 'sass__inst_executed_per_opcode': MetricCorrelationData(correlated={'LDCU': 16., 'LDC': 16.}),
-                'L1/TEX cache global load sectors.sum': 0.,
+                'L1/TEX cache global load sectors sum': 0.,
             }),
         )
         results.assign_metrics(
@@ -36,7 +36,7 @@ class TestProfilingResults:
             data=ncu.ProfilingMetrics({
                 'smsp__inst_executed.sum': 96.,
                 'sass__inst_executed_per_opcode': MetricCorrelationData(correlated={'LDCU': 16., 'LDC': 16.}),
-                'L1/TEX cache global load sectors.sum': 0.,
+                'L1/TEX cache global load sectors sum': 0.,
             }),
         )
         return results
@@ -153,13 +153,13 @@ Profiling results
     │       └── kernel
     │           ├── smsp__inst_executed.sum: 100.0
     │           ├── sass__inst_executed_per_opcode: MetricCorrelationData(correlated={'LDCU': 16.0, 'LDC': 16.0}, value=None)
-    │           └── L1/TEX cache global load sectors.sum: 0.0
+    │           └── L1/TEX cache global load sectors sum: 0.0
     └── nvtx_push_region_B
         └── nvtx_push_region_other_kernel
             └── other_kernel
                 ├── smsp__inst_executed.sum: 96.0
                 ├── sass__inst_executed_per_opcode: MetricCorrelationData(correlated={'LDCU': 16.0, 'LDC': 16.0}, value=None)
-                └── L1/TEX cache global load sectors.sum: 0.0
+                └── L1/TEX cache global load sectors sum: 0.0
 """
 
         results_A = results.query(("nvtx_range_name", "nvtx_push_region_A"))
@@ -170,7 +170,7 @@ Profiling results
     └── kernel
         ├── smsp__inst_executed.sum: 100.0
         ├── sass__inst_executed_per_opcode: MetricCorrelationData(correlated={'LDCU': 16.0, 'LDC': 16.0}, value=None)
-        └── L1/TEX cache global load sectors.sum: 0.0
+        └── L1/TEX cache global load sectors sum: 0.0
 """
 
 class TestCommand:
@@ -203,29 +203,130 @@ class TestMetrics:
     """
     Tests for :py:mod:`reprospect.tools.ncu.metrics`.
     """
-    METRICS: typing.Final[tuple[tuple[ncu.MetricKind, tuple[str, ...]], ...]] = (
-        (ncu.MetricCounter(name='dram__bytes_op_write', subs=((ncu.MetricCounterRollUp.SUM, ncu.MetricCounterRollUpQuantity.PCT_OF_PEAK_SUSTAINED_ELAPSED),)), ('dram__bytes_op_write.sum.pct_of_peak_sustained_elapsed',)),
+    class MetricCase(typing.NamedTuple):
+        metric: ncu.MetricKind
+        gathered: tuple[str, ...]
+        labels: tuple[str, ...]
+
+    class CreatedMetricsCase(typing.NamedTuple):
+        metrics: tuple[ncu.MetricKind, ...]
+        expected: tuple[ncu.MetricKind, ...]
+        gathered: tuple[str, ...]
+        labels: tuple[str, ...]
+
+    METRICS: typing.Final[tuple[MetricCase, ...]] = (
+        MetricCase(
+            metric=ncu.MetricCounter(name='dram__bytes_op_write', subs=((ncu.MetricCounterRollUp.SUM, ncu.MetricCounterRollUpQuantity.PCT_OF_PEAK_SUSTAINED_ELAPSED),)),
+            gathered=('dram__bytes_op_write.sum.pct_of_peak_sustained_elapsed',),
+            labels=('dram__bytes_op_write.sum.pct_of_peak_sustained_elapsed',),
+        ),
     )
 
-    METRICS_FROM_METRIC_FACTORIES: typing.Final[tuple[tuple[tuple[ncu.MetricKind, ...], tuple[ncu.MetricKind, ...], tuple[str, ...]], ...]] = (
-        (ncu.LaunchBlock.create(), (ncu.Metric(name='launch__block_dim_x', pretty_name='launch block size x'), ncu.Metric(name='launch__block_dim_y', pretty_name='launch block size y'), ncu.Metric(name='launch__block_dim_z', pretty_name='launch block size z')), ('launch__block_dim_x', 'launch__block_dim_y', 'launch__block_dim_z')),
-        (ncu.LaunchBlock.create(dims=()), (ncu.Metric(name='launch__block_dim_x', pretty_name='launch block size x'), ncu.Metric(name='launch__block_dim_y', pretty_name='launch block size y'), ncu.Metric(name='launch__block_dim_z', pretty_name='launch block size z')), ('launch__block_dim_x', 'launch__block_dim_y', 'launch__block_dim_z')),
-        (ncu.LaunchBlock.create(dims=('x',)), (ncu.Metric(name='launch__block_dim_x', pretty_name='launch block size x'),), ('launch__block_dim_x',)),
-        (ncu.L1TEXCache.GlobalStore.Instructions.create(), (ncu.MetricCounter(name='smsp__sass_inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions sass', subs=(ncu.MetricCounterRollUp.SUM,)),), ('smsp__sass_inst_executed_op_global_st.sum',)),
-        (ncu.L1TEXCache.GlobalStore.Instructions.create(mode=None), (ncu.MetricCounter(name='smsp__inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions', subs=(ncu.MetricCounterRollUp.SUM,)),), ('smsp__inst_executed_op_global_st.sum',)),
-        (ncu.L1TEXCache.GlobalStore.Instructions.create(subs=(ncu.MetricCounterRollUp.MIN, ncu.MetricCounterRollUp.MAX)), (ncu.MetricCounter(name='smsp__sass_inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions sass', subs=(ncu.MetricCounterRollUp.MIN, ncu.MetricCounterRollUp.MAX)),), ('smsp__sass_inst_executed_op_global_st.min', 'smsp__sass_inst_executed_op_global_st.max')),
-        (ncu.L1TEXCache.GlobalStore.Requests.create(), (ncu.MetricCounter(name='l1tex__t_requests_pipe_lsu_mem_global_op_st', pretty_name='L1/TEX cache global store requests', subs=(ncu.MetricCounterRollUp.SUM,)),), ('l1tex__t_requests_pipe_lsu_mem_global_op_st.sum',)),
-        (ncu.L1TEXCache.GlobalStore.Sectors.create(), (ncu.MetricCounter(name='l1tex__t_sectors_pipe_lsu_mem_global_op_st', pretty_name='L1/TEX cache global store sectors', subs=(ncu.MetricCounterRollUp.SUM,)),), ('l1tex__t_sectors_pipe_lsu_mem_global_op_st.sum',)),
+    CREATED_METRICS: typing.Final[tuple[CreatedMetricsCase, ...]] = (
+        CreatedMetricsCase(
+            metrics=ncu.LaunchBlock.create(),
+            expected=(
+                ncu.Metric(name='launch__block_dim_x', pretty_name='launch block size x'),
+                ncu.Metric(name='launch__block_dim_y', pretty_name='launch block size y'),
+                ncu.Metric(name='launch__block_dim_z', pretty_name='launch block size z'),
+            ),
+            gathered=(
+                'launch__block_dim_x',
+                'launch__block_dim_y',
+                'launch__block_dim_z',
+            ),
+            labels=(
+                'launch block size x',
+                'launch block size y',
+                'launch block size z',
+            ),
+        ),
+        CreatedMetricsCase(
+            metrics=ncu.LaunchBlock.create(dims=('x',)),
+            expected=(ncu.Metric(name='launch__block_dim_x', pretty_name='launch block size x'),),
+            gathered=('launch__block_dim_x',),
+            labels=('launch block size x',),
+        ),
+        CreatedMetricsCase(
+            metrics=ncu.LaunchBlock.create(dims=()),
+            expected=(
+                ncu.Metric(name='launch__block_dim_x', pretty_name='launch block size x'),
+                ncu.Metric(name='launch__block_dim_y', pretty_name='launch block size y'),
+                ncu.Metric(name='launch__block_dim_z', pretty_name='launch block size z'),
+            ),
+            gathered=(
+                'launch__block_dim_x',
+                'launch__block_dim_y',
+                'launch__block_dim_z',
+            ),
+            labels=(
+                'launch block size x',
+                'launch block size y',
+                'launch block size z',
+            ),
+        ),
+        CreatedMetricsCase(
+            metrics=ncu.L1TEXCache.GlobalStore.Instructions.create(),
+            expected=(ncu.MetricCounter(name='smsp__sass_inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions sass', subs=(ncu.MetricCounterRollUp.SUM,)),),
+            gathered=('smsp__sass_inst_executed_op_global_st.sum',),
+            labels=('L1/TEX cache global store instructions sass sum',),
+        ),
+        CreatedMetricsCase(
+            metrics=ncu.L1TEXCache.GlobalStore.Instructions.create(mode=None),
+            expected=(ncu.MetricCounter(name='smsp__inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions', subs=(ncu.MetricCounterRollUp.SUM,)),),
+            gathered=('smsp__inst_executed_op_global_st.sum',),
+            labels=('L1/TEX cache global store instructions sum',),
+        ),
+        CreatedMetricsCase(
+            metrics=ncu.L1TEXCache.GlobalStore.Instructions.create(
+                subs=(
+                    ncu.MetricCounterRollUp.MIN,
+                    ncu.MetricCounterRollUp.MAX,
+                ),
+            ),
+            expected=(
+                ncu.MetricCounter(
+                    name='smsp__sass_inst_executed_op_global_st',
+                    pretty_name='L1/TEX cache global store instructions sass',
+                    subs=(
+                        ncu.MetricCounterRollUp.MIN,
+                        ncu.MetricCounterRollUp.MAX,
+                    ),
+                ),
+            ),
+            gathered=(
+                'smsp__sass_inst_executed_op_global_st.min',
+                'smsp__sass_inst_executed_op_global_st.max',
+            ),
+            labels=(
+                'L1/TEX cache global store instructions sass min',
+                'L1/TEX cache global store instructions sass max',
+            ),
+        ),
+        CreatedMetricsCase(
+            metrics=ncu.L1TEXCache.GlobalStore.Requests.create(),
+            expected=(ncu.MetricCounter(name='l1tex__t_requests_pipe_lsu_mem_global_op_st', pretty_name='L1/TEX cache global store requests', subs=(ncu.MetricCounterRollUp.SUM,)),),
+            gathered=('l1tex__t_requests_pipe_lsu_mem_global_op_st.sum',),
+            labels=('L1/TEX cache global store requests sum',),
+        ),
+        CreatedMetricsCase(
+            metrics=ncu.L1TEXCache.GlobalStore.Sectors.create(),
+            expected=(ncu.MetricCounter(name='l1tex__t_sectors_pipe_lsu_mem_global_op_st', pretty_name='L1/TEX cache global store sectors', subs=(ncu.MetricCounterRollUp.SUM,)),),
+            gathered=('l1tex__t_sectors_pipe_lsu_mem_global_op_st.sum',),
+            labels=('L1/TEX cache global store sectors sum',),
+        ),
     )
 
-    @pytest.mark.parametrize(('metric', 'gather'), METRICS)
-    def test_metrics(self, metric: ncu.MetricKind, gather: tuple[str, ...]) -> None:
+    @pytest.mark.parametrize(('metric', 'gather', 'labels'), METRICS)
+    def test_metrics(self, metric: ncu.MetricKind, gather: tuple[str, ...], labels: tuple[str, ...]) -> None:
         assert ncu.gather([metric]) == gather
+        assert ncu.labels([metric]) == labels
 
-    @pytest.mark.parametrize(('metrics', 'expected', 'gather'), METRICS_FROM_METRIC_FACTORIES)
-    def test_metrics_from_metric_factories(self, metrics: tuple[ncu.MetricKind, ...], expected: tuple[ncu.MetricKind, ...], gather: tuple[str, ...]) -> None:
+    @pytest.mark.parametrize(('metrics', 'expected', 'gather', 'labels'), CREATED_METRICS)
+    def test_metrics_from_metric_factories(self, metrics: tuple[ncu.MetricKind, ...], expected: tuple[ncu.MetricKind, ...], gather: tuple[str, ...], labels: tuple[str, ...]) -> None:
         assert metrics == expected
         assert ncu.gather(metrics) == gather
+        assert ncu.labels(metrics) == labels
 
 @pytest.mark.skipif(not detect.GPUDetector.count() > 0, reason='needs a GPU')
 class TestSession:
@@ -260,7 +361,7 @@ class TestSession:
             ncu.MetricDeviceAttribute(name='numa_config'),
         )
 
-        EXPT_METRICS_AND_METADATA = (
+        EXPT_METRIC_LABELS_AND_METADATA = (
             'launch__registers_per_thread_allocated',
             'smsp__inst_executed.sum',
             'launch block size x',
@@ -269,8 +370,8 @@ class TestSession:
             'launch grid size x',
             'launch grid size y',
             'launch grid size z',
-            'L1/TEX cache global load instructions sass.sum',
-            'L1/TEX cache global load sectors.sum',
+            'L1/TEX cache global load instructions sass sum',
+            'L1/TEX cache global load sectors sum',
             'mangled',
             'demangled',
             'device__attribute_display_name',
@@ -305,8 +406,8 @@ class TestSession:
 
         metrics_saxpy_kernel_0 = results.query_metrics(('saxpy_kernel-0',))
         metrics_saxpy_kernel_1 = results.query_metrics(('saxpy_kernel-1',))
-        assert all(x in metrics_saxpy_kernel_0 for x in EXPT_METRICS_AND_METADATA)
-        assert all(x in metrics_saxpy_kernel_1 for x in EXPT_METRICS_AND_METADATA)
+        assert all(x in metrics_saxpy_kernel_0 for x in EXPT_METRIC_LABELS_AND_METADATA)
+        assert all(x in metrics_saxpy_kernel_1 for x in EXPT_METRIC_LABELS_AND_METADATA)
         # Extract results with NVTX filtering. Request only the 2 first metrics.
         with pytest.raises(RuntimeError, match='no action found'):
             results_filtered = report.extract_results_in_range(metrics=METRICS[:2], includes=('outer_useless_range',))
@@ -323,8 +424,8 @@ class TestSession:
 
         metrics_filtered_first_saxpy_kernel_0  = results_filtered_first.query_metrics( ('saxpy_kernel-0',))
         metrics_filtered_second_saxpy_kernel_1 = results_filtered_second.query_metrics(('saxpy_kernel-1',))
-        assert all(x in metrics_filtered_first_saxpy_kernel_0  for x in EXPT_METRICS_AND_METADATA[:2])
-        assert all(x in metrics_filtered_second_saxpy_kernel_1 for x in EXPT_METRICS_AND_METADATA[:2])
+        assert all(x in metrics_filtered_first_saxpy_kernel_0  for x in EXPT_METRIC_LABELS_AND_METADATA[:2])
+        assert all(x in metrics_filtered_second_saxpy_kernel_1 for x in EXPT_METRIC_LABELS_AND_METADATA[:2])
 
         # A few checks.
         assert metrics_saxpy_kernel_0['launch block size x'] == 128
@@ -337,7 +438,7 @@ class TestSession:
         assert metrics_saxpy_kernel_0['mangled'] == '_Z12saxpy_kerneljfPKfPf'
         assert metrics_saxpy_kernel_0['demangled'] == 'saxpy_kernel(unsigned int, float, const float *, float *)'
 
-        for metric in EXPT_METRICS_AND_METADATA[:2]:
+        for metric in EXPT_METRIC_LABELS_AND_METADATA[:2]:
             assert metrics_filtered_first_saxpy_kernel_0 [metric] == metrics_saxpy_kernel_0[metric]
             assert metrics_filtered_second_saxpy_kernel_1[metric] == metrics_saxpy_kernel_1[metric]
 
@@ -445,34 +546,34 @@ class TestSession:
         assert SIGNATURES['node_D'](metrics_node_D)
 
         metrics_aggregate = results.aggregate_metrics(accessors=(), keys=(
-            'L1/TEX cache global store sectors.sum',
-            'L1/TEX cache global load sectors.sum',
+            'L1/TEX cache global store sectors sum',
+            'L1/TEX cache global load sectors sum',
         ))
 
         # Node A makes one load and one store.
-        assert metrics_node_A['L1/TEX cache global load sectors.sum']  == 1
-        assert metrics_node_A['L1/TEX cache global store sectors.sum'] == 1
+        assert metrics_node_A['L1/TEX cache global load sectors sum']  == 1
+        assert metrics_node_A['L1/TEX cache global store sectors sum'] == 1
 
         assert metrics_node_A['launch__registers_per_thread_allocated'] == 512
 
         # Nodes B and C make two loads and one store each.
-        assert metrics_node_B['L1/TEX cache global load sectors.sum']  == 2
-        assert metrics_node_B['L1/TEX cache global store sectors.sum'] == 1
-        assert metrics_node_C['L1/TEX cache global load sectors.sum']  == 2
-        assert metrics_node_C['L1/TEX cache global store sectors.sum'] == 1
+        assert metrics_node_B['L1/TEX cache global load sectors sum']  == 2
+        assert metrics_node_B['L1/TEX cache global store sectors sum'] == 1
+        assert metrics_node_C['L1/TEX cache global load sectors sum']  == 2
+        assert metrics_node_C['L1/TEX cache global store sectors sum'] == 1
 
         assert metrics_node_B['launch__registers_per_thread_allocated'] == 512
         assert metrics_node_C['launch__registers_per_thread_allocated'] == 512
 
         # Node D makes three loads and one store.
-        assert metrics_node_D['L1/TEX cache global load sectors.sum']  == 3
-        assert metrics_node_D['L1/TEX cache global store sectors.sum'] == 1
+        assert metrics_node_D['L1/TEX cache global load sectors sum']  == 3
+        assert metrics_node_D['L1/TEX cache global store sectors sum'] == 1
 
         assert metrics_node_D['launch__registers_per_thread_allocated'] == 512
 
         assert metrics_aggregate == {
-            'L1/TEX cache global load sectors.sum':  8,
-            'L1/TEX cache global store sectors.sum': 4,
+            'L1/TEX cache global load sectors sum':  8,
+            'L1/TEX cache global store sectors sum': 4,
         }
 
     def test_fails_correctly_with_retries(self, bindir, workdir) -> None:


### PR DESCRIPTION
To retrieve the labels that the tree representation of the profiling results uses.

Related to:
- #682 