### PR TITLE
build(deps): centralize common dependency information

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,7 @@ jobs:
         container:
             image: ghcr.io/${{ github.repository }}/setup-job-matrix:latest
         outputs:
+            common_dependency_versions_as_build_args: ${{ steps.strategy.outputs.common_dependency_versions_as_build_args }}
             image_deploy: ${{ steps.strategy.outputs.image_deploy }}
             job_documentation: ${{ steps.strategy.outputs.job_documentation }}
             matrix_examples: ${{ steps.strategy.outputs.matrix_examples }}
@@ -231,13 +232,11 @@ jobs:
                   cache-from: type=registry,ref=${{ matrix.image }}
                   cache-to: type=inline
                   build-args: |
+                      ${{ needs.setup-job-matrix.outputs.common_dependency_versions_as_build_args }}
                       BASE_IMAGE=${{ matrix.base_image }}
                       CXX_COMPILER_ID=${{ matrix.compilers.CXX.ID_lower }}
                       CXX_COMPILER_VERSION=${{ matrix.compilers.CXX.version }}
                       CXX_COMPILER=${{ matrix.compilers.CXX.path }}
-                      DOXYGEN_VERSION=1_14_0
-                      GOOGLEBENCHMARK_VERSION=1.9.5
-                      NVTX3_VERSION=3.5.0
                       PYTHON_VERSION=${{ matrix.python_version }}
                   labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 
@@ -251,14 +250,13 @@ jobs:
                   cache-from: type=registry,ref=${{ matrix.kokkos }}
                   cache-to: type=inline
                   build-args: |
+                      ${{ needs.setup-job-matrix.outputs.common_dependency_versions_as_build_args }}
                       BASE_IMAGE=${{ matrix.image }}
                       KOKKOS_ARCH=${{ matrix.nvidia_arch }}
                       KOKKOS_CXX_COMPILER=${{ matrix.compilers.CXX.path }}
                       KOKKOS_CUDA_COMPILER=${{ matrix.compilers.CUDA.path }}
                       KOKKOS_INSTALL_SUFFIX=${{ matrix.cmake_preset }}-${{ matrix.nvidia_arch }}
-                      KOKKOS_SHA=${{ matrix.kokkos_sha }}
                       KOKKOS_TOOLS_INSTALL_SUFFIX=${{ matrix.cmake_preset }}
-                      KOKKOS_TOOLS_SHA=6493964271d2e887432489f20559b72757db02b0
                   labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 
     tests:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
         container:
             image: ghcr.io/${{ github.repository }}/setup-job-matrix:latest
         outputs:
-            common_dependency_versions_as_build_args: ${{ steps.strategy.outputs.common_dependency_versions_as_build_args }}
+            dependencies: ${{ steps.strategy.outputs.dependencies }}
             image_deploy: ${{ steps.strategy.outputs.image_deploy }}
             job_documentation: ${{ steps.strategy.outputs.job_documentation }}
             matrix_examples: ${{ steps.strategy.outputs.matrix_examples }}
@@ -232,11 +232,13 @@ jobs:
                   cache-from: type=registry,ref=${{ matrix.image }}
                   cache-to: type=inline
                   build-args: |
-                      ${{ needs.setup-job-matrix.outputs.common_dependency_versions_as_build_args }}
                       BASE_IMAGE=${{ matrix.base_image }}
                       CXX_COMPILER_ID=${{ matrix.compilers.CXX.ID_lower }}
                       CXX_COMPILER_VERSION=${{ matrix.compilers.CXX.version }}
                       CXX_COMPILER=${{ matrix.compilers.CXX.path }}
+                      DOXYGEN_VERSION=${{ fromJSON(needs.setup-job-matrix.outputs.dependencies).doxygen.version }}
+                      GOOGLEBENCHMARK_VERSION=${{ fromJSON(needs.setup-job-matrix.outputs.dependencies).googlebenchmark.version }}
+                      NVTX3_VERSION=${{ fromJSON(needs.setup-job-matrix.outputs.dependencies).nvtx3.version }}
                       PYTHON_VERSION=${{ matrix.python_version }}
                   labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 
