### PR TITLE
tools(kernel profiling): add warp stall metric factories

### DIFF
--- a/reprospect/tools/ncu/__init__.py
+++ b/reprospect/tools/ncu/__init__.py
@@ -25,6 +25,11 @@ from .metrics import (
     MetricKind,
     MetricRatio,
     MetricRatioRollUp,
+    WarpStall,
+    WarpStallLGThrottle,
+    WarpStallLongScoreboard,
+    WarpStallMIOThrottle,
+    WarpStallShortScoreboard,
     gather,
     labels,
 )
@@ -67,6 +72,11 @@ __all__ = (
     'ProfilingResults',
     'Report',
     'Session',
+    'WarpStall',
+    'WarpStallLGThrottle',
+    'WarpStallLongScoreboard',
+    'WarpStallMIOThrottle',
+    'WarpStallShortScoreboard',
     'gather',
     'labels',
 )

--- a/reprospect/tools/ncu/metrics.py
+++ b/reprospect/tools/ncu/metrics.py
@@ -484,6 +484,78 @@ class L1TEXCache:
 
     LocalStore: typing.Final[type[L1TEXCacheLocalStore]] = L1TEXCacheLocalStore # pylint: disable=invalid-name
 
+class WarpStallBase:
+    """
+    Base class for factories of warp-stall ratio metrics.
+    """
+    TEMPLATE_NAME: typing.Final[str] = 'smsp__average_warps_issue_stalled_{reason}_per_issue_active'
+    TEMPLATE_LABEL: typing.Final[str] = 'Warp stall {reason}'
+
+    #: The stall reason as it appears in the ``ncu`` metric name.
+    reason: typing.ClassVar[str]
+
+    #: The stall reason as it appears in the label.
+    pretty_reason: typing.ClassVar[str]
+
+    @classmethod
+    def create(cls, *,
+        subs: tuple[MetricRatioRollUp, ...] = (MetricRatioRollUp.PCT,),
+    ) -> tuple[MetricRatio, ...]:
+        name = cls.TEMPLATE_NAME.format(reason=cls.reason)
+
+        pretty_name = cls.TEMPLATE_LABEL.format(reason=cls.pretty_reason)
+
+        return (MetricRatio(name=name, pretty_name=pretty_name, subs=subs),)
+
+class WarpStallLGThrottle(WarpStallBase):
+    """
+    Factory of ratio metric ``smsp__average_warps_issue_stalled_lg_throttle_per_issue_active``.
+    """
+    reason: typing.ClassVar[str] = 'lg_throttle'
+
+    pretty_reason: typing.ClassVar[str] = 'LG throttle'
+
+class WarpStallLongScoreboard(WarpStallBase):
+    """
+    Factory of ratio metric ``smsp__average_warps_issue_stalled_long_scoreboard_per_issue_active``.
+    """
+    reason: typing.ClassVar[str] = 'long_scoreboard'
+
+    pretty_reason: typing.ClassVar[str] = 'Long scoreboard'
+
+class WarpStallMIOThrottle(WarpStallBase):
+    """
+    Factory of ratio metric ``smsp__average_warps_issue_stalled_mio_throttle_per_issue_active``.
+    """
+    reason: typing.ClassVar[str] = 'mio_throttle'
+
+    pretty_reason: typing.ClassVar[str] = 'MIO throttle'
+
+class WarpStallShortScoreboard(WarpStallBase):
+    """
+    Factory of ratio metric ``smsp__average_warps_issue_stalled_short_scoreboard_per_issue_active``.
+    """
+    reason: typing.ClassVar[str] = 'short_scoreboard'
+
+    pretty_reason: typing.ClassVar[str] = 'Short scoreboard'
+
+class WarpStall:
+    """
+    A selection of metrics related to warp stall reasons.
+
+    References:
+
+    * https://docs.nvidia.com/nsight-compute/ProfilingGuide/index.html#warp-stall-reasons
+    """
+    LGThrottle: typing.Final[type[WarpStallLGThrottle]] = WarpStallLGThrottle # pylint: disable=invalid-name
+
+    LongScoreboard: typing.Final[type[WarpStallLongScoreboard]] = WarpStallLongScoreboard # pylint: disable=invalid-name
+
+    MIOThrottle: typing.Final[type[WarpStallMIOThrottle]] = WarpStallMIOThrottle # pylint: disable=invalid-name
+
+    ShortScoreboard: typing.Final[type[WarpStallShortScoreboard]] = WarpStallShortScoreboard # pylint: disable=invalid-name
+
+
 MetricKind: typing.TypeAlias = Metric | MetricCorrelation | MetricDeviceAttribute
 
 def gather(metrics: typing.Iterable[MetricKind]) -> tuple[str, ...]:

--- a/tests/tools/ncu/test_ncu.py
+++ b/tests/tools/ncu/test_ncu.py
@@ -315,6 +315,12 @@ class TestMetrics:
             gathered=('l1tex__t_sectors_pipe_lsu_mem_global_op_st.sum',),
             labels=('L1/TEX cache global store sectors sum',),
         ),
+        CreatedMetricsCase(
+            metrics=ncu.WarpStall.LGThrottle.create(),
+            expected=(ncu.MetricRatio(name='smsp__average_warps_issue_stalled_lg_throttle_per_issue_active', pretty_name='Warp stall LG throttle', subs=(ncu.MetricRatioRollUp.PCT,)),),
+            gathered=('smsp__average_warps_issue_stalled_lg_throttle_per_issue_active.pct',),
+            labels=('Warp stall LG throttle pct',),
+        ),
     )
 
     @pytest.mark.parametrize(('metric', 'gather', 'labels'), METRICS)


### PR DESCRIPTION
This PR:
- adds "warp stall reason" metric factories

Related to:
- #682 