### PR TITLE
tools(kernel profiling): minor consistency changes; remove `unit` parameter from l1tex instruction metrics

### DIFF
--- a/examples/kokkos/complex/example_alignment.py
+++ b/examples/kokkos/complex/example_alignment.py
@@ -247,14 +247,14 @@ class TestNCU(TestAlignment):
         expt_stg_count_specified = self.WARP_COUNT * self.STORE_COUNT
         expt_stg_count_default   = expt_stg_count_specified * 2
 
-        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global load sass instructions smsp sum'] == expt_ldg_count_default
-        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global load sass instructions smsp sum'] == expt_ldg_count_specified
+        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global load sass instructions smsp'] == expt_ldg_count_default
+        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global load sass instructions smsp'] == expt_ldg_count_specified
 
-        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global store sass instructions smsp sum'] == expt_stg_count_default
-        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global store sass instructions smsp sum'] == expt_stg_count_specified
+        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global store sass instructions smsp'] == expt_stg_count_default
+        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global store sass instructions smsp'] == expt_stg_count_specified
 
-        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache local store sass instructions smsp sum'] == 0
-        assert metrics[Alignment.SPECIFIED]['L1/TEX cache local store sass instructions smsp sum'] == 0
+        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache local store sass instructions smsp'] == 0
+        assert metrics[Alignment.SPECIFIED]['L1/TEX cache local store sass instructions smsp'] == 0
 
     def test_l1tex_memory_traffic_sector_count(self, metrics: dict[Alignment, ProfilingMetrics]) -> None:
         """
@@ -269,8 +269,8 @@ class TestNCU(TestAlignment):
         read_memory = self.LOAD_COUNT * self.ELEMENT_COUNT * self.COMPLEX_DOUBLE_SIZE
         sector_count = read_memory / self.SECTOR_SIZE
 
-        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global load sectors sum'] == sector_count * 2
-        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global load sectors sum'] == sector_count
+        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global load sectors'] == sector_count * 2
+        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global load sectors'] == sector_count
 
     def test_l2_memory_traffic_sector_count(self, metrics: dict[Alignment, ProfilingMetrics]) -> None:
         """
@@ -280,7 +280,7 @@ class TestNCU(TestAlignment):
         the same sector as the first load and can thus be expected to hit in L1 cache.
         """
         keys_sectors_lookup_misses = (
-            'L1/TEX cache global load sectors miss sum',
+            'L1/TEX cache global load sectors miss',
             'lts__t_sectors_srcunit_tex_op_read_lookup_miss.sum',
         )
 

--- a/examples/kokkos/complex/example_alignment.py
+++ b/examples/kokkos/complex/example_alignment.py
@@ -247,14 +247,14 @@ class TestNCU(TestAlignment):
         expt_stg_count_specified = self.WARP_COUNT * self.STORE_COUNT
         expt_stg_count_default   = expt_stg_count_specified * 2
 
-        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global load sass instructions smsp'] == expt_ldg_count_default
-        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global load sass instructions smsp'] == expt_ldg_count_specified
+        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global load sass instructions'] == expt_ldg_count_default
+        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global load sass instructions'] == expt_ldg_count_specified
 
-        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global store sass instructions smsp'] == expt_stg_count_default
-        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global store sass instructions smsp'] == expt_stg_count_specified
+        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache global store sass instructions'] == expt_stg_count_default
+        assert metrics[Alignment.SPECIFIED]['L1/TEX cache global store sass instructions'] == expt_stg_count_specified
 
-        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache local store sass instructions smsp'] == 0
-        assert metrics[Alignment.SPECIFIED]['L1/TEX cache local store sass instructions smsp'] == 0
+        assert metrics[Alignment.DEFAULT  ]['L1/TEX cache local store sass instructions'] == 0
+        assert metrics[Alignment.SPECIFIED]['L1/TEX cache local store sass instructions'] == 0
 
     def test_l1tex_memory_traffic_sector_count(self, metrics: dict[Alignment, ProfilingMetrics]) -> None:
         """

--- a/examples/kokkos/view/example_restrict.py
+++ b/examples/kokkos/view/example_restrict.py
@@ -565,8 +565,8 @@ class TestNCU(TestRestrict):
             case _:
                 raise ValueError(method)
 
-        assert metrics['L1/TEX cache global load sectors sum']  == factor * self.SECTOR_COUNT_LOAD
-        assert metrics['L1/TEX cache global store sectors sum'] == factor * self.SECTOR_COUNT_STORE
+        assert metrics['L1/TEX cache global load sectors']  == factor * self.SECTOR_COUNT_LOAD
+        assert metrics['L1/TEX cache global store sectors'] == factor * self.SECTOR_COUNT_STORE
 