@@ -250,13 +252,14 @@ jobs:
                   cache-from: type=registry,ref=${{ matrix.kokkos }}
                   cache-to: type=inline
                   build-args: |
-                      ${{ needs.setup-job-matrix.outputs.common_dependency_versions_as_build_args }}
                       BASE_IMAGE=${{ matrix.image }}
                       KOKKOS_ARCH=${{ matrix.nvidia_arch }}
                       KOKKOS_CXX_COMPILER=${{ matrix.compilers.CXX.path }}
                       KOKKOS_CUDA_COMPILER=${{ matrix.compilers.CUDA.path }}
                       KOKKOS_INSTALL_SUFFIX=${{ matrix.cmake_preset }}-${{ matrix.nvidia_arch }}
+                      KOKKOS_SHA=${{ fromJSON(needs.setup-job-matrix.outputs.dependencies).kokkos.sha }}
                       KOKKOS_TOOLS_INSTALL_SUFFIX=${{ matrix.cmake_preset }}
+                      KOKKOS_TOOLS_SHA=${{ fromJSON(needs.setup-job-matrix.outputs.dependencies).kokkos-tools.sha }}
                   labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 
     tests:

--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -4,6 +4,7 @@ import argparse
 import copy
 import dataclasses
 import enum
+import functools
 import json
 import logging
 import pathlib
