### PR TITLE
utils(rich): replace `rich-tools` `df_to_table` with our own; add `rows_to_table`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ requires = [
     "pyyaml",
     "regex",
     "rich",
-    "rich-tools",
     "semantic_version",
     "system-helpers>=0.0.3",
     "typing-extensions>=4.4.0",

--- a/reprospect/tools/nsys/report.py
+++ b/reprospect/tools/nsys/report.py
@@ -115,7 +115,7 @@ class Report:
         """
         if len(data) != 1:
             raise RuntimeError(data)
-        return data.squeeze()
+        return data.iloc[0]
 
     @classmethod
     def get_correlated_row(cls, *,
@@ -239,7 +239,7 @@ ORDER BY NVTX_EVENTS.start ASC, NVTX_EVENTS.end DESC
         if len(filtered) != 1:
             raise RuntimeError(f'Expecting exactly one NVTX event, got {len(filtered)}.')
 
-        filtered = filtered.squeeze()
+        filtered = filtered.iloc[0]
 
         logging.info(f"Events will be filtered in the time frame {filtered['start']} -> {filtered['end']}.")
 

--- a/reprospect/utils/rich_helpers.py
+++ b/reprospect/utils/rich_helpers.py
@@ -5,7 +5,6 @@ import pandas
 import rich.console
 import rich.table
 import rich.tree
-import rich_tools
 
 
 def to_string(
@@ -38,22 +37,48 @@ def df_to_table(
     *,
     rich_table: rich.table.Table | None = None,
     show_index: bool = False,
-    **kwargs,
 ) -> rich.table.Table:
     """
     Convert a :py:class:`pandas.DataFrame` to a :py:class:`rich.table.Table`.
 
     .. note:
 
-        This wrapper around the equivalent function from the `rich-tools` package
-        can be avoided once an issue with their function is resolved:
+        This function is similar to an equivalent function from the `rich-tools` package.
+
+        However, this function allows the indices to be the indices of the :py:class:`pandas.DataFrame`
+        rather than an enumeration of the rows.
+
+        There is also an issue with the `rich-tools` function:
 
         * https://github.com/avi-perl/rich_tools/issues/10
     """
     if rich_table is None:
         rich_table = rich.table.Table()
 
-    return rich_tools.df_to_table(df, rich_table=rich_table, show_index=show_index, **kwargs)
+    if show_index:
+        index_name = df.index.name or ''
+        rich_table.add_column(str(index_name))
+
+    for column in df.columns:
+        rich_table.add_column(str(column))
+
+    for index, value_list in df.iterrows():
+        row = [str(index)] if show_index else []
+        row += [str(x) for x in value_list]
+        rich_table.add_row(*row)
+
+    return rich_table
+
+def rows_to_table(rows: typing.Iterable[tuple[typing.Any, ...]], *, columns: tuple[str, ...]) -> rich.table.Table:
+    """
+    Build a :py:class:`rich.table.Table` from `rows`, one table row per tuple.
+
+    Values are converted with :py:class:`str`.
+    """
+    table = rich.table.Table(*columns)
+    for row in rows:
+        table.add_row(*map(str, row))
+    return table
 
 class TableMixin(metaclass=abc.ABCMeta):
     """

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,7 +9,6 @@ pyelftools==0.33
 pyyaml
 regex
 rich
-rich-tools
 semantic_version
 system-helpers>=0.0.3
 typing-extensions>=4.4.0

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_pytest(cmake)
 add_pytest(detect)
 add_pytest(environment)
+add_pytest(rich_helpers)
 add_pytest(subprocess_helpers)
 add_pytest(types)

--- a/tests/utils/test_rich_helpers.py
+++ b/tests/utils/test_rich_helpers.py
@@ -1,0 +1,60 @@
+import pandas as pd
+import pytest
+
+from reprospect.utils import rich_helpers
+
+
+@pytest.fixture(scope='session')
+def df() -> pd.DataFrame:
+    return pd.DataFrame(
+        data=[(1, 'a'), (2, 'b'), (3, 'c')],
+        index=['row1', 'row2', 'row3'],
+        columns=['col1', 'col2'],
+    )
+
+def test_df_to_table_do_not_show_index(df: pd.DataFrame) -> None:
+    """
+    Test :py:func:`reprospect.utils.rich_helpers.df_to_table` with `show_index=False`.
+    """
+    assert rich_helpers.to_string(rich_helpers.df_to_table(df, show_index=False)) == """\
+┏━━━━━━┳━━━━━━┓
+┃ col1 ┃ col2 ┃
+┡━━━━━━╇━━━━━━┩
+│ 1    │ a    │
+│ 2    │ b    │
+│ 3    │ c    │
+└──────┴──────┘
+"""
+
+def test_df_to_table_show_index(df: pd.DataFrame) -> None:
+    """
+    Test :py:func:`reprospect.utils.rich_helpers.df_to_table` with `show_index=True`.
+    """
+    assert rich_helpers.to_string(rich_helpers.df_to_table(df, show_index=True)) == """\
+┏━━━━━━┳━━━━━━┳━━━━━━┓
+┃      ┃ col1 ┃ col2 ┃
+┡━━━━━━╇━━━━━━╇━━━━━━┩
+│ row1 │ 1    │ a    │
+│ row2 │ 2    │ b    │
+│ row3 │ 3    │ c    │
+└──────┴──────┴──────┘
+"""
+
+def test_rows_to_table() -> None:
+    """
+    Test :py:func:`reprospect.utils.rich_helpers.rows_to_table`.
+    """
+    rows = [
+        (1, 'a'),
+        (2, 'b'),
+        (3, 'c'),
+    ]
+    assert rich_helpers.to_string(rich_helpers.rows_to_table(rows, columns=('col1', 'col2'))) == """\
+┏━━━━━━┳━━━━━━┓
+┃ col1 ┃ col2 ┃
+┡━━━━━━╇━━━━━━┩
+│ 1    │ a    │
+│ 2    │ b    │
+│ 3    │ c    │
+└──────┴──────┘
+"""


### PR DESCRIPTION
Motivated by:
- when asked to show the indices, the `rich-tools` package prints row numbers rather than the dataframe's indices

https://github.com/avi-perl/rich_tools/blob/7b5b2539f379f9d33270cde81716da53fe805d21/rich_tools/table.py#L33

Related to:
- #682 