### PR TITLE
tools(kernel profiling): update string labels for sass instructions and unit

### DIFF
--- a/examples/kokkos/complex/example_alignment.py
+++ b/examples/kokkos/complex/example_alignment.py
@@ -247,14 +247,14 @@ class TestNCU(TestAlignment):
         expt_stg_count_specified = self.WARP_COUNT * self.STORE_COUNT
         expt_stg_count_default   = expt_stg_count_specified * 2
 
-        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global load instructions sass sum'] == expt_ldg_count_default
-        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global load instructions sass sum'] == expt_ldg_count_specified
+        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global load sass instructions smsp sum'] == expt_ldg_count_default
+        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global load sass instructions smsp sum'] == expt_ldg_count_specified
 
-        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global store instructions sass sum'] == expt_stg_count_default
-        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global store instructions sass sum'] == expt_stg_count_specified
+        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global store sass instructions smsp sum'] == expt_stg_count_default
+        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global store sass instructions smsp sum'] == expt_stg_count_specified
 
-        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache local store instructions sass sum'] == 0
-        assert metrics[Alignment.SPECIFIED]['L1/TEX cache local store instructions sass sum'] == 0
+        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache local store sass instructions smsp sum'] == 0
+        assert metrics[Alignment.SPECIFIED]['L1/TEX cache local store sass instructions smsp sum'] == 0
 
     def test_l1tex_memory_traffic_sector_count(self, metrics: dict[Alignment, ProfilingMetrics]) -> None:
         """

--- a/reprospect/tools/ncu/metrics.py
+++ b/reprospect/tools/ncu/metrics.py
@@ -276,7 +276,7 @@ class L1TEXCacheGlobalLoadInstructions:
             qualifier='executed_op_global_ld',
         )
 
-        pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.GlobalLoad.NAME, 'instructions', mode)))
+        pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.GlobalLoad.NAME, mode, 'instructions', unit)))
 
         return (MetricCounter(name=name, pretty_name=pretty_name, subs=subs),)
 
@@ -392,7 +392,7 @@ class L1TEXCacheGlobalStoreInstructions:
             qualifier='executed_op_global_st',
         )
 
-        pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.GlobalStore.NAME, 'instructions', mode)))
+        pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.GlobalStore.NAME, mode, 'instructions', unit)))
 
         return (MetricCounter(name=name, pretty_name=pretty_name, subs=subs),)
 
@@ -460,7 +460,7 @@ class L1TEXCacheLocalStoreInstructions:
             qualifier='executed_op_local_st',
         )
 
-        pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.LocalStore.NAME, 'instructions', mode)))
+        pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.LocalStore.NAME, mode, 'instructions', unit)))
 
         return (MetricCounter(name=name, pretty_name=pretty_name, subs=subs),)
 

--- a/tests/integration/test_half.py
+++ b/tests/integration/test_half.py
@@ -192,8 +192,8 @@ class TestNCU:
         assert individual['launch block size x'] == self.BLOCK_DIM_X['individual']
         assert packed    ['launch block size x'] == self.BLOCK_DIM_X['packed']
 
-        assert individual['L1/TEX cache global load instructions sass sum'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
-        assert packed    ['L1/TEX cache global load instructions sass sum'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)
+        assert individual['L1/TEX cache global load sass instructions smsp sum'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
+        assert packed    ['L1/TEX cache global load sass instructions smsp sum'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)
 
         assert individual['L1/TEX cache global load requests sum'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
         assert packed    ['L1/TEX cache global load requests sum'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)

--- a/tests/tools/ncu/test_ncu.py
+++ b/tests/tools/ncu/test_ncu.py
@@ -267,15 +267,15 @@ class TestMetrics:
         ),
         CreatedMetricsCase(
             metrics=ncu.L1TEXCache.GlobalStore.Instructions.create(),
-            expected=(ncu.MetricCounter(name='smsp__sass_inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions sass', subs=(ncu.MetricCounterRollUp.SUM,)),),
+            expected=(ncu.MetricCounter(name='smsp__sass_inst_executed_op_global_st', pretty_name='L1/TEX cache global store sass instructions smsp', subs=(ncu.MetricCounterRollUp.SUM,)),),
             gathered=('smsp__sass_inst_executed_op_global_st.sum',),
-            labels=('L1/TEX cache global store instructions sass sum',),
+            labels=('L1/TEX cache global store sass instructions smsp sum',),
         ),
         CreatedMetricsCase(
             metrics=ncu.L1TEXCache.GlobalStore.Instructions.create(mode=None),
-            expected=(ncu.MetricCounter(name='smsp__inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions', subs=(ncu.MetricCounterRollUp.SUM,)),),
+            expected=(ncu.MetricCounter(name='smsp__inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions smsp', subs=(ncu.MetricCounterRollUp.SUM,)),),
             gathered=('smsp__inst_executed_op_global_st.sum',),
-            labels=('L1/TEX cache global store instructions sum',),
+            labels=('L1/TEX cache global store instructions smsp sum',),
         ),
         CreatedMetricsCase(
             metrics=ncu.L1TEXCache.GlobalStore.Instructions.create(
@@ -287,7 +287,7 @@ class TestMetrics:
             expected=(
                 ncu.MetricCounter(
                     name='smsp__sass_inst_executed_op_global_st',
-                    pretty_name='L1/TEX cache global store instructions sass',
+                    pretty_name='L1/TEX cache global store sass instructions smsp',
                     subs=(
                         ncu.MetricCounterRollUp.MIN,
                         ncu.MetricCounterRollUp.MAX,
@@ -299,8 +299,8 @@ class TestMetrics:
                 'smsp__sass_inst_executed_op_global_st.max',
             ),
             labels=(
-                'L1/TEX cache global store instructions sass min',
-                'L1/TEX cache global store instructions sass max',
+                'L1/TEX cache global store sass instructions smsp min',
+                'L1/TEX cache global store sass instructions smsp max',
             ),
         ),
         CreatedMetricsCase(
@@ -370,7 +370,7 @@ class TestSession:
             'launch grid size x',
             'launch grid size y',
             'launch grid size z',
-            'L1/TEX cache global load instructions sass sum',
+            'L1/TEX cache global load sass instructions smsp sum',
             'L1/TEX cache global load sectors sum',
             'mangled',
             'demangled',


### PR DESCRIPTION
This PR:
- improves the "human readable" character of the metric labels for global load/store instructions.
- adds the "unit" in the label because otherwise, there is not one-to-one correspondence with the metric name

Related to:
- #682 