-        assert metrics['L1/TEX cache global load sectors miss sum']          == self.SECTOR_COUNT_LOAD
+        assert metrics['L1/TEX cache global load sectors miss']          == self.SECTOR_COUNT_LOAD
         assert metrics['lts__t_sectors_srcunit_tex_op_read_lookup_miss.sum'] == self.SECTOR_COUNT_LOAD

--- a/reprospect/tools/ncu/metrics.py
+++ b/reprospect/tools/ncu/metrics.py
@@ -10,13 +10,13 @@ if sys.version_info >= (3, 11):
 else:
     from backports.strenum.strenum import StrEnum
 
+
 #: A single metric value type.
 ValueType: typing.TypeAlias = int | float
 
 #: A single metric value type or a dictionary of submetric values of such type.
 MetricData: typing.TypeAlias = ValueType | dict[str, ValueType]
 
-@dataclasses.dataclass(frozen=True, slots=True)
 class Metric:
     """
     Used to represent a ``ncu`` metric.
@@ -27,20 +27,30 @@ class Metric:
     References:
 
     * https://docs.nvidia.com/nsight-compute/ProfilingGuide/index.html#metrics-structure
+
+    .. note::
+
+        It is not decorated with :py:func:`dataclasses.dataclass` because of https://github.com/mypyc/mypyc/issues/1061.
     """
-    #: The base name of the metric.
-    name: str
+    #: Sub-metric components implied by the metric kind, omitted from labels.
+    SILENT_SUBS: typing.ClassVar[frozenset[str]] = frozenset()
 
-    #: Human readable name.
-    pretty_name: str | None = None
+    __slots__ = ('name', 'pretty_name', 'subs')
 
-    #: Optional sub-metric names, each one stored as a path of components
-    subs: tuple[str | tuple[str, ...], ...] | None = None
+    def __init__(self, name: str, pretty_name: str | None = None, subs: tuple[str | tuple[str, ...], ...] | None = None) -> None:
+        """
+        :param name: The base name of the metric.
+        :param pretty_name: Human readable name; defaults to :py:attr:`name`.
+        :param subs: Sub-metric names. The constructor normalizes each to a path of components.
+        """
+        self.name: typing.Final[str] = name
+        self.pretty_name: typing.Final[str | None] = pretty_name
+        self.subs: typing.Final[tuple[tuple[str, ...], ...] | None] = tuple((sub,) if isinstance(sub, str) else sub for sub in subs) if subs is not None else None
 
-    def __post_init__(self) -> None:
-        if self.subs is not None:
-            object.__setattr__(self, 'subs',
-                tuple((sub,) if isinstance(sub, str) else sub for sub in self.subs))
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, Metric):
+            return self.name == other.name and self.pretty_name == other.pretty_name and self.subs == other.subs
+        return NotImplemented
 
     def gather(self) -> tuple[str, ...]:
         """
@@ -54,16 +64,25 @@ class Metric:
         """
         Get the list of sub-metric labels. Parallel to :py:meth:`gather`, but uses the pretty name.
         """
-        if self.pretty_name is not None:
-            if self.subs is not None:
-                return tuple(' '.join((self.pretty_name, *sub)) for sub in self.subs)
+        if self.pretty_name is None:
+            return self.gather()
+        if self.subs is None:
             return (self.pretty_name,)
-        return self.gather()
+        result = []
+        for sub in self.subs:
+            sub_labels = tuple(getattr(c, 'label', c) for c in sub if c not in self.SILENT_SUBS)
+            result.append(f'{self.pretty_name} ({", ".join(sub_labels)})' if sub_labels else self.pretty_name)
+        assert len(set(result)) == len(result), result
+        return tuple(result)
 
 class MetricCounterRollUpQuantity(StrEnum):
     """
     Available quantities for :py:class:`MetricCounterRollUp`.
     """
+    @property
+    def label(self) -> str:
+        return {self.PCT_OF_PEAK_SUSTAINED_ACTIVE: '% of peak active', self.PCT_OF_PEAK_SUSTAINED_ELAPSED: '% of peak elapsed'}[self]
+
     PCT_OF_PEAK_SUSTAINED_ACTIVE = enum.auto()
     PCT_OF_PEAK_SUSTAINED_ELAPSED = enum.auto()
 
@@ -71,12 +90,15 @@ class MetricCounterRollUp(StrEnum):
     """
     Available roll-ups for :py:class:`MetricCounter`.
     """
+    @property
+    def label(self) -> str:
+        return self.value
+
     SUM = enum.auto()
     AVG = enum.auto()
     MIN = enum.auto()
     MAX = enum.auto()
 
-@dataclasses.dataclass(frozen=True, slots=True)
 class MetricCounter(Metric):
     """
     A counter metric.