@@ -53,8 +54,6 @@ AVAILABLE_RUNNERS: typing.Final[tuple[Runner, ...]] = (
 
 SELF_HOSTED: typing.Final[tuple[str, ...]] = ('self-hosted', 'linux', 'docker')
 
-KOKKOS_SHA: typing.Final[str] = '5.1.0'
-
 @dataclasses.dataclass(frozen=False, slots=True)
 class Compiler:
     ID: COMPILER_ID
@@ -74,6 +73,8 @@ class Compiler:
                     raise ValueError
 
 JobDict: typing.TypeAlias = dict[str, typing.Any]
+
+DependencyDict: typing.TypeAlias = dict[str, dict[str, str]]
 
 @dataclasses.dataclass(frozen=False, slots=True)
 class Config:
@@ -222,7 +223,7 @@ def runs_on(spec: Runner, jtype: typing.Literal['tests', 'examples', 'documentat
         case _:
             raise ValueError
 
-def complete_job_impl(*, partial: JobDict, args: argparse.Namespace) -> JobDict:
+def complete_job_impl(*, partial: JobDict, deps: DependencyDict, args: argparse.Namespace) -> JobDict:
     """
     Add fields to a job.
     """
@@ -250,8 +251,8 @@ def complete_job_impl(*, partial: JobDict, args: argparse.Namespace) -> JobDict:
     partial['nvidia_arch'] = str(arch)
 
     partial['base_image'] = f'{base_name}:{base_tag}@{base_digest}'
-    partial[     'image'] = full_image(platform=partial['platform'], args=args, name=name,                          tag=base_tag)
-    partial[    'kokkos'] = full_image(platform=partial['platform'], args=args, name=f'{name}-kokkos-{KOKKOS_SHA}', tag=f'{base_tag}-{arch}'.lower())
+    partial[     'image'] = full_image(platform=partial['platform'], args=args, name=name,                                     tag=base_tag)
+    partial[    'kokkos'] = full_image(platform=partial['platform'], args=args, name=f'{name}-kokkos-{deps["kokkos"]["sha"]}', tag=f'{base_tag}-{arch}'.lower())
 
     # Name of the job.
     # See also https://futurestud.io/tutorials/github-actions-customize-the-job-name.
@@ -304,35 +305,31 @@ def complete_job_impl(*, partial: JobDict, args: argparse.Namespace) -> JobDict:
 
     return partial
 
-def from_config(config: Config, args: argparse.Namespace) -> list[JobDict]:
+def from_config(config: Config, deps: DependencyDict, args: argparse.Namespace) -> list[JobDict]:
     return [
-        complete_job_impl(partial=copy.deepcopy(job), args=args)
+        complete_job_impl(partial=copy.deepcopy(job), deps=deps, args=args)
         for job in config.jobs()
     ]
 
-def common_dependencies() -> dict:
+@functools.cache
+def dependencies() -> DependencyDict:
     """
     Read the information on dependencies common across all strategy entries.
     """
-    return json.loads((pathlib.Path(__file__).parents[2] / 'dependencies.json').read_text())
-
-def common_dependency_versions_as_build_args() -> str:
-    """
-    Return the common dependency versions as build arguments.
-    """
-    deps = common_dependencies()
-    return '\n'.join((
-        f'DOXYGEN_VERSION={deps["doxygen"]["version"]}',
-        f'GOOGLEBENCHMARK_VERSION={deps["googlebenchmark"]["version"]}',
-        f'NVTX3_VERSION={deps["nvtx3"]["version"]}',
-        f'KOKKOS_SHA={deps["kokkos"]["sha"]}',
-        f'KOKKOS_TOOLS_SHA={deps["kokkos-tools"]["sha"]}',
-    ))
+    deps = json.loads((pathlib.Path(__file__).parents[2] / 'dependencies.json').read_text())
+    assert isinstance(deps, dict) and all(
+        isinstance(k, str) and isinstance(v, dict)
+        and all(isinstance(kk, str) and isinstance(vv, str) for kk, vv in v.items())
+        for k, v in deps.items()
+    )
+    return deps
 
 def main(*, args: argparse.Namespace) -> None:
     """
     Generate the strategy matrix.
     """
+    deps = dependencies()
+
     matrix = []
 
     # STRATEGY-MATRIX-START
@@ -344,7 +341,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='GNU', version='13'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=7, minor=0),
         platforms=(Platform.from_str('linux/amd64'), Platform.from_str('linux/arm64')),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='12.8.1',
@@ -353,7 +350,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='GNU', version='14'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=9, minor=0),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='13.1.0',
@@ -363,7 +360,7 @@ def main(*, args: argparse.Namespace) -> None:
         compute_capability=ComputeCapability(major=12, minor=0),
         platforms=(Platform.from_str('linux/amd64'),),
         use_for_documentation=True,
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='13.1.0',
@@ -372,7 +369,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='GNU', version='14'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=12, minor=0),
         platforms=(Platform.from_str('linux/arm64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='12.6.3',
@@ -381,7 +378,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='GNU', version='12'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=7, minor=5),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='12.8.1',
@@ -390,7 +387,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='GNU', version='13'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=8, minor=0),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='12.6.3',
@@ -399,7 +396,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='GNU', version='13'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=8, minor=9),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='13.0.0',
@@ -408,7 +405,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='GNU', version='14'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=8, minor=6),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='12.8.1',
@@ -417,7 +414,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='Clang', version='19'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=7, minor=0),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='13.1.0',
@@ -426,7 +423,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='GNU', version='14'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=10, minor=0),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='13.2.0',
@@ -435,7 +432,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='GNU', version='14'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=10, minor=0),
         platforms=(Platform.from_str('linux/amd64'), Platform.from_str('linux/arm64')),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='13.0.0',
@@ -444,7 +441,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='Clang', version='20'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=12, minor=0),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='13.1.0',
@@ -453,7 +450,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='Clang', version='21'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=10, minor=3),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='13.1.0',
@@ -462,7 +459,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='Clang', version='21'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=12, minor=1),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='12.8.1',
@@ -471,7 +468,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='Clang', version='21')},
         compute_capability=ComputeCapability(major=12, minor=0),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='12.8.1',
@@ -480,7 +477,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='Clang', version='22')},
         compute_capability=ComputeCapability(major=9, minor=0),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='13.1.0',
