### PR TITLE
doc(kernel profiling): formulate short scoreboard interpretation more robustly

### DIFF
--- a/docs/source/getting-started/example_kernel_profiling.ipynb
+++ b/docs/source/getting-started/example_kernel_profiling.ipynb
@@ -474,7 +474,6 @@
     "    gather,\n",
     "    labels,\n",
     ")\n",
-    "from reprospect.utils import rich_helpers\n",
     "\n",
     "metrics = (\n",
     "    # Launch grid sizes.\n",
@@ -849,8 +848,8 @@
    "id": "41",
    "metadata": {},
    "source": [
-    "We can observe that the short scoreboard stalls are highest for the reference kernel and decrease with the static batch size.\n",
-    "The long scoreboard stalls show the opposite trend."
+    "We can observe that the short scoreboard stalls are non-zero for the reference kernel and decrease or remain about the same as the static batch size increases.\n",
+    "The long scoreboard stalls are exactly zero for the reference kernel and increase with the static batch size."
    ]
   },
   {
@@ -892,7 +891,7 @@
     "The scoreboard warp stall reason metrics are associated with warps stalled waiting for such scoreboard dependencies.\n",
     "Nsight Compute [distinguishes](https://docs.nvidia.com/nsight-compute/ProfilingGuide/index.html?highlight=average#warp-stall-reasons) between long scoreboard stalls associated with waits on L1/TEX cache memory operations (local, global, texture and surface memory) and short scoreboard stalls associated with waits on memory operations other than L1/TEX (thus including the loads from constant memory that we see in our example).\n",
     "\n",
-    "The collected short-scoreboard warp stall reason metric indicates that as the static batch size increases, the number of warp stalls associated with waits on the once-per-warp loads of the kernel parameters decreases.\n",
+    "The collected short-scoreboard warp stall reason metric indicates that as the static batch size increases, the number of warp stalls associated with waits on the once-per-warp loads of the kernel parameters decreases or remains about the same.\n",
     "\n",
     "For the reference kernel, the collected long-scoreboard warp stall reason metric is zero.\n",
     "Indeed, for this kernel, the store instruction does not set a scoreboard barrier, because no subsequent instruction overwrites its operands.\n",


### PR DESCRIPTION
The results produced in the pipeline do not fully support what was written.