@@ -87,16 +109,20 @@ class MetricCounter(Metric):
 
     * https://docs.nvidia.com/nsight-compute/ProfilingGuide/index.html#metrics-structure
     """
+    SILENT_SUBS: typing.ClassVar[frozenset[str]] = frozenset({MetricCounterRollUp.SUM})
 
 class MetricRatioRollUp(StrEnum):
     """
     Available roll-ups for :py:class:`MetricRatio`.
     """
+    @property
+    def label(self) -> str:
+        return {self.PCT: '%', self.RATIO: 'ratio', self.MAX_RATE: 'max rate'}[self]
+
     PCT = enum.auto()
     RATIO = enum.auto()
     MAX_RATE = enum.auto()
 
-@dataclasses.dataclass(frozen=True, slots=True)
 class MetricRatio(Metric):
     """
     A ratio metric.
@@ -107,6 +133,7 @@ class MetricRatio(Metric):
 
     * https://docs.nvidia.com/nsight-compute/ProfilingGuide/index.html#metrics-structure
     """
+    SILENT_SUBS: typing.ClassVar[frozenset[str]] = frozenset({MetricRatioRollUp.RATIO})
 
 @dataclasses.dataclass(frozen=True, slots=True)
 class MetricDeviceAttribute:
@@ -172,33 +199,33 @@ class XYZBase:
 
     * https://docs.nvidia.com/nsight-compute/ProfilingGuide/#metrics-reference
     """
-    prefix: typing.ClassVar[str]
+    PREFIX: typing.ClassVar[str]
 
-    pretty_prefix: typing.ClassVar[str | None] = None
+    PRETTY_PREFIX: typing.ClassVar[str | None] = None
 
     @classmethod
     def create(cls, dims: typing.Iterable[str] | None = None) -> tuple[Metric, ...]:
         if not dims:
             dims = ('x', 'y', 'z')
-        if cls.pretty_prefix:
-            return tuple(Metric(name=cls.prefix + dim, pretty_name=f'{cls.pretty_prefix} {dim}') for dim in dims)
-        return tuple(Metric(name=cls.prefix + dim) for dim in dims)
+        if cls.PRETTY_PREFIX:
+            return tuple(Metric(name=cls.PREFIX + dim, pretty_name=f'{cls.PRETTY_PREFIX} {dim}') for dim in dims)
+        return tuple(Metric(name=cls.PREFIX + dim) for dim in dims)
 
 class LaunchBlock(XYZBase):
     """
     Factory of metrics ``launch__block_dim_x``, ``launch__block_dim_y`` and ``launch__block_dim_z``.
     """
-    prefix: typing.ClassVar[str] = 'launch__block_dim_'
+    PREFIX: typing.ClassVar[str] = 'launch__block_dim_'
 
-    pretty_prefix: typing.ClassVar[str | None] = 'Launch block size'
+    PRETTY_PREFIX: typing.ClassVar[str | None] = 'Launch block size'
 
 class LaunchGrid(XYZBase):
     """
     Factory of metrics ``launch__grid_dim_x``, ``launch__grid_dim_y`` and ``launch__grid_dim_z``.
     """
-    prefix: typing.ClassVar[str] = 'launch__grid_dim_'
+    PREFIX: typing.ClassVar[str] = 'launch__grid_dim_'
 