@@ -489,7 +486,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='Clang', version='22')},
         compute_capability=ComputeCapability(major=10, minor=0),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='13.2.1',
@@ -498,7 +495,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='Clang', version='21'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=12, minor=0),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     matrix.extend(from_config(Config(
         cuda_version='13.3.0',
@@ -507,7 +504,7 @@ def main(*, args: argparse.Namespace) -> None:
         compilers={'CXX': Compiler(ID='GNU', version='15'), 'CUDA': Compiler(ID='NVIDIA')},
         compute_capability=ComputeCapability(major=12, minor=0),
         platforms=(Platform.from_str('linux/amd64'),),
-    ), args=args))
+    ), deps=deps, args=args))
 
     # STRATEGY-MATRIX-END
 
@@ -524,7 +521,7 @@ def main(*, args: argparse.Namespace) -> None:
 
     print(f"image_deploy={matrix[0]['image']}")
 
-    print(f"common_dependency_versions_as_build_args={common_dependency_versions_as_build_args()}")
+    print(f"dependencies={json.dumps(dependencies(), default=str)}")
 
 if __name__ == '__main__':
 

--- a/.github/workflows/strategy.py
+++ b/.github/workflows/strategy.py
@@ -6,6 +6,7 @@ import dataclasses
 import enum
 import json
 import logging
+import pathlib
 import pprint
 import typing
 
@@ -234,9 +235,6 @@ def complete_job_impl(*, partial: JobDict, args: argparse.Namespace) -> JobDict:
     # https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html.
     partial['cmake_cuda_architectures'] = f"{partial['compute_capability'].as_int}-real"
 
-    # Kokkos SHA.
-    partial['kokkos_sha'] = KOKKOS_SHA
-
     # Name and tag of the image (lower case).
     name = ('-'.join((
         'cuda',
@@ -311,6 +309,25 @@ def from_config(config: Config, args: argparse.Namespace) -> list[JobDict]:
         complete_job_impl(partial=copy.deepcopy(job), args=args)
         for job in config.jobs()
     ]
+
+def common_dependencies() -> dict:
+    """
+    Read the information on dependencies common across all strategy entries.
+    """
+    return json.loads((pathlib.Path(__file__).parents[2] / 'dependencies.json').read_text())
+
+def common_dependency_versions_as_build_args() -> str:
+    """
+    Return the common dependency versions as build arguments.
+    """
+    deps = common_dependencies()
+    return '\n'.join((
+        f'DOXYGEN_VERSION={deps["doxygen"]["version"]}',
+        f'GOOGLEBENCHMARK_VERSION={deps["googlebenchmark"]["version"]}',
+        f'NVTX3_VERSION={deps["nvtx3"]["version"]}',
+        f'KOKKOS_SHA={deps["kokkos"]["sha"]}',
+        f'KOKKOS_TOOLS_SHA={deps["kokkos-tools"]["sha"]}',
+    ))
 
 def main(*, args: argparse.Namespace) -> None:
     """
@@ -506,6 +523,8 @@ def main(*, args: argparse.Namespace) -> None:
     print(f"job_documentation={json.dumps(job_documentation, default=str)}")
 
     print(f"image_deploy={matrix[0]['image']}")
+
+    print(f"common_dependency_versions_as_build_args={common_dependency_versions_as_build_args()}")
 
 if __name__ == '__main__':
 

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,0 +1,17 @@
+{
+    "doxygen": {
+        "version": "1_14_0"
+    },
+    "googlebenchmark": {
+        "version": "1.9.5"
+    },
+    "nvtx3": {
+        "version": "3.5.0"
+    },
+    "kokkos": {
+        "sha": "5.1.0"
+    },
+    "kokkos-tools": {
+        "sha": "6493964271d2e887432489f20559b72757db02b0"
+    }
+}


### PR DESCRIPTION
Motivated by:
- making common dependency information more clearly visible, e.g. that all our images use a certain Kokkos version

Partially addresses:
- #665 