### PR TITLE
tools(api tracing): fix `pandas` 2.3.3 vs 3.0.5 missing value behavior

### DIFF
--- a/reprospect/tools/nsys/report.py
+++ b/reprospect/tools/nsys/report.py
@@ -194,6 +194,11 @@ ORDER BY NVTX_EVENTS.start ASC, NVTX_EVENTS.end DESC
 """
         events = pandas.read_sql_query(query, self.conn)
 
+        # Normalize missing values to None.
+        text = events['text'].astype(object)
+        text[text.isna()] = None
+        events['text'] = text
+
         # Add a 'level' column.
         events['level'] = -1
 


### PR DESCRIPTION
In a recent image update, we retrieve a new `pandas` version in our Python 3.14 images. This version handles missing values differently. This breaks certain tests, where missing values were `None` before, but `nan` now. This PR fixes an occurrence in the nsys report. With the fix, missing values are always "None". 