-    pretty_prefix: typing.ClassVar[str | None] = 'Launch grid size'
+    PRETTY_PREFIX: typing.ClassVar[str | None] = 'Launch grid size'
 
 class Unit(StrEnum):
     """
@@ -492,18 +519,18 @@ class WarpStallBase:
     TEMPLATE_LABEL: typing.Final[str] = 'Warp stall {reason}'
 
     #: The stall reason as it appears in the ``ncu`` metric name.
-    reason: typing.ClassVar[str]
+    REASON: typing.ClassVar[str]
 
     #: The stall reason as it appears in the label.
-    pretty_reason: typing.ClassVar[str]
+    PRETTY_REASON: typing.ClassVar[str]
 
     @classmethod
     def create(cls, *,
-        subs: tuple[MetricRatioRollUp, ...] = (MetricRatioRollUp.PCT,),
+        subs: tuple[MetricRatioRollUp, ...] = (MetricRatioRollUp.RATIO,),
     ) -> tuple[MetricRatio, ...]:
-        name = cls.TEMPLATE_NAME.format(reason=cls.reason)
+        name = cls.TEMPLATE_NAME.format(reason=cls.REASON)
 
-        pretty_name = cls.TEMPLATE_LABEL.format(reason=cls.pretty_reason)
+        pretty_name = cls.TEMPLATE_LABEL.format(reason=cls.PRETTY_REASON)
 
         return (MetricRatio(name=name, pretty_name=pretty_name, subs=subs),)
 
@@ -511,33 +538,33 @@ class WarpStallLGThrottle(WarpStallBase):
     """
     Factory of ratio metric ``smsp__average_warps_issue_stalled_lg_throttle_per_issue_active``.
     """
-    reason: typing.ClassVar[str] = 'lg_throttle'
+    REASON: typing.ClassVar[str] = 'lg_throttle'
 
-    pretty_reason: typing.ClassVar[str] = 'LG throttle'
+    PRETTY_REASON: typing.ClassVar[str] = 'LG throttle'
 
 class WarpStallLongScoreboard(WarpStallBase):
     """
     Factory of ratio metric ``smsp__average_warps_issue_stalled_long_scoreboard_per_issue_active``.
     """
-    reason: typing.ClassVar[str] = 'long_scoreboard'
+    REASON: typing.ClassVar[str] = 'long_scoreboard'
 
-    pretty_reason: typing.ClassVar[str] = 'Long scoreboard'
+    PRETTY_REASON: typing.ClassVar[str] = 'Long scoreboard'
 
 class WarpStallMIOThrottle(WarpStallBase):
     """
     Factory of ratio metric ``smsp__average_warps_issue_stalled_mio_throttle_per_issue_active``.
     """
-    reason: typing.ClassVar[str] = 'mio_throttle'
+    REASON: typing.ClassVar[str] = 'mio_throttle'
 
-    pretty_reason: typing.ClassVar[str] = 'MIO throttle'
+    PRETTY_REASON: typing.ClassVar[str] = 'MIO throttle'
 
 class WarpStallShortScoreboard(WarpStallBase):
     """
     Factory of ratio metric ``smsp__average_warps_issue_stalled_short_scoreboard_per_issue_active``.
     """
-    reason: typing.ClassVar[str] = 'short_scoreboard'
+    REASON: typing.ClassVar[str] = 'short_scoreboard'
 
-    pretty_reason: typing.ClassVar[str] = 'Short scoreboard'
+    PRETTY_REASON: typing.ClassVar[str] = 'Short scoreboard'
 
 class WarpStall:
     """
@@ -561,11 +588,15 @@ MetricKind: typing.TypeAlias = Metric | MetricCorrelation | MetricDeviceAttribut
 def gather(metrics: typing.Iterable[MetricKind]) -> tuple[str, ...]:
     """
     Retrieve all sub-metric names, e.g. to pass them to ``ncu``.
+
+    Order follows `metrics`, then each metric's :py:attr:`~Metric.subs`; parallel to :py:func:`labels`.
     """
     return tuple(name for metric in metrics for name in metric.gather())
 
 def labels(metrics: typing.Iterable[MetricKind]) -> tuple[str, ...]:
     """
     Retrieve all sub-metric labels, e.g. to lookup collected data by label.
+
+    Order follows `metrics`, then each metric's :py:attr:`~Metric.subs`; parallel to :py:func:`gather`.
     """
     return tuple(label for metric in metrics for label in metric.labels())

--- a/reprospect/tools/ncu/metrics.py
+++ b/reprospect/tools/ncu/metrics.py
@@ -293,17 +293,16 @@ class L1TEXCacheGlobalLoadInstructions:
     """
     @staticmethod
     def create(*,
-        unit: Unit = Unit.SMSP,
         mode: typing.Literal['sass'] | None = 'sass',
         subs: tuple[MetricCounterRollUp, ...] = (MetricCounterRollUp.SUM,),
     ) -> tuple[MetricCounter, ...]:
         name = counter_name_from(
-            unit=unit,
+            unit=Unit.SMSP,
             quantity=f'sass_{Quantity.INSTRUCTION}' if mode == 'sass' else Quantity.INSTRUCTION,
             qualifier='executed_op_global_ld',
         )
 
-        pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.GlobalLoad.NAME, mode, 'instructions', unit)))
+        pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.GlobalLoad.NAME, mode, 'instructions')))
 
         return (MetricCounter(name=name, pretty_name=pretty_name, subs=subs),)
 
@@ -409,17 +408,16 @@ class L1TEXCacheGlobalStoreInstructions:
     """
     @staticmethod
     def create(*,
-        unit: Unit = Unit.SMSP,
         mode: typing.Literal['sass'] | None = 'sass',
         subs: tuple[MetricCounterRollUp, ...] = (MetricCounterRollUp.SUM,),
     ) -> tuple[MetricCounter, ...]:
         name = counter_name_from(
-            unit=unit,
+            unit=Unit.SMSP,
             quantity=f'sass_{Quantity.INSTRUCTION}' if mode == 'sass' else Quantity.INSTRUCTION,
             qualifier='executed_op_global_st',
         )
 
-        pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.GlobalStore.NAME, mode, 'instructions', unit)))
+        pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.GlobalStore.NAME, mode, 'instructions')))
 
         return (MetricCounter(name=name, pretty_name=pretty_name, subs=subs),)
 
@@ -477,17 +475,16 @@ class L1TEXCacheLocalStoreInstructions:
     """
     @staticmethod
     def create(*,
-        unit: Unit = Unit.SMSP,
         mode: typing.Literal['sass'] | None = 'sass',
         subs: tuple[MetricCounterRollUp, ...] = (MetricCounterRollUp.SUM,),
     ) -> tuple[MetricCounter, ...]:
         name = counter_name_from(
-            unit=unit,
+            unit=Unit.SMSP,
             quantity=f'sass_{Quantity.INSTRUCTION}' if mode == 'sass' else Quantity.INSTRUCTION,
             qualifier='executed_op_local_st',
         )
 
-        pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.LocalStore.NAME, mode, 'instructions', unit)))
+        pretty_name = ' '.join(filter(None, (L1TEXCache.NAME, L1TEXCache.LocalStore.NAME, mode, 'instructions')))
 
         return (MetricCounter(name=name, pretty_name=pretty_name, subs=subs),)
 
@@ -548,7 +545,7 @@ class WarpStallLongScoreboard(WarpStallBase):
     """
     REASON: typing.ClassVar[str] = 'long_scoreboard'
 
-    PRETTY_REASON: typing.ClassVar[str] = 'Long scoreboard'
+    PRETTY_REASON: typing.ClassVar[str] = 'long scoreboard'
 
 class WarpStallMIOThrottle(WarpStallBase):
     """
@@ -564,7 +561,7 @@ class WarpStallShortScoreboard(WarpStallBase):
     """
     REASON: typing.ClassVar[str] = 'short_scoreboard'
 
-    PRETTY_REASON: typing.ClassVar[str] = 'Short scoreboard'
+    PRETTY_REASON: typing.ClassVar[str] = 'short scoreboard'
 
 class WarpStall:
     """

--- a/tests/integration/test_half.py
+++ b/tests/integration/test_half.py
@@ -192,13 +192,13 @@ class TestNCU:
         assert individual['Launch block size x'] == self.BLOCK_DIM_X['individual']
         assert packed    ['Launch block size x'] == self.BLOCK_DIM_X['packed']
 
-        assert individual['L1/TEX cache global load sass instructions smsp sum'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
-        assert packed    ['L1/TEX cache global load sass instructions smsp sum'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)
+        assert individual['L1/TEX cache global load sass instructions smsp'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
+        assert packed    ['L1/TEX cache global load sass instructions smsp'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)
 
-        assert individual['L1/TEX cache global load requests sum'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
-        assert packed    ['L1/TEX cache global load requests sum'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)
+        assert individual['L1/TEX cache global load requests'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
+        assert packed    ['L1/TEX cache global load requests'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)
 
         sectors = math.ceil(self.SIZE * self.SIZEOF / self.WARP_SIZE)
 
-        assert individual['L1/TEX cache global load sectors sum'] == sectors
-        assert packed    ['L1/TEX cache global load sectors sum'] == sectors
+        assert individual['L1/TEX cache global load sectors'] == sectors
+        assert packed    ['L1/TEX cache global load sectors'] == sectors

--- a/tests/integration/test_half.py
+++ b/tests/integration/test_half.py
@@ -192,8 +192,8 @@ class TestNCU:
         assert individual['Launch block size x'] == self.BLOCK_DIM_X['individual']
         assert packed    ['Launch block size x'] == self.BLOCK_DIM_X['packed']
 
-        assert individual['L1/TEX cache global load sass instructions smsp'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
-        assert packed    ['L1/TEX cache global load sass instructions smsp'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)
+        assert individual['L1/TEX cache global load sass instructions'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
+        assert packed    ['L1/TEX cache global load sass instructions'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)
 
         assert individual['L1/TEX cache global load requests'] == math.ceil(self.BLOCK_DIM_X['individual'] / self.WARP_SIZE)
         assert packed    ['L1/TEX cache global load requests'] == math.ceil(self.BLOCK_DIM_X['packed']     / self.WARP_SIZE)

--- a/tests/tools/ncu/test_ncu.py
+++ b/tests/tools/ncu/test_ncu.py
@@ -28,7 +28,7 @@ class TestProfilingResults:
             data=ncu.ProfilingMetrics({
                 'smsp__inst_executed.sum': 100.,
                 'sass__inst_executed_per_opcode': MetricCorrelationData(correlated={'LDCU': 16., 'LDC': 16.}),
-                'L1/TEX cache global load sectors sum': 0.,
+                'L1/TEX cache global load sectors': 0.,
             }),
         )
         results.assign_metrics(
@@ -36,7 +36,7 @@ class TestProfilingResults:
             data=ncu.ProfilingMetrics({
                 'smsp__inst_executed.sum': 96.,
                 'sass__inst_executed_per_opcode': MetricCorrelationData(correlated={'LDCU': 16., 'LDC': 16.}),
-                'L1/TEX cache global load sectors sum': 0.,
+                'L1/TEX cache global load sectors': 0.,
             }),
         )
         return results
@@ -153,13 +153,13 @@ Profiling results
     │       └── kernel
     │           ├── smsp__inst_executed.sum: 100.0
     │           ├── sass__inst_executed_per_opcode: MetricCorrelationData(correlated={'LDCU': 16.0, 'LDC': 16.0}, value=None)
-    │           └── L1/TEX cache global load sectors sum: 0.0
+    │           └── L1/TEX cache global load sectors: 0.0
     └── nvtx_push_region_B
         └── nvtx_push_region_other_kernel
             └── other_kernel
                 ├── smsp__inst_executed.sum: 96.0
                 ├── sass__inst_executed_per_opcode: MetricCorrelationData(correlated={'LDCU': 16.0, 'LDC': 16.0}, value=None)
-                └── L1/TEX cache global load sectors sum: 0.0
+                └── L1/TEX cache global load sectors: 0.0
 """
 
         results_A = results.query(("nvtx_range_name", "nvtx_push_region_A"))
@@ -170,7 +170,7 @@ Profiling results
     └── kernel
         ├── smsp__inst_executed.sum: 100.0
         ├── sass__inst_executed_per_opcode: MetricCorrelationData(correlated={'LDCU': 16.0, 'LDC': 16.0}, value=None)
-        └── L1/TEX cache global load sectors sum: 0.0
+        └── L1/TEX cache global load sectors: 0.0
 """
 
 class TestCommand:
@@ -219,6 +219,11 @@ class TestMetrics:
             metric=ncu.MetricCounter(name='dram__bytes_op_write', subs=((ncu.MetricCounterRollUp.SUM, ncu.MetricCounterRollUpQuantity.PCT_OF_PEAK_SUSTAINED_ELAPSED),)),
             gathered=('dram__bytes_op_write.sum.pct_of_peak_sustained_elapsed',),
             labels=('dram__bytes_op_write.sum.pct_of_peak_sustained_elapsed',),
+        ),
+        MetricCase(
+            metric=ncu.MetricCounter(name='dram__bytes_op_write', pretty_name='Device memory store bytes', subs=((ncu.MetricCounterRollUp.SUM, ncu.MetricCounterRollUpQuantity.PCT_OF_PEAK_SUSTAINED_ELAPSED),)),
+            gathered=('dram__bytes_op_write.sum.pct_of_peak_sustained_elapsed',),
+            labels=('Device memory store bytes (% of peak elapsed)',),
         ),
     )
 
@@ -269,13 +274,13 @@ class TestMetrics:
             metrics=ncu.L1TEXCache.GlobalStore.Instructions.create(),
             expected=(ncu.MetricCounter(name='smsp__sass_inst_executed_op_global_st', pretty_name='L1/TEX cache global store sass instructions smsp', subs=(ncu.MetricCounterRollUp.SUM,)),),
             gathered=('smsp__sass_inst_executed_op_global_st.sum',),
-            labels=('L1/TEX cache global store sass instructions smsp sum',),
+            labels=('L1/TEX cache global store sass instructions smsp',),
         ),
         CreatedMetricsCase(
             metrics=ncu.L1TEXCache.GlobalStore.Instructions.create(mode=None),
             expected=(ncu.MetricCounter(name='smsp__inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions smsp', subs=(ncu.MetricCounterRollUp.SUM,)),),
             gathered=('smsp__inst_executed_op_global_st.sum',),
-            labels=('L1/TEX cache global store instructions smsp sum',),
+            labels=('L1/TEX cache global store instructions smsp',),
         ),
         CreatedMetricsCase(
             metrics=ncu.L1TEXCache.GlobalStore.Instructions.create(
@@ -299,27 +304,27 @@ class TestMetrics:
                 'smsp__sass_inst_executed_op_global_st.max',
             ),
             labels=(
-                'L1/TEX cache global store sass instructions smsp min',
-                'L1/TEX cache global store sass instructions smsp max',
+                'L1/TEX cache global store sass instructions smsp (min)',
+                'L1/TEX cache global store sass instructions smsp (max)',
             ),
         ),
         CreatedMetricsCase(
             metrics=ncu.L1TEXCache.GlobalStore.Requests.create(),
             expected=(ncu.MetricCounter(name='l1tex__t_requests_pipe_lsu_mem_global_op_st', pretty_name='L1/TEX cache global store requests', subs=(ncu.MetricCounterRollUp.SUM,)),),
             gathered=('l1tex__t_requests_pipe_lsu_mem_global_op_st.sum',),
-            labels=('L1/TEX cache global store requests sum',),
+            labels=('L1/TEX cache global store requests',),
         ),
         CreatedMetricsCase(
             metrics=ncu.L1TEXCache.GlobalStore.Sectors.create(),
             expected=(ncu.MetricCounter(name='l1tex__t_sectors_pipe_lsu_mem_global_op_st', pretty_name='L1/TEX cache global store sectors', subs=(ncu.MetricCounterRollUp.SUM,)),),
             gathered=('l1tex__t_sectors_pipe_lsu_mem_global_op_st.sum',),
-            labels=('L1/TEX cache global store sectors sum',),
+            labels=('L1/TEX cache global store sectors',),
         ),
         CreatedMetricsCase(
             metrics=ncu.WarpStall.LGThrottle.create(),
-            expected=(ncu.MetricRatio(name='smsp__average_warps_issue_stalled_lg_throttle_per_issue_active', pretty_name='Warp stall LG throttle', subs=(ncu.MetricRatioRollUp.PCT,)),),
-            gathered=('smsp__average_warps_issue_stalled_lg_throttle_per_issue_active.pct',),
-            labels=('Warp stall LG throttle pct',),
+            expected=(ncu.MetricRatio(name='smsp__average_warps_issue_stalled_lg_throttle_per_issue_active', pretty_name='Warp stall LG throttle', subs=(ncu.MetricRatioRollUp.RATIO,)),),
+            gathered=('smsp__average_warps_issue_stalled_lg_throttle_per_issue_active.ratio',),
+            labels=('Warp stall LG throttle',),
         ),
     )
 
@@ -376,8 +381,8 @@ class TestSession:
             'Launch grid size x',
             'Launch grid size y',
             'Launch grid size z',
-            'L1/TEX cache global load sass instructions smsp sum',
-            'L1/TEX cache global load sectors sum',
+            'L1/TEX cache global load sass instructions smsp',
+            'L1/TEX cache global load sectors',
             'mangled',
             'demangled',
             'device__attribute_display_name',
@@ -552,34 +557,34 @@ class TestSession:
         assert SIGNATURES['node_D'](metrics_node_D)
 
         metrics_aggregate = results.aggregate_metrics(accessors=(), keys=(
-            'L1/TEX cache global store sectors sum',
-            'L1/TEX cache global load sectors sum',
+            'L1/TEX cache global store sectors',
+            'L1/TEX cache global load sectors',
         ))
 
         # Node A makes one load and one store.
-        assert metrics_node_A['L1/TEX cache global load sectors sum']  == 1
-        assert metrics_node_A['L1/TEX cache global store sectors sum'] == 1
+        assert metrics_node_A['L1/TEX cache global load sectors']  == 1
+        assert metrics_node_A['L1/TEX cache global store sectors'] == 1
 
         assert metrics_node_A['launch__registers_per_thread_allocated'] == 512
 
         # Nodes B and C make two loads and one store each.
-        assert metrics_node_B['L1/TEX cache global load sectors sum']  == 2
-        assert metrics_node_B['L1/TEX cache global store sectors sum'] == 1
-        assert metrics_node_C['L1/TEX cache global load sectors sum']  == 2
-        assert metrics_node_C['L1/TEX cache global store sectors sum'] == 1
+        assert metrics_node_B['L1/TEX cache global load sectors']  == 2
+        assert metrics_node_B['L1/TEX cache global store sectors'] == 1
+        assert metrics_node_C['L1/TEX cache global load sectors']  == 2
+        assert metrics_node_C['L1/TEX cache global store sectors'] == 1
 
         assert metrics_node_B['launch__registers_per_thread_allocated'] == 512
         assert metrics_node_C['launch__registers_per_thread_allocated'] == 512
 
         # Node D makes three loads and one store.
-        assert metrics_node_D['L1/TEX cache global load sectors sum']  == 3
-        assert metrics_node_D['L1/TEX cache global store sectors sum'] == 1
+        assert metrics_node_D['L1/TEX cache global load sectors']  == 3
+        assert metrics_node_D['L1/TEX cache global store sectors'] == 1
 
         assert metrics_node_D['launch__registers_per_thread_allocated'] == 512
 
         assert metrics_aggregate == {
-            'L1/TEX cache global load sectors sum':  8,
-            'L1/TEX cache global store sectors sum': 4,
+            'L1/TEX cache global load sectors':  8,
+            'L1/TEX cache global store sectors': 4,
         }
 
     def test_fails_correctly_with_retries(self, bindir, workdir) -> None:

--- a/tests/tools/ncu/test_ncu.py
+++ b/tests/tools/ncu/test_ncu.py
@@ -272,15 +272,15 @@ class TestMetrics:
         ),
         CreatedMetricsCase(
             metrics=ncu.L1TEXCache.GlobalStore.Instructions.create(),
-            expected=(ncu.MetricCounter(name='smsp__sass_inst_executed_op_global_st', pretty_name='L1/TEX cache global store sass instructions smsp', subs=(ncu.MetricCounterRollUp.SUM,)),),
+            expected=(ncu.MetricCounter(name='smsp__sass_inst_executed_op_global_st', pretty_name='L1/TEX cache global store sass instructions', subs=(ncu.MetricCounterRollUp.SUM,)),),
             gathered=('smsp__sass_inst_executed_op_global_st.sum',),
-            labels=('L1/TEX cache global store sass instructions smsp',),
+            labels=('L1/TEX cache global store sass instructions',),
         ),
         CreatedMetricsCase(
             metrics=ncu.L1TEXCache.GlobalStore.Instructions.create(mode=None),
-            expected=(ncu.MetricCounter(name='smsp__inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions smsp', subs=(ncu.MetricCounterRollUp.SUM,)),),
+            expected=(ncu.MetricCounter(name='smsp__inst_executed_op_global_st', pretty_name='L1/TEX cache global store instructions', subs=(ncu.MetricCounterRollUp.SUM,)),),
             gathered=('smsp__inst_executed_op_global_st.sum',),
-            labels=('L1/TEX cache global store instructions smsp',),
+            labels=('L1/TEX cache global store instructions',),
         ),
         CreatedMetricsCase(
             metrics=ncu.L1TEXCache.GlobalStore.Instructions.create(
@@ -292,7 +292,7 @@ class TestMetrics:
             expected=(
                 ncu.MetricCounter(
                     name='smsp__sass_inst_executed_op_global_st',
-                    pretty_name='L1/TEX cache global store sass instructions smsp',
+                    pretty_name='L1/TEX cache global store sass instructions',
                     subs=(
                         ncu.MetricCounterRollUp.MIN,
                         ncu.MetricCounterRollUp.MAX,
@@ -304,8 +304,8 @@ class TestMetrics:
                 'smsp__sass_inst_executed_op_global_st.max',
             ),
             labels=(
-                'L1/TEX cache global store sass instructions smsp (min)',
-                'L1/TEX cache global store sass instructions smsp (max)',
+                'L1/TEX cache global store sass instructions (min)',
+                'L1/TEX cache global store sass instructions (max)',
             ),
         ),
         CreatedMetricsCase(
@@ -381,7 +381,7 @@ class TestSession:
             'Launch grid size x',
             'Launch grid size y',
             'Launch grid size z',
-            'L1/TEX cache global load sass instructions smsp',
+            'L1/TEX cache global load sass instructions',
             'L1/TEX cache global load sectors',
             'mangled',
             'demangled',


### PR DESCRIPTION
Further minor changes to labels:
- consistency of lower vs upper case
- remove `unit` parameter from l1tex load/store instruction metrics; it